### PR TITLE
Added error handling to the dataset api response closing

### DIFF
--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -101,7 +101,7 @@ func (c *Client) Get(ctx context.Context, id, serviceToken string) (m Model, err
 		return
 	}
 	defer closeResponseBody(ctx, resp)
-	
+
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
 		return
@@ -151,7 +151,7 @@ func (c *Client) GetByPath(ctx context.Context, serviceToken, path string) (m Mo
 		return
 	}
 	defer closeResponseBody(ctx, resp)
-	
+
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
 		return
@@ -597,8 +597,8 @@ func NewDatasetAPIResponse(resp *http.Response, uri string) (e *ErrInvalidDatase
 			e.body = "Client failed to read DatasetAPI body"
 			return
 		}
-		
 		defer closeResponseBody(nil, resp)
+
 		e.body = string(b)
 	}
 	return

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -49,17 +49,10 @@ type Client struct {
 	url string
 }
 
-// closeResponseBodyWithContext closes the response body and logs an error containing the context if unsuccessful
-func closeResponseBodyWithContext(ctx context.Context, resp *http.Response) {
+// closeResponseBody closes the response body and logs an error containing the context if unsuccessful
+func closeResponseBody(ctx context.Context, resp *http.Response) {
 	if err := resp.Body.Close(); err != nil {
-		log.ErrorCtx(ctx, err, log.Data{"Message": "error closing http response body"})
-	}
-}
-// closeResponseBody closes the response body and logs an error if unsuccessful
-
-func closeResponseBody(resp *http.Response) {
-	if err := resp.Body.Close(); err != nil {
-		log.Error(err, log.Data{"Message": "error closing http response body"})
+		log.ErrorCtx(ctx, err, log.Data{"message": "error closing http response body"})
 	}
 }
 
@@ -79,7 +72,7 @@ func (c *Client) Healthcheck() (string, error) {
 	if err != nil {
 		return service, err
 	}
-	defer closeResponseBodyWithContext(ctx, resp)
+	defer closeResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return service, NewDatasetAPIResponse(resp, "/healthcheck")
@@ -107,7 +100,7 @@ func (c *Client) Get(ctx context.Context, id, serviceToken string) (m Model, err
 	if err != nil {
 		return
 	}
-	defer closeResponseBodyWithContext(ctx, resp)
+	defer closeResponseBody(ctx, resp)
 	
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -157,7 +150,7 @@ func (c *Client) GetByPath(ctx context.Context, serviceToken, path string) (m Mo
 	if err != nil {
 		return
 	}
-	defer closeResponseBodyWithContext(ctx, resp)
+	defer closeResponseBody(ctx, resp)
 	
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -207,7 +200,7 @@ func (c *Client) GetDatasets(ctx context.Context, serviceToken string) (m ModelC
 	if err != nil {
 		return
 	}
-	defer closeResponseBodyWithContext(ctx, resp)
+	defer closeResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -246,7 +239,7 @@ func (c *Client) GetEdition(ctx context.Context, serviceToken, datasetID, editio
 	if err != nil {
 		return
 	}
-	defer closeResponseBodyWithContext(ctx, resp)
+	defer closeResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -293,7 +286,7 @@ func (c *Client) GetEditions(ctx context.Context, serviceToken, id string) (m []
 	if err != nil {
 		return
 	}
-	defer closeResponseBodyWithContext(ctx, resp)
+	defer closeResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -352,7 +345,7 @@ func (c *Client) GetVersions(ctx context.Context, serviceToken, downloadServiceT
 	if err != nil {
 		return
 	}
-	defer closeResponseBodyWithContext(ctx, resp)
+	defer closeResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -394,7 +387,7 @@ func (c *Client) GetVersion(ctx context.Context, serviceToken, downloadServiceTo
 	if err != nil {
 		return
 	}
-	defer closeResponseBodyWithContext(ctx, resp)
+	defer closeResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -429,7 +422,7 @@ func (c *Client) GetInstance(ctx context.Context, serviceToken, instanceID strin
 	if err != nil {
 		return
 	}
-	defer closeResponseBodyWithContext(ctx, resp)
+	defer closeResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -469,7 +462,7 @@ func (c *Client) PutVersion(ctx context.Context, serviceToken, datasetID, editio
 		return errors.Wrap(err, "http client returned error while attempting to make request")
 	}
 
-	defer closeResponseBodyWithContext(ctx, resp)
+	defer closeResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return errors.Errorf("incorrect http status, expected: 200, actual: %d, uri: %s", resp.StatusCode, uri)
@@ -501,7 +494,7 @@ func (c *Client) GetVersionMetadata(ctx context.Context, serviceToken, id, editi
 	if err != nil {
 		return
 	}
-	defer closeResponseBodyWithContext(ctx, resp)
+	defer closeResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -536,7 +529,7 @@ func (c *Client) GetDimensions(ctx context.Context, serviceToken, id, edition, v
 	if err != nil {
 		return
 	}
-	defer closeResponseBodyWithContext(ctx, resp)
+	defer closeResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -576,7 +569,7 @@ func (c *Client) GetOptions(ctx context.Context, serviceToken, id, edition, vers
 	if err != nil {
 		return
 	}
-	defer closeResponseBodyWithContext(ctx, resp)
+	defer closeResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -605,7 +598,7 @@ func NewDatasetAPIResponse(resp *http.Response, uri string) (e *ErrInvalidDatase
 			return
 		}
 		
-		defer closeResponseBody(resp)
+		defer closeResponseBody(nil, resp)
 		e.body = string(b)
 	}
 	return

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/ONSdigital/go-ns/log"
 	"io/ioutil"
 	"net/http"
 	"sort"
@@ -48,6 +49,20 @@ type Client struct {
 	url string
 }
 
+// closeResponseBodyWithContext closes the response body and logs an error containing the context if unsuccessful
+func closeResponseBodyWithContext(ctx context.Context, resp *http.Response) {
+	if err := resp.Body.Close(); err != nil {
+		log.ErrorCtx(ctx, err, log.Data{"Message": "error closing http response body"})
+	}
+}
+// closeResponseBody closes the response body and logs an error if unsuccessful
+
+func closeResponseBody(resp *http.Response) {
+	if err := resp.Body.Close(); err != nil {
+		log.Error(err, log.Data{"Message": "error closing http response body"})
+	}
+}
+
 // NewAPIClient creates a new instance of Client with a given dataset api url and the relevant tokens
 func NewAPIClient(datasetAPIURL string) *Client {
 	return &Client{
@@ -64,7 +79,7 @@ func (c *Client) Healthcheck() (string, error) {
 	if err != nil {
 		return service, err
 	}
-	defer resp.Body.Close()
+	defer closeResponseBodyWithContext(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return service, NewDatasetAPIResponse(resp, "/healthcheck")
@@ -92,8 +107,8 @@ func (c *Client) Get(ctx context.Context, id, serviceToken string) (m Model, err
 	if err != nil {
 		return
 	}
-	defer resp.Body.Close()
-
+	defer closeResponseBodyWithContext(ctx, resp)
+	
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
 		return
@@ -142,8 +157,8 @@ func (c *Client) GetByPath(ctx context.Context, serviceToken, path string) (m Mo
 	if err != nil {
 		return
 	}
-	defer resp.Body.Close()
-
+	defer closeResponseBodyWithContext(ctx, resp)
+	
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
 		return
@@ -192,7 +207,7 @@ func (c *Client) GetDatasets(ctx context.Context, serviceToken string) (m ModelC
 	if err != nil {
 		return
 	}
-	defer resp.Body.Close()
+	defer closeResponseBodyWithContext(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -231,7 +246,7 @@ func (c *Client) GetEdition(ctx context.Context, serviceToken, datasetID, editio
 	if err != nil {
 		return
 	}
-	defer resp.Body.Close()
+	defer closeResponseBodyWithContext(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -278,7 +293,7 @@ func (c *Client) GetEditions(ctx context.Context, serviceToken, id string) (m []
 	if err != nil {
 		return
 	}
-	defer resp.Body.Close()
+	defer closeResponseBodyWithContext(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -317,7 +332,7 @@ func (c *Client) GetEditions(ctx context.Context, serviceToken, id string) (m []
 }
 
 // GetVersions gets all versions for an edition from the dataset api
-func (c *Client) GetVersions(ctx context.Context, serviceToken, id, edition, downloadServiceToken string) (m []Version, err error) {
+func (c *Client) GetVersions(ctx context.Context, serviceToken, downloadServiceToken, id, edition string ) (m []Version, err error) {
 	uri := fmt.Sprintf("%s/datasets/%s/editions/%s/versions", c.url, id, edition)
 
 	clientlog.Do(ctx, "retrieving dataset versions", service, uri)
@@ -337,7 +352,7 @@ func (c *Client) GetVersions(ctx context.Context, serviceToken, id, edition, dow
 	if err != nil {
 		return
 	}
-	defer resp.Body.Close()
+	defer closeResponseBodyWithContext(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -359,7 +374,7 @@ func (c *Client) GetVersions(ctx context.Context, serviceToken, id, edition, dow
 }
 
 // GetVersion gets a specific version for an edition from the dataset api
-func (c *Client) GetVersion(ctx context.Context, serviceToken, id, edition, version, downloadServiceToken string) (m Version, err error) {
+func (c *Client) GetVersion(ctx context.Context, serviceToken, downloadServiceToken, id, edition, version string) (m Version, err error) {
 	uri := fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s", c.url, id, edition, version)
 
 	clientlog.Do(ctx, "retrieving dataset version", service, uri)
@@ -379,7 +394,7 @@ func (c *Client) GetVersion(ctx context.Context, serviceToken, id, edition, vers
 	if err != nil {
 		return
 	}
-	defer resp.Body.Close()
+	defer closeResponseBodyWithContext(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -414,7 +429,7 @@ func (c *Client) GetInstance(ctx context.Context, serviceToken, instanceID strin
 	if err != nil {
 		return
 	}
-	defer resp.Body.Close()
+	defer closeResponseBodyWithContext(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -454,7 +469,7 @@ func (c *Client) PutVersion(ctx context.Context, serviceToken, datasetID, editio
 		return errors.Wrap(err, "http client returned error while attempting to make request")
 	}
 
-	defer resp.Body.Close()
+	defer closeResponseBodyWithContext(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return errors.Errorf("incorrect http status, expected: 200, actual: %d, uri: %s", resp.StatusCode, uri)
@@ -486,7 +501,7 @@ func (c *Client) GetVersionMetadata(ctx context.Context, serviceToken, id, editi
 	if err != nil {
 		return
 	}
-	defer resp.Body.Close()
+	defer closeResponseBodyWithContext(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -521,7 +536,7 @@ func (c *Client) GetDimensions(ctx context.Context, serviceToken, id, edition, v
 	if err != nil {
 		return
 	}
-	defer resp.Body.Close()
+	defer closeResponseBodyWithContext(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -561,7 +576,7 @@ func (c *Client) GetOptions(ctx context.Context, serviceToken, id, edition, vers
 	if err != nil {
 		return
 	}
-	defer resp.Body.Close()
+	defer closeResponseBodyWithContext(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = NewDatasetAPIResponse(resp, uri)
@@ -589,7 +604,8 @@ func NewDatasetAPIResponse(resp *http.Response, uri string) (e *ErrInvalidDatase
 			e.body = "Client failed to read DatasetAPI body"
 			return
 		}
-		defer resp.Body.Close()
+		
+		defer closeResponseBody(resp)
 		e.body = string(b)
 	}
 	return

--- a/hierarchy/hierarchy.go
+++ b/hierarchy/hierarchy.go
@@ -44,6 +44,7 @@ type Client struct {
 	url string
 }
 
+// CloseResponseBody closes the response body and logs an error if unsuccessful
 func closeResponseBody(ctx context.Context, resp *http.Response) {
 	if err := resp.Body.Close(); err != nil {
 		log.ErrorCtx(ctx, err, log.Data{"Message": "error closing http response body"})

--- a/hierarchy/hierarchy.go
+++ b/hierarchy/hierarchy.go
@@ -47,7 +47,7 @@ type Client struct {
 // CloseResponseBody closes the response body and logs an error if unsuccessful
 func closeResponseBody(ctx context.Context, resp *http.Response) {
 	if err := resp.Body.Close(); err != nil {
-		log.ErrorCtx(ctx, err, log.Data{"Message": "error closing http response body"})
+		log.ErrorCtx(ctx, err, log.Data{"message": "error closing http response body"})
 	}
 }
 

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -46,7 +46,7 @@ func New(url string) *Renderer {
 
 func closeResponseBody(ctx context.Context, resp *http.Response) {
 	if err := resp.Body.Close(); err != nil {
-		log.ErrorCtx(ctx, err, log.Data{"Message": "error closing http response body"})
+		log.ErrorCtx(ctx, err, log.Data{"message": "error closing http response body"})
 	}
 }
 


### PR DESCRIPTION
### What

- Added error handling to the dataset api response closing
- Reordered download service auth token expected parameter position

### How to review

Check this is consistent with the other clients

### Who can review

Anyone except me