### PR TITLE
Reorder params to follow convention

### DIFF
--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -82,7 +82,7 @@ func (c *Client) Healthcheck() (string, error) {
 }
 
 // Get returns dataset level information for a given dataset id
-func (c *Client) Get(ctx context.Context, id, serviceToken string) (m Model, err error) {
+func (c *Client) Get(ctx context.Context, serviceToken, id  string) (m Model, err error) {
 	uri := fmt.Sprintf("%s/datasets/%s", c.url, id)
 
 	clientlog.Do(ctx, "retrieving dataset", service, uri)


### PR DESCRIPTION
### What

Reorder params for getting method of dataset client, all methods should now follow param order convention

### How to review

Check the params are in the right order, context, tokens followed by any other param

### Who can review

Anyone except me
