### PR TITLE
added defensive nil pointer check to closeResponse

### DIFF
--- a/identity/authentication.go
+++ b/identity/authentication.go
@@ -157,6 +157,10 @@ func unmarshalIdentityResponse(resp *http.Response) (identityResp *common.Identi
 }
 
 func closeResponse(ctx context.Context, resp *http.Response, data log.Data) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+
 	if errClose := resp.Body.Close(); errClose != nil {
 		log.Event(ctx, "error closing response body", log.Error(errClose), data)
 	}


### PR DESCRIPTION
Added a defensive check to prevent a `nil pointer` error when closing a response if:
- The `response` is `nil` 
OR
- The `response.body` is `nil`
