### PR TITLE
added new headers pkg as new source of truth for common request headers

### DIFF
--- a/headers/headers.go
+++ b/headers/headers.go
@@ -38,8 +38,10 @@ func setRequestHeader(req *http.Request, headerName string, headerValue string) 
 		return errRequestNil
 	}
 
+	logD := log.Data{"header_name": headerName}
+
 	if len(headerValue) == 0 {
-		log.Event(context.Background(), "request header not set as value was empty", log.Data{"header_name": headerName})
+		log.Event(context.Background(), "request header not set as value was empty", logD)
 		return nil
 	}
 
@@ -49,11 +51,8 @@ func setRequestHeader(req *http.Request, headerName string, headerValue string) 
 	}
 
 	if err != nil && err == ErrHeaderNotFound {
-		logD := log.Data{
-			"header_name": headerName,
-			"existing":    existing,
-			"new":         headerValue,
-		}
+		logD["existing"] = existing
+		logD["new"] = headerValue
 		log.Event(context.Background(), "overwriting existing request header", logD)
 	}
 

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -1,0 +1,75 @@
+// headers package provides header name constants and get/set functions for commonly used http headers in the
+// dp-api-clients-go repo. Package replaces go-ns lib and should be treated as the single source of truth
+package headers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/ONSdigital/log.go/log"
+)
+
+var (
+	// CollectionIDKey is the name used for a collection ID http request header
+	CollectionIDKey = "Collection-Id"
+
+	// ErrHeaderNotFound returned if the requested header is not present in the provided request
+	ErrHeaderNotFound = errors.New("header not found")
+
+	errRequestNil = errors.New("error setting request header request was nil")
+)
+
+func getRequestHeader(req *http.Request, headerName string) (string, error) {
+	if req == nil {
+		return "", errRequestNil
+	}
+
+	headerValue := req.Header.Get(headerName)
+	if len(headerValue) == 0 {
+		return "", ErrHeaderNotFound
+	}
+
+	return headerValue, nil
+}
+
+func setRequestHeader(req *http.Request, headerName string, headerValue string) error {
+	if req == nil {
+		return errRequestNil
+	}
+
+	if len(headerValue) == 0 {
+		log.Event(context.Background(), "request header not set as value was empty", log.Data{"header_name": headerName})
+		return nil
+	}
+
+	existing, err := GetCollectionID(req)
+	if err != nil && err != ErrHeaderNotFound {
+		return err
+	}
+
+	if err != nil && err == ErrHeaderNotFound {
+		logD := log.Data{
+			"header_name": headerName,
+			"existing":    existing,
+			"new":         headerValue,
+		}
+		log.Event(context.Background(), "overwriting existing request header", logD)
+	}
+
+	req.Header.Set(headerName, headerValue)
+	return nil
+}
+
+// GetCollectionID returns the value of the "Collection-Id" request header if it exists, returns ErrHeaderNotFound if
+// the header is not found.
+func GetCollectionID(req *http.Request) (string, error) {
+	return getRequestHeader(req, CollectionIDKey)
+}
+
+// SetCollectionID set the collection ID header on the provided request. If the collection ID header is already present
+// in the request it will be overwritten by the new value. If the header value is empty then no header will be set and
+// no error is returned.
+func SetCollectionID(req *http.Request, collectionID string) error {
+	return setRequestHeader(req, CollectionIDKey, collectionID)
+}

--- a/headers/headers_test.go
+++ b/headers/headers_test.go
@@ -1,0 +1,84 @@
+package headers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var (
+	testHeader1 = "1234567890"
+	testHeader2 = "0987654321"
+)
+
+func TestSetCollectionID(t *testing.T) {
+	Convey("should return error if request is nil", t, func() {
+		err := SetCollectionID(nil, "")
+
+		So(err, ShouldResemble, errRequestNil)
+	})
+
+	Convey("should not add header if value is empty", t, func() {
+		req := requestWithHeader("")
+
+		err := SetCollectionID(req, "")
+
+		So(err, ShouldBeNil)
+		So(req.Header.Get(CollectionIDKey), ShouldBeEmpty)
+	})
+
+	Convey("should overwrite an existing header", t, func() {
+		req := requestWithHeader(testHeader1)
+
+		err := SetCollectionID(req, testHeader2)
+
+		So(err, ShouldBeNil)
+		So(req.Header.Get(CollectionIDKey), ShouldEqual, testHeader2)
+	})
+
+	Convey("should set header if it does not already exist", t, func() {
+		req := requestWithHeader("")
+
+		err := SetCollectionID(req, testHeader1)
+
+		So(err, ShouldBeNil)
+		So(req.Header.Get(CollectionIDKey), ShouldEqual, testHeader1)
+	})
+}
+
+func TestGetCollectionID(t *testing.T) {
+	Convey("should return expected error if request is nil", t, func() {
+		actual, err := GetCollectionID(nil)
+
+		So(err, ShouldResemble, errRequestNil)
+		So(actual, ShouldBeEmpty)
+	})
+
+	Convey("should return ErrHeaderNotFound if the collection ID request header is not found", t, func() {
+		req := requestWithHeader("")
+
+		actual, err := GetCollectionID(req)
+
+		So(err, ShouldResemble, ErrHeaderNotFound)
+		So(actual, ShouldBeEmpty)
+	})
+
+	Convey("should return header value if present", t, func() {
+		req := requestWithHeader(testHeader1)
+
+		actual, err := GetCollectionID(req)
+
+		So(err, ShouldBeNil)
+		So(actual, ShouldEqual, testHeader1)
+	})
+}
+
+func requestWithHeader(val string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "http://localhost:456789/schwifty", nil)
+	if len(val) > 0 {
+		r.Header.Set(CollectionIDKey, val)
+	}
+	return r
+}


### PR DESCRIPTION
### What

Added new `headers` package to replace duplicated & inconsistent header utilities in `go-ns`.
Added functions for `Get/Set` `Collection-Id` header plus unit tests.
