### PR TITLE
Feature/codelist client headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Common client code - in go - for ONS APIs:
 * codelist
 * dataset
 * filter
+* headers - common API request headers
 * hierarchy
 * identity
 * importapi

--- a/codelist/codelist.go
+++ b/codelist/codelist.go
@@ -7,8 +7,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/ONSdigital/dp-api-clients-go/headers"
 	rchttp "github.com/ONSdigital/dp-rchttp"
-	"github.com/ONSdigital/go-ns/common"
 	"github.com/ONSdigital/log.go/log"
 )
 
@@ -279,9 +279,25 @@ func (c *Client) doGetWithAuthHeaders(ctx context.Context, userAuthToken string,
 		return nil, err
 	}
 
-	common.AddFlorenceHeader(req, userAuthToken)
-	common.AddServiceTokenHeader(req, serviceAuthToken)
+	if err := setAuthenticationHeaders(req, userAuthToken, serviceAuthToken); err != nil {
+		return nil, err
+	}
+
 	return c.cli.Do(ctx, req)
+}
+
+func setAuthenticationHeaders(req *http.Request, userAuthToken, serviceAuthToken string) error {
+	err := headers.SetUserAuthToken(req, userAuthToken)
+	if err != nil && err != headers.ErrValueEmpty {
+		return err
+	}
+
+	err = headers.SetServiceAuthToken(req, serviceAuthToken);
+	if err != nil && err != headers.ErrValueEmpty {
+		return err
+	}
+
+	return nil
 }
 
 func closeResponseBody(ctx context.Context, resp *http.Response) {

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -35,6 +35,7 @@ var (
 	// ErrValueEmpty returned if an empty value is passed to a SetX header function
 	ErrValueEmpty = errors.New("header not set as value was empty")
 
+	// ErrRequestNil return if SetX header function is called with a nil request
 	ErrRequestNil = errors.New("error setting request header request was nil")
 )
 

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -35,7 +35,7 @@ var (
 	// ErrValueEmpty returned if an empty value is passed to a SetX header function
 	ErrValueEmpty = errors.New("header not set as value was empty")
 
-	errRequestNil = errors.New("error setting request header request was nil")
+	ErrRequestNil = errors.New("error setting request header request was nil")
 )
 
 // GetCollectionID returns the value of the "Collection-Id" request header if it exists, returns ErrHeaderNotFound if
@@ -78,7 +78,7 @@ func GetUserIdentity(req *http.Request) (string, error) {
 
 func getRequestHeader(req *http.Request, headerName string) (string, error) {
 	if req == nil {
-		return "", errRequestNil
+		return "", ErrRequestNil
 	}
 
 	headerValue := req.Header.Get(headerName)
@@ -105,7 +105,7 @@ func SetUserAuthToken(req *http.Request, headerValue string) error {
 // already present it will be overwritten by the new value. If the header value is empty then returns ErrValueEmpty
 func SetServiceAuthToken(req *http.Request, headerValue string) error {
 	if req == nil {
-		return errRequestNil
+		return ErrRequestNil
 	}
 
 	if len(headerValue) == 0 {
@@ -133,7 +133,7 @@ func SetUserIdentity(req *http.Request, headerValue string) error {
 
 func setRequestHeader(req *http.Request, headerName string, headerValue string) error {
 	if req == nil {
-		return errRequestNil
+		return ErrRequestNil
 	}
 
 	if len(headerValue) == 0 {

--- a/headers/headers_test.go
+++ b/headers/headers_test.go
@@ -46,7 +46,7 @@ func TestSetCollectionID(t *testing.T) {
 				return ""
 			},
 			assertResultFunc: func(err error, val string) {
-				So(err, ShouldResemble, errRequestNil)
+				So(err, ShouldResemble, ErrRequestNil)
 			},
 		},
 		{
@@ -119,7 +119,7 @@ func TestSetUserAuthToken(t *testing.T) {
 				return ""
 			},
 			assertResultFunc: func(err error, val string) {
-				So(err, ShouldResemble, errRequestNil)
+				So(err, ShouldResemble, ErrRequestNil)
 			},
 		},
 		{
@@ -192,7 +192,7 @@ func TestSetServiceAuthToken(t *testing.T) {
 				return ""
 			},
 			assertResultFunc: func(err error, val string) {
-				So(err, ShouldResemble, errRequestNil)
+				So(err, ShouldResemble, ErrRequestNil)
 			},
 		},
 		{
@@ -265,7 +265,7 @@ func TestSetDownloadServiceToken(t *testing.T) {
 				return ""
 			},
 			assertResultFunc: func(err error, val string) {
-				So(err, ShouldResemble, errRequestNil)
+				So(err, ShouldResemble, ErrRequestNil)
 			},
 		},
 		{
@@ -338,7 +338,7 @@ func TestSetUserIdentity(t *testing.T) {
 				return ""
 			},
 			assertResultFunc: func(err error, val string) {
-				So(err, ShouldResemble, errRequestNil)
+				So(err, ShouldResemble, ErrRequestNil)
 			},
 		},
 		{
@@ -405,7 +405,7 @@ func TestGetCollectionID(t *testing.T) {
 				return GetCollectionID(r)
 			},
 			assertResultFunc: func(err error, val string) {
-				So(err, ShouldResemble, errRequestNil)
+				So(err, ShouldResemble, ErrRequestNil)
 				So(val, ShouldBeEmpty)
 			},
 		},
@@ -451,7 +451,7 @@ func TestGetUserAuthToken(t *testing.T) {
 				return GetUserAuthToken(r)
 			},
 			assertResultFunc: func(err error, val string) {
-				So(err, ShouldResemble, errRequestNil)
+				So(err, ShouldResemble, ErrRequestNil)
 				So(val, ShouldBeEmpty)
 			},
 		},
@@ -497,7 +497,7 @@ func TestGetServiceAuthToken(t *testing.T) {
 				return GetServiceAuthToken(r)
 			},
 			assertResultFunc: func(err error, val string) {
-				So(err, ShouldResemble, errRequestNil)
+				So(err, ShouldResemble, ErrRequestNil)
 				So(val, ShouldBeEmpty)
 			},
 		},
@@ -543,7 +543,7 @@ func TestGetDownloadServiceToken(t *testing.T) {
 				return GetDownloadServiceToken(r)
 			},
 			assertResultFunc: func(err error, val string) {
-				So(err, ShouldResemble, errRequestNil)
+				So(err, ShouldResemble, ErrRequestNil)
 				So(val, ShouldBeEmpty)
 			},
 		},
@@ -589,7 +589,7 @@ func TestGetUserIdentity(t *testing.T) {
 				return GetUserIdentity(r)
 			},
 			assertResultFunc: func(err error, val string) {
-				So(err, ShouldResemble, errRequestNil)
+				So(err, ShouldResemble, ErrRequestNil)
 				So(val, ShouldBeEmpty)
 			},
 		},


### PR DESCRIPTION
### What

Migrated the codelist client from the `go-ns` to use the new `headers` package for auth request headers and updated appropriate unit tests.

### How to review

Code review, run unit tests and check coverage and scenarios.

### Who can review

@jondewijones @dandwal @janderson2 @eldeal @jessjenkins @gedge 
