### PR TITLE
added helper func for checking if an error is ErrHeaderNotFound

### DIFF
--- a/headers/headers.go
+++ b/headers/headers.go
@@ -45,6 +45,11 @@ var (
 	ErrRequestNil = errors.New("error setting request header request was nil")
 )
 
+// IsNotFound return true if the err equals ErrHeaderNotFound return false otherwise
+func IsNotFound(err error) bool {
+	return err == ErrHeaderNotFound
+}
+
 // GetCollectionID returns the value of the "Collection-Id" request header if it exists, returns ErrHeaderNotFound if
 // the header is not found.
 func GetCollectionID(req *http.Request) (string, error) {

--- a/headers/headers_test.go
+++ b/headers/headers_test.go
@@ -1,6 +1,7 @@
 package headers
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -27,6 +28,20 @@ type getHeaderTestCase struct {
 	getRequestFunc   func() *http.Request
 	getHeaderFunc    func(r *http.Request) (string, error)
 	assertResultFunc func(err error, val string)
+}
+
+func TestIsNotFound(t *testing.T) {
+	Convey("IsNotFound should return false if nil", t, func() {
+		So(IsNotFound(nil), ShouldBeFalse)
+	})
+
+	Convey("IsNotFound should return false if err not equal to ErrHeaderNotFound ", t, func() {
+		So(IsNotFound(errors.New("test")), ShouldBeFalse)
+	})
+
+	Convey("IsNotFound should return true if err equal to ErrHeaderNotFound ", t, func() {
+		So(IsNotFound(ErrHeaderNotFound), ShouldBeTrue)
+	})
 }
 
 func TestSetCollectionID(t *testing.T) {
@@ -467,7 +482,6 @@ func TestSetRequestID(t *testing.T) {
 	execSetHeaderTestCases(t, cases)
 }
 
-
 func TestSetLocaleCode(t *testing.T) {
 	cases := []setHeaderTestCase{
 		{
@@ -862,7 +876,6 @@ func TestGetLocaleCode(t *testing.T) {
 
 	execGetHeaderTestCases(t, cases)
 }
-
 
 func execSetHeaderTestCases(t *testing.T, cases []setHeaderTestCase) {
 	for i, tc := range cases {


### PR DESCRIPTION
Added new func for checking if an error is equal to `ErrHeaderNotFound` to reduce the burden on the caller. 
A fairly common pattern in Go for "expected errors" i.e. `os.IsNotExist(err error)`. Added unit tests for new functionality.