### PR TITLE
Add health checker function

### DIFF
--- a/health/check.go
+++ b/health/check.go
@@ -1,0 +1,48 @@
+package health
+
+import (
+	"context"
+	"time"
+
+	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
+)
+
+var (
+	statusDescription = map[string]string{
+		health.StatusOK:       "Everything is ok",
+		health.StatusWarning:  "Things are degraded, but at least partially functioning",
+		health.StatusCritical: "The checked functionality is unavailable or non-functioning",
+	}
+
+	unixTime = time.Unix(1494505756, 0)
+)
+
+func getCheck(ctx *context.Context, name string, code int) *health.Check {
+
+	currentTime := time.Now().UTC()
+
+	check := &health.Check{
+		Name:        name,
+		StatusCode:  code,
+		LastChecked: currentTime,
+		LastSuccess: unixTime,
+		LastFailure: unixTime,
+	}
+
+	switch code {
+	case 200:
+		check.Message = statusDescription[health.StatusOK]
+		check.Status = health.StatusOK
+		check.LastSuccess = currentTime
+	case 429:
+		check.Message = statusDescription[health.StatusWarning]
+		check.Status = health.StatusWarning
+		check.LastFailure = currentTime
+	default:
+		check.Message = statusDescription[health.StatusCritical]
+		check.Status = health.StatusCritical
+		check.LastFailure = currentTime
+	}
+
+	return check
+}

--- a/health/check_test.go
+++ b/health/check_test.go
@@ -1,0 +1,52 @@
+package health
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestHealth_GetCheck(t *testing.T) {
+	defaultTime := time.Now().UTC()
+	ctx := context.Background()
+
+	Convey("Given a 200 status code return OK health check object", t, func() {
+		check := getCheck(&ctx, "api", 200)
+
+		So(check.Name, ShouldEqual, "api")
+		So(check.StatusCode, ShouldEqual, 200)
+		So(check.Status, ShouldEqual, health.StatusOK)
+		So(check.Message, ShouldEqual, statusDescription[health.StatusOK])
+		So(check.LastChecked, ShouldHappenAfter, defaultTime)
+		So(check.LastSuccess, ShouldHappenAfter, defaultTime)
+		So(check.LastFailure, ShouldEqual, unixTime)
+	})
+
+	Convey("Given a 429 status code return Warning health check object", t, func() {
+		check := getCheck(&ctx, "api", 429)
+
+		So(check.Name, ShouldEqual, "api")
+		So(check.StatusCode, ShouldEqual, 429)
+		So(check.Status, ShouldEqual, health.StatusWarning)
+		So(check.Message, ShouldEqual, statusDescription[health.StatusWarning])
+		So(check.LastChecked, ShouldHappenAfter, defaultTime)
+		So(check.LastSuccess, ShouldEqual, unixTime)
+		So(check.LastFailure, ShouldHappenAfter, defaultTime)
+	})
+
+	Convey("Given a 404 status code return Critical health check object", t, func() {
+		check := getCheck(&ctx, "api", 404)
+
+		So(check.Name, ShouldEqual, "api")
+		So(check.StatusCode, ShouldEqual, 404)
+		So(check.Status, ShouldEqual, health.StatusCritical)
+		So(check.Message, ShouldEqual, statusDescription[health.StatusCritical])
+		So(check.LastChecked, ShouldHappenAfter, defaultTime)
+		So(check.LastSuccess, ShouldEqual, unixTime)
+		So(check.LastFailure, ShouldHappenAfter, defaultTime)
+	})
+
+}

--- a/health/health.go
+++ b/health/health.go
@@ -27,8 +27,8 @@ type Client struct {
 	url    string
 }
 
-// New creates a new instance of Client with a given api url
-func New(name, url string) *Client {
+// NewClient creates a new instance of Client with a given api url
+func NewClient(name, url string) *Client {
 	c := &Client{
 		client: rchttp.NewClient(),
 		name:   name,

--- a/health/health.go
+++ b/health/health.go
@@ -1,0 +1,93 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
+	rchttp "github.com/ONSdigital/dp-rchttp"
+	"github.com/ONSdigital/log.go/log"
+)
+
+// ErrInvalidAPIResponse is returned when an api does not respond
+// with a valid status
+type ErrInvalidAPIResponse struct {
+	expectedCode int
+	actualCode   int
+	uri          string
+}
+
+// Client represents an api client
+type Client struct {
+	client rchttp.Clienter
+	name   string
+	url    string
+}
+
+// New creates a new instance of Client with a given api url
+func New(name, url string) *Client {
+	c := &Client{
+		client: rchttp.NewClient(),
+		name:   name,
+		url:    url,
+	}
+
+	// Set the number of max retries to 1, allow caller to
+	// handle re-calling health checker
+	c.client.SetMaxRetries(1)
+
+	return c
+}
+
+// Error should be called by the user to print out the stringified version of the error
+func (e ErrInvalidAPIResponse) Error() string {
+	return fmt.Sprintf("invalid response from downstream api - should be: %d, got: %d, path: %s",
+		e.expectedCode,
+		e.actualCode,
+		e.uri,
+	)
+}
+
+// Checker calls an api health endpoint and returns a check object to the caller
+func (c *Client) Checker(ctx *context.Context) (*health.Check, error) {
+	logData := log.Data{
+		"api": c.name,
+	}
+
+	statusCode, err := c.get(*ctx, "/health")
+	// Apps may still have /healthcheck endpoint
+	// instead of a /health one
+	if statusCode == http.StatusNotFound {
+		statusCode, err = c.get(*ctx, "/healthcheck")
+	}
+	if err != nil {
+		log.Event(*ctx, "failed to request api health", log.Error(err), logData)
+	}
+
+	check := getCheck(ctx, c.name, statusCode)
+
+	return check, nil
+}
+
+func (c *Client) get(ctx context.Context, path string) (int, error) {
+	req, err := http.NewRequest("GET", c.url+path, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := c.client.Do(ctx, req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || (resp.StatusCode > 399 && resp.StatusCode != 429) {
+		io.Copy(ioutil.Discard, resp.Body)
+		return resp.StatusCode, ErrInvalidAPIResponse{http.StatusOK, resp.StatusCode, req.URL.Path}
+	}
+
+	return resp.StatusCode, nil
+}

--- a/health/health.go
+++ b/health/health.go
@@ -28,16 +28,15 @@ type Client struct {
 }
 
 // NewClient creates a new instance of Client with a given api url
-func NewClient(name, url string) *Client {
+func NewClient(name, url string, maxRetries int) *Client {
 	c := &Client{
 		client: rchttp.NewClient(),
 		name:   name,
 		url:    url,
 	}
 
-	// Set the number of max retries to 1, allow caller to
-	// handle re-calling health checker
-	c.client.SetMaxRetries(1)
+	// Overwrite the default number of max retries on the new client
+	c.client.SetMaxRetries(maxRetries)
 
 	return c
 }

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -32,7 +32,7 @@ func getMockAPI(expectRequest http.Request, mockedHTTPResponse MockedHTTPRespons
 		fmt.Fprintln(w, mockedHTTPResponse.Body)
 	}))
 
-	api := New(apiName, ts.URL)
+	api := NewClient(apiName, ts.URL)
 	// Set the number of retries to 1 for test
 	api.client.SetMaxRetries(1)
 

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -32,9 +32,10 @@ func getMockAPI(expectRequest http.Request, mockedHTTPResponse MockedHTTPRespons
 		fmt.Fprintln(w, mockedHTTPResponse.Body)
 	}))
 
-	api := NewClient(apiName, ts.URL)
 	// Set the number of retries to 1 for test
-	api.client.SetMaxRetries(1)
+	maxRetries := 1
+
+	api := NewClient(apiName, ts.URL, maxRetries)
 
 	return api
 }

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -1,0 +1,129 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type MockedHTTPResponse struct {
+	StatusCode int
+	Body       string
+}
+
+const apiName = "api"
+
+var ctx = context.Background()
+
+func getMockAPI(expectRequest http.Request, mockedHTTPResponse MockedHTTPResponse) *Client {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != expectRequest.Method {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("unexpected HTTP method used"))
+			return
+		}
+		w.WriteHeader(mockedHTTPResponse.StatusCode)
+		fmt.Fprintln(w, mockedHTTPResponse.Body)
+	}))
+
+	api := New(apiName, ts.URL)
+	// Set the number of retries to 1 for test
+	api.client.SetMaxRetries(1)
+
+	return api
+}
+
+func TestClient_GetOutput(t *testing.T) {
+	defaultTime := time.Now().UTC()
+
+	Convey("When health endpoint returns status OK", t, func() {
+		mockedAPI := getMockAPI(
+			http.Request{Method: "GET"},
+			MockedHTTPResponse{StatusCode: 200, Body: "{\"status\": \"OK\"}"},
+		)
+
+		check, err := mockedAPI.Checker(&ctx)
+		So(check.Name, ShouldEqual, apiName)
+		So(check.StatusCode, ShouldEqual, 200)
+		So(check.Status, ShouldEqual, health.StatusOK)
+		So(check.Message, ShouldEqual, statusDescription[health.StatusOK])
+		So(check.LastChecked, ShouldHappenAfter, defaultTime)
+		So(check.LastFailure, ShouldEqual, unixTime)
+		So(check.LastSuccess, ShouldHappenAfter, defaultTime)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("When health endpoint returns status Warning", t, func() {
+		mockedAPI := getMockAPI(
+			http.Request{Method: "GET"},
+			MockedHTTPResponse{StatusCode: 429, Body: "{\"status\": \"WARNING\"}"},
+		)
+
+		check, err := mockedAPI.Checker(&ctx)
+		So(check.Name, ShouldEqual, apiName)
+		So(check.StatusCode, ShouldEqual, 429)
+		So(check.Status, ShouldEqual, health.StatusWarning)
+		So(check.Message, ShouldEqual, statusDescription[health.StatusWarning])
+		So(check.LastChecked, ShouldHappenAfter, defaultTime)
+		So(check.LastFailure, ShouldHappenAfter, defaultTime)
+		So(check.LastSuccess, ShouldEqual, unixTime)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("When health endpoint returns status Critical", t, func() {
+		mockedAPI := getMockAPI(
+			http.Request{Method: "GET"},
+			MockedHTTPResponse{StatusCode: 500, Body: "{\"status\": \"CRITICAL\"}"},
+		)
+
+		check, err := mockedAPI.Checker(&ctx)
+		So(check.Name, ShouldEqual, apiName)
+		So(check.StatusCode, ShouldEqual, 500)
+		So(check.Status, ShouldEqual, health.StatusCritical)
+		So(check.Message, ShouldEqual, statusDescription[health.StatusCritical])
+		So(check.LastChecked, ShouldHappenAfter, defaultTime)
+		So(check.LastFailure, ShouldHappenAfter, defaultTime)
+		So(check.LastSuccess, ShouldEqual, unixTime)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("When health endpoint is not implemented a status code of 404 is returned", t, func() {
+		mockedAPI := getMockAPI(
+			http.Request{Method: "GET"},
+			MockedHTTPResponse{StatusCode: 404, Body: ""},
+		)
+
+		check, err := mockedAPI.Checker(&ctx)
+		So(check.Name, ShouldEqual, apiName)
+		So(check.StatusCode, ShouldEqual, 404)
+		So(check.Status, ShouldEqual, health.StatusCritical)
+		So(check.Message, ShouldEqual, statusDescription[health.StatusCritical])
+		So(check.LastChecked, ShouldHappenAfter, defaultTime)
+		So(check.LastFailure, ShouldHappenAfter, defaultTime)
+		So(check.LastSuccess, ShouldEqual, unixTime)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("When an api is unavailable a status code of 500 is returned", t, func() {
+		mockedAPI := getMockAPI(
+			http.Request{Method: "GET"},
+			MockedHTTPResponse{StatusCode: 500, Body: ""},
+		)
+
+		check, err := mockedAPI.Checker(&ctx)
+		So(check.Name, ShouldEqual, apiName)
+		So(check.StatusCode, ShouldEqual, 500)
+		So(check.Status, ShouldEqual, health.StatusCritical)
+		So(check.Message, ShouldEqual, statusDescription[health.StatusCritical])
+		So(check.LastChecked, ShouldHappenAfter, defaultTime)
+		So(check.LastFailure, ShouldHappenAfter, defaultTime)
+		So(check.LastSuccess, ShouldEqual, unixTime)
+		So(err, ShouldBeNil)
+	})
+}


### PR DESCRIPTION
### What

Add health checker function for calling API health endpoints and it abides the healthcheck.checker interface.

### How to review

Check code logic - particularly the creation of check object determined by the response from `/health` or `/healthcheck` endpoints, see [documentation](https://github.com/ONSdigital/dp/blob/master/standards/HEALTH_CHECK_SPECIFICATION.md#check-statuses)

### Who can review

Anyone
