### PR TITLE
Handle 401 errors returning from `/health`

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -78,7 +78,7 @@ func (c *Client) Checker(ctx context.Context, state *health.CheckState) error {
 	code, err := c.get(ctx, "/health")
 	// Apps may still have /healthcheck endpoint
 	// instead of a /health one
-	if code == http.StatusNotFound {
+	if code == http.StatusNotFound || code == http.StatusUnauthorized {
 		code, err = c.get(ctx, "/healthcheck")
 	}
 	if err != nil {

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -97,23 +97,44 @@ func TestClient_GetOutput(t *testing.T) {
 		So(err, ShouldBeNil)
 	})
 
-	Convey("When health endpoint is not implemented a status code of 404 is returned", t, func() {
-		mockedAPI := getMockAPI(
-			http.Request{Method: "GET"},
-			MockedHTTPResponse{StatusCode: 404, Body: ""},
-		)
+	Convey("When health endpoint is not implemented", t, func() {
+		Convey("and a status code of 404 is returned", func() {
+			mockedAPI := getMockAPI(
+				http.Request{Method: "GET"},
+				MockedHTTPResponse{StatusCode: 404, Body: ""},
+			)
 
-		check := CreateCheckState(apiName)
+			check := CreateCheckState(apiName)
 
-		err := mockedAPI.Checker(ctx, &check)
-		So(check.Name(), ShouldEqual, apiName)
-		So(check.StatusCode(), ShouldEqual, 404)
-		So(check.Status(), ShouldEqual, health.StatusCritical)
-		So(check.Message(), ShouldEqual, apiName+StatusMessage[health.StatusCritical])
-		So(*check.LastChecked(), ShouldHappenAfter, initialTime)
-		So(*check.LastFailure(), ShouldHappenAfter, initialTime)
-		So(check.LastSuccess(), ShouldBeNil)
-		So(err, ShouldBeNil)
+			err := mockedAPI.Checker(ctx, &check)
+			So(check.Name(), ShouldEqual, apiName)
+			So(check.StatusCode(), ShouldEqual, 404)
+			So(check.Status(), ShouldEqual, health.StatusCritical)
+			So(check.Message(), ShouldEqual, apiName+StatusMessage[health.StatusCritical])
+			So(*check.LastChecked(), ShouldHappenAfter, initialTime)
+			So(*check.LastFailure(), ShouldHappenAfter, initialTime)
+			So(check.LastSuccess(), ShouldBeNil)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("and a status code of 401 is returned", func() {
+			mockedAPI := getMockAPI(
+				http.Request{Method: "GET"},
+				MockedHTTPResponse{StatusCode: 404, Body: ""},
+			)
+
+			check := CreateCheckState(apiName)
+
+			err := mockedAPI.Checker(ctx, &check)
+			So(check.Name(), ShouldEqual, apiName)
+			So(check.StatusCode(), ShouldEqual, 404)
+			So(check.Status(), ShouldEqual, health.StatusCritical)
+			So(check.Message(), ShouldEqual, apiName+StatusMessage[health.StatusCritical])
+			So(*check.LastChecked(), ShouldHappenAfter, initialTime)
+			So(*check.LastFailure(), ShouldHappenAfter, initialTime)
+			So(check.LastSuccess(), ShouldBeNil)
+			So(err, ShouldBeNil)
+		})
 	})
 
 	Convey("When an api is unavailable a status code of 503 is returned", t, func() {


### PR DESCRIPTION
### What

The health package checker functionality should make a second request to `/healthcheck` endpoint if the response status code from `/health` is 401.

The reason `/health` service endpoint may return 401 instead of a 404 is due to whitelisting endpoints for authentication. Current services will not have a `/health` endpoint and if instances of a service are in publishing state they will return a 401 over a 404 for an endpoint that doesn't exist.

### How to review

* Code changes make logical sense and cover the ###What statement above
* Check unit tests still pass

### Who can review

Anyone
