### PR TITLE
Feature/support byte array getters

### DIFF
--- a/clientlog/clientlog.go
+++ b/clientlog/clientlog.go
@@ -13,7 +13,7 @@ import (
 func Do(ctx context.Context, action, service, uri string, data ...log.Data) {
 	d := buildLogData(action, uri, data...)
 
-	log.Event(ctx, fmt.Sprintf("Making request to service: %s", service), d)
+	log.Event(ctx, fmt.Sprintf("Making request to service: %s", service), log.INFO, d)
 }
 
 func buildLogData(action, uri string, data ...log.Data) (d log.Data) {

--- a/codelist/codelist.go
+++ b/codelist/codelist.go
@@ -309,6 +309,6 @@ func closeResponseBody(ctx context.Context, resp *http.Response) {
 	}
 
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.Error(err))
+		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
 	}
 }

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -54,7 +54,7 @@ type Client struct {
 // closeResponseBody closes the response body and logs an error containing the context if unsuccessful
 func closeResponseBody(ctx context.Context, resp *http.Response) {
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.Error(err))
+		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
 	}
 }
 

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -23,9 +23,9 @@ const service = "filter-api"
 // ErrInvalidFilterAPIResponse is returned when the filter api does not respond
 // with a valid status
 type ErrInvalidFilterAPIResponse struct {
-	expectedCode int
-	actualCode   int
-	uri          string
+	ExpectedCode int
+	ActualCode   int
+	URI          string
 }
 
 // Config contains any configuration required to send requests to the filter api
@@ -37,15 +37,15 @@ type Config struct {
 // Error should be called by the user to print out the stringified version of the error
 func (e ErrInvalidFilterAPIResponse) Error() string {
 	return fmt.Sprintf("invalid response from filter api - should be: %d, got: %d, path: %s",
-		e.expectedCode,
-		e.actualCode,
-		e.uri,
+		e.ExpectedCode,
+		e.ActualCode,
+		e.URI,
 	)
 }
 
 // Code returns the status code received from filter api if an error is returned
 func (e ErrInvalidFilterAPIResponse) Code() int {
-	return e.actualCode
+	return e.ActualCode
 }
 
 var _ error = ErrInvalidFilterAPIResponse{}

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -83,7 +83,7 @@ func CloseResponseBody(ctx context.Context, resp *http.Response) {
 		return
 	}
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.Error(err))
+		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
 	}
 }
 

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -87,43 +87,56 @@ func CloseResponseBody(ctx context.Context, resp *http.Response) {
 	}
 }
 
-// GetOutput returns a filter output job for a given filter output id
-func (c *Client) GetOutput(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID string) (Model, error) {
+// GetOutput returns a filter output job for a given filter output id, unmarshalled as a Model struct
+func (c *Client) GetOutput(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID string) (m Model, err error) {
+	b, err := c.GetOutputBytes(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID)
+	if err != nil {
+		return m, err
+	}
+	err = json.Unmarshal(b, &m)
+	return m, err
+}
+
+// GetOutputBytes returns a filter output job for a given filter output id as a byte array
+func (c *Client) GetOutputBytes(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID string) ([]byte, error) {
 	uri := fmt.Sprintf("%s/filter-outputs/%s", c.url, filterOutputID)
-	var m Model
 	clientlog.Do(ctx, "retrieving filter output", service, uri)
 
 	resp, err := c.doGetWithAuthHeadersAndWithDownloadToken(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, uri)
 	if err != nil {
-		return m, err
+		return nil, err
 	}
 
 	defer CloseResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		err = &ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
-		return m, err
+		return nil, err
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return m, err
-	}
-
-	err = json.Unmarshal(b, &m)
-	return m, err
+	return ioutil.ReadAll(resp.Body)
 }
 
-// GetDimension returns information on a requested dimension name for a given filterID
-func (c *Client) GetDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (Dimension, error) {
+// GetDimension returns information on a requested dimension name for a given filterID unmarshalled as a Dimension struct
+func (c *Client) GetDimension(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (dim Dimension, err error) {
+	b, err := c.GetDimensionBytes(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name)
+	if err != nil {
+		return dim, err
+	}
+
+	err = json.Unmarshal(b, &dim)
+	return dim, err
+}
+
+// GetDimensionBytes returns information on a requested dimension name for a given filterID as a byte array
+func (c *Client) GetDimensionBytes(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) ([]byte, error) {
 	uri := fmt.Sprintf("%s/filters/%s/dimensions/%s", c.url, filterID, name)
-	var dim Dimension
 	clientlog.Do(ctx, "retrieving dimension information", service, uri)
 
 	resp, err := c.doGetWithAuthHeaders(ctx, userAuthToken, serviceAuthToken, collectionID, uri)
 
 	if err != nil {
-		return dim, err
+		return nil, err
 	}
 
 	defer CloseResponseBody(ctx, resp)
@@ -132,41 +145,15 @@ func (c *Client) GetDimension(ctx context.Context, userAuthToken, serviceAuthTok
 		if resp.StatusCode != http.StatusNoContent {
 			err = &ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
 		}
-		return dim, err
+		return nil, err
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return dim, err
-	}
-
-	if err = json.Unmarshal(b, &dim); err != nil {
-		return dim, err
-	}
-
-	return dim, err
+	return ioutil.ReadAll(resp.Body)
 }
 
-// GetDimensions will return the dimensions associated with the provided filter id
-func (c *Client) GetDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID string) ([]Dimension, error) {
-	uri := fmt.Sprintf("%s/filters/%s/dimensions", c.url, filterID)
-	var dims []Dimension
-	clientlog.Do(ctx, "retrieving all dimensions for given filter job", service, uri)
-
-	resp, err := c.doGetWithAuthHeaders(ctx, userAuthToken, serviceAuthToken, collectionID, uri)
-
-	if err != nil {
-		return dims, err
-	}
-
-	defer CloseResponseBody(ctx, resp)
-
-	if resp.StatusCode != http.StatusOK {
-		err = &ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
-		return dims, err
-	}
-
-	b, err := ioutil.ReadAll(resp.Body)
+// GetDimensions will return the dimensions associated with the provided filter id as an array of Dimension structs
+func (c *Client) GetDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID string) (dims []Dimension, err error) {
+	b, err := c.GetDimensionsBytes(ctx, userAuthToken, serviceAuthToken, collectionID, filterID)
 	if err != nil {
 		return dims, err
 	}
@@ -175,16 +162,47 @@ func (c *Client) GetDimensions(ctx context.Context, userAuthToken, serviceAuthTo
 	return dims, err
 }
 
-// GetDimensionOptions retrieves a list of the dimension options
-func (c *Client) GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) ([]DimensionOption, error) {
+// GetDimensionsBytes will return the dimensions associated with the provided filter id as a byte array
+func (c *Client) GetDimensionsBytes(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID string) ([]byte, error) {
+	uri := fmt.Sprintf("%s/filters/%s/dimensions", c.url, filterID)
+	clientlog.Do(ctx, "retrieving all dimensions for given filter job", service, uri)
+
+	resp, err := c.doGetWithAuthHeaders(ctx, userAuthToken, serviceAuthToken, collectionID, uri)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer CloseResponseBody(ctx, resp)
+
+	if resp.StatusCode != http.StatusOK {
+		err = &ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
+		return nil, err
+	}
+
+	return ioutil.ReadAll(resp.Body)
+}
+
+// GetDimensionOptions retrieves a list of the dimension options unmarshalled as an array of DimensionOption structs
+func (c *Client) GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (opts []DimensionOption, err error) {
+	b, err := c.GetDimensionOptionsBytes(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name)
+	if err != nil {
+		return opts, err
+	}
+
+	err = json.Unmarshal(b, &opts)
+	return opts, err
+}
+
+// GetDimensionOptionsBytes retrieves a list of the dimension options as a byte array
+func (c *Client) GetDimensionOptionsBytes(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) ([]byte, error) {
 	uri := fmt.Sprintf("%s/filters/%s/dimensions/%s/options", c.url, filterID, name)
-	var opts []DimensionOption
 	clientlog.Do(ctx, "retrieving selected dimension options for filter job", service, uri)
 
 	resp, err := c.doGetWithAuthHeaders(ctx, userAuthToken, serviceAuthToken, collectionID, uri)
 
 	if err != nil {
-		return opts, err
+		return nil, err
 	}
 
 	defer CloseResponseBody(ctx, resp)
@@ -193,16 +211,10 @@ func (c *Client) GetDimensionOptions(ctx context.Context, userAuthToken, service
 		if resp.StatusCode != http.StatusNoContent {
 			err = &ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
 		}
-		return opts, err
+		return nil, err
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return opts, err
-	}
-
-	err = json.Unmarshal(b, &opts)
-	return opts, err
+	return ioutil.ReadAll(resp.Body)
 }
 
 // CreateBlueprint creates a filter blueprint and returns the associated filterID
@@ -442,31 +454,35 @@ func (c *Client) AddDimension(ctx context.Context, userAuthToken, serviceAuthTok
 	return nil
 }
 
-// GetJobState will return the current state of the filter job
-func (c *Client) GetJobState(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID string) (Model, error) {
-	uri := fmt.Sprintf("%s/filters/%s", c.url, filterID)
-	var m Model
-	clientlog.Do(ctx, "retrieving filter job state", service, uri)
-
-	resp, err := c.doGetWithAuthHeaders(ctx, userAuthToken, serviceAuthToken, collectionID, uri)
-	if err != nil {
-		return m, err
-	}
-
-	defer CloseResponseBody(ctx, resp)
-
-	if resp.StatusCode != http.StatusOK {
-		err = &ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
-		return m, err
-	}
-
-	b, err := ioutil.ReadAll(resp.Body)
+// GetJobState will return the current state of the filter job unmarshalled as a Model struct
+func (c *Client) GetJobState(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID string) (m Model, err error) {
+	b, err := c.GetJobStateBytes(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID)
 	if err != nil {
 		return m, err
 	}
 
 	err = json.Unmarshal(b, &m)
 	return m, err
+}
+
+// GetJobStateBytes will return the current state of the filter job as a byte array
+func (c *Client) GetJobStateBytes(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterID string) ([]byte, error) {
+	uri := fmt.Sprintf("%s/filters/%s", c.url, filterID)
+	clientlog.Do(ctx, "retrieving filter job state", service, uri)
+
+	resp, err := c.doGetWithAuthHeaders(ctx, userAuthToken, serviceAuthToken, collectionID, uri)
+	if err != nil {
+		return nil, err
+	}
+
+	defer CloseResponseBody(ctx, resp)
+
+	if resp.StatusCode != http.StatusOK {
+		err = &ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
+		return nil, err
+	}
+
+	return ioutil.ReadAll(resp.Body)
 }
 
 // AddDimensionValues adds many options to a filter job dimension
@@ -512,10 +528,20 @@ func (c *Client) AddDimensionValues(ctx context.Context, userAuthToken, serviceA
 	return nil
 }
 
-// GetPreview attempts to retrieve a preview for a given filterOutputID
-func (c *Client) GetPreview(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID string) (Preview, error) {
+// GetPreview attempts to retrieve a preview for a given filterOutputID unmarshalled as a Preview struct
+func (c *Client) GetPreview(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID string) (p Preview, err error) {
+	b, err := c.GetPreviewBytes(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID)
+	if err != nil {
+		return p, err
+	}
+
+	err = json.Unmarshal(b, &p)
+	return p, err
+}
+
+// GetPreviewBytes attempts to retrieve a preview for a given filterOutputID as a byte array
+func (c *Client) GetPreviewBytes(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID string) ([]byte, error) {
 	uri := fmt.Sprintf("%s/filter-outputs/%s/preview", c.url, filterOutputID)
-	var p Preview
 	clientlog.Do(ctx, "retrieving preview for filter output job", service, uri, log.Data{
 		"method":   "GET",
 		"filterID": filterOutputID,
@@ -523,22 +549,16 @@ func (c *Client) GetPreview(ctx context.Context, userAuthToken, serviceAuthToken
 
 	resp, err := c.doGetWithAuthHeadersAndWithDownloadToken(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, uri)
 	if err != nil {
-		return p, err
+		return nil, err
 	}
 
 	defer CloseResponseBody(ctx, resp)
 
 	if resp.StatusCode != http.StatusOK {
-		return p, &ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
+		return nil, &ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return p, err
-	}
-
-	err = json.Unmarshal(b, &p)
-	return p, err
+	return ioutil.ReadAll(resp.Body)
 }
 
 // doGetWithAuthHeaders executes clienter.Do setting the user and service authentication token as a request header. Returns the http.Response and any error.

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -274,8 +274,9 @@ func TestClient_GetOutput(t *testing.T) {
 
 	Convey("When a filter-instance is returned", t, func() {
 		mockedAPI := getMockfilterAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 200, Body: filterOutputBody})
-		_, err := mockedAPI.GetOutput(ctx, testUserAuthToken, testServiceToken, testDownloadServiceToken, testCollectionID, filterOutputID)
+		model, err := mockedAPI.GetOutput(ctx, testUserAuthToken, testServiceToken, testDownloadServiceToken, testCollectionID, filterOutputID)
 		So(err, ShouldBeNil)
+		So(model, ShouldResemble, Model{FilterID: filterOutputID})
 	})
 }
 
@@ -283,7 +284,7 @@ func TestClient_GetDimension(t *testing.T) {
 	filterOutputID := "foo"
 	name := "corge"
 	dimensionBody := `{
-		"url": "www.ons.gov.uk",
+		"dimension_url": "www.ons.gov.uk",
 		"name": "quuz",
 		"options": ["corge"]}`
 	Convey("When bad request is returned", t, func() {
@@ -301,15 +302,19 @@ func TestClient_GetDimension(t *testing.T) {
 
 	Convey("When a dimension-instance is returned", t, func() {
 		mockedAPI := getMockfilterAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 200, Body: dimensionBody})
-		_, err := mockedAPI.GetDimension(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name)
+		dim, err := mockedAPI.GetDimension(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name)
 		So(err, ShouldBeNil)
+		So(dim, ShouldResemble, Dimension{
+			Name: "quuz",
+			URI:  "www.ons.gov.uk",
+		})
 	})
 }
 
 func TestClient_GetDimensions(t *testing.T) {
 	filterOutputID := "foo"
 	dimensionBody := `[{
-		"url": "www.ons.gov.uk",
+		"dimension_url": "www.ons.gov.uk",
 		"name": "quuz",
 		"options": ["corge"]}]`
 
@@ -328,14 +333,20 @@ func TestClient_GetDimensions(t *testing.T) {
 
 	Convey("When a dimension-instance is returned", t, func() {
 		mockedAPI := getMockfilterAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 200, Body: dimensionBody})
-		_, err := mockedAPI.GetDimensions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID)
+		dims, err := mockedAPI.GetDimensions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID)
 		So(err, ShouldBeNil)
+		So(dims, ShouldResemble, []Dimension{
+			Dimension{
+				Name: "quuz",
+				URI:  "www.ons.gov.uk",
+			},
+		})
 	})
 }
 
 func TestClient_GetDimensionOptions(t *testing.T) {
 	filterOutputID := "foo"
-	dimensionBody := `[{"dimension_options_url":"quux","option": "quuz"}]`
+	dimensionBody := `[{"dimension_option_url":"quux","option": "quuz"}]`
 	name := "corge"
 	Convey("When bad request is returned", t, func() {
 		mockedAPI := getMockfilterAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 400, Body: ""})
@@ -352,8 +363,14 @@ func TestClient_GetDimensionOptions(t *testing.T) {
 
 	Convey("When a dimension option is returned", t, func() {
 		mockedAPI := getMockfilterAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 200, Body: dimensionBody})
-		_, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name)
+		opts, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name)
 		So(err, ShouldBeNil)
+		So(opts, ShouldResemble, []DimensionOption{
+			DimensionOption{
+				DimensionOptionsURL: "quux",
+				Option:              "quuz",
+			},
+		})
 	})
 }
 
@@ -796,8 +813,9 @@ func TestClient_GetJobState(t *testing.T) {
 	Convey("When server error is returned", t, func() {
 		mockedAPI := getMockfilterAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 500, Body: "qux"})
 		mockedAPI.cli.SetMaxRetries(2)
-		_, err := mockedAPI.GetJobState(ctx, testUserAuthToken, testServiceToken, testDownloadServiceToken, testCollectionID, filterID)
+		m, err := mockedAPI.GetJobState(ctx, testUserAuthToken, testServiceToken, testDownloadServiceToken, testCollectionID, filterID)
 		So(err, ShouldNotBeNil)
+		So(m, ShouldResemble, Model{})
 	})
 }
 
@@ -894,7 +912,8 @@ func TestClient_GetPreview(t *testing.T) {
 
 	Convey("When a preview is returned", t, func() {
 		mockedAPI := getMockfilterAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 200, Body: previewBody})
-		_, err := mockedAPI.GetPreview(ctx, testUserAuthToken, testServiceToken, testDownloadServiceToken, testCollectionID, filterOutputID)
+		p, err := mockedAPI.GetPreview(ctx, testUserAuthToken, testServiceToken, testDownloadServiceToken, testCollectionID, filterOutputID)
 		So(err, ShouldBeNil)
+		So(p, ShouldResemble, Preview{})
 	})
 }

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -280,6 +280,29 @@ func TestClient_GetOutput(t *testing.T) {
 	})
 }
 
+func TestClient_UpdateFilterOutput(t *testing.T) {
+	filterJobID := "filterID"
+	model := Model{FilterID: filterJobID, InstanceID: "someInstance"}
+	Convey("When bad request is returned", t, func() {
+		mockedAPI := getMockfilterAPI(http.Request{Method: "PUT"}, MockedHTTPResponse{StatusCode: 400, Body: ""})
+		err := mockedAPI.UpdateFilterOutput(ctx, testUserAuthToken, testServiceToken, testDownloadServiceToken, filterJobID, &model)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("When server error is returned", t, func() {
+		mockedAPI := getMockfilterAPI(http.Request{Method: "PUT"}, MockedHTTPResponse{StatusCode: 500, Body: ""})
+		mockedAPI.cli.SetMaxRetries(2)
+		err := mockedAPI.UpdateFilterOutput(ctx, testUserAuthToken, testServiceToken, testDownloadServiceToken, filterJobID, &model)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("When server returns 200 OK", t, func() {
+		mockedAPI := getMockfilterAPI(http.Request{Method: "PUT"}, MockedHTTPResponse{StatusCode: 200, Body: ""})
+		err := mockedAPI.UpdateFilterOutput(ctx, testUserAuthToken, testServiceToken, testDownloadServiceToken, filterJobID, &model)
+		So(err, ShouldBeNil)
+	})
+}
+
 func TestClient_GetDimension(t *testing.T) {
 	filterOutputID := "foo"
 	name := "corge"

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/ONSdigital/dp-api-clients-go
 go 1.12
 
 require (
-	github.com/ONSdigital/dp-healthcheck v0.0.0-20200219161048-205cb782aff1
+	github.com/ONSdigital/dp-healthcheck v1.0.0
 	github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9
 	github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8
 	github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58
-	github.com/ONSdigital/log.go v0.0.0-20191127134126-2a610b254f20
+	github.com/ONSdigital/log.go v1.0.0
 	github.com/golang/mock v1.3.1
 	github.com/gorilla/mux v1.7.3
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-api-clients-go
 go 1.12
 
 require (
-	github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e
+	github.com/ONSdigital/dp-healthcheck v0.0.0-20200219161048-205cb782aff1
 	github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9
 	github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8
 	github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ONSdigital/dp-healthcheck v0.0.0-20200219161048-205cb782aff1 h1:CqtCMHec03AfCsTLEkk34q7RQJFYRRMZHq6HVVM6ZOA=
-github.com/ONSdigital/dp-healthcheck v0.0.0-20200219161048-205cb782aff1/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
+github.com/ONSdigital/dp-healthcheck v1.0.0 h1:bySQU8kQRs4n3WbgH8QtVwCJLqG9ri722saATjvNNfc=
+github.com/ONSdigital/dp-healthcheck v1.0.0/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59/go.mod h1:KkW68U3FPuivW4ogi9L8CPKNj9ZxGko4qcUY7KoAAkQ=
@@ -7,10 +7,12 @@ github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8 h1:MWIHCr/ud5
 github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8/go.mod h1:821jZtK0oBsV8hjIkNr8vhAWuv0FxJBPJuAHa2B70Gk=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58 h1:XHnzoC7TxueLAfkBpblPiwaIxjngGv1VNVZhvE4jY6w=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
-github.com/ONSdigital/log.go v0.0.0-20191127134126-2a610b254f20 h1:1bNmts028atdwyylee7DnEyV5xsz7RVSyVCx7HcyIU4=
 github.com/ONSdigital/log.go v0.0.0-20191127134126-2a610b254f20/go.mod h1:BD7D8FWP1fzwUWsrCopEG72jl9cchCaVNIGSz6YvL+Y=
-github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
+github.com/ONSdigital/log.go v1.0.0 h1:hZQTuitFv4nSrpzMhpGvafUC5/8xMVnLI0CWe1rAJNc=
+github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
+github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -25,6 +27,7 @@ github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
+github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,5 @@
-github.com/ONSdigital/dp-healthcheck v0.0.0-20200108090555-e18ed65f5bdd h1:i2m46h3okQ4LgtVxAhiqs5s6H4Coa+VzOFWLswzrg/s=
-github.com/ONSdigital/dp-healthcheck v0.0.0-20200108090555-e18ed65f5bdd/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
-github.com/ONSdigital/dp-healthcheck v0.0.0-20200115183048-4eeccfeaf78a h1:8VMB6ABLt8dNSM6iFPy+QrJigirl9Dafv/CvyNbu9Ps=
-github.com/ONSdigital/dp-healthcheck v0.0.0-20200115183048-4eeccfeaf78a/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
-github.com/ONSdigital/dp-healthcheck v0.0.0-20200124150251-169c38bada89 h1:6hqRmzNC26sIimbQG1lGCug1CImTuz7QapolHoo5tbU=
-github.com/ONSdigital/dp-healthcheck v0.0.0-20200124150251-169c38bada89/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
-github.com/ONSdigital/dp-healthcheck v0.0.0-20200130191125-3c5ad16474bb h1:vB3sr8i+dVBEQ88gBShrdVjZz3NyJsDvwfEG9FUesXE=
-github.com/ONSdigital/dp-healthcheck v0.0.0-20200130191125-3c5ad16474bb/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
-github.com/ONSdigital/dp-healthcheck v0.0.0-20200131111544-791d276787f0 h1:rZqQE7TW50L+EfNhzat8092YnzYKsXbC7yvEDeEiA9c=
-github.com/ONSdigital/dp-healthcheck v0.0.0-20200131111544-791d276787f0/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
-github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e h1:H2KVzsFp5oTbqjPXDlTHOB/LvYy2I6Mc8eSTLrmZkXs=
-github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
+github.com/ONSdigital/dp-healthcheck v0.0.0-20200219161048-205cb782aff1 h1:CqtCMHec03AfCsTLEkk34q7RQJFYRRMZHq6HVVM6ZOA=
+github.com/ONSdigital/dp-healthcheck v0.0.0-20200219161048-205cb782aff1/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59/go.mod h1:KkW68U3FPuivW4ogi9L8CPKNj9ZxGko4qcUY7KoAAkQ=

--- a/health/health.go
+++ b/health/health.go
@@ -82,7 +82,7 @@ func (c *Client) Checker(ctx context.Context, state *health.CheckState) error {
 		code, err = c.get(ctx, "/healthcheck")
 	}
 	if err != nil {
-		log.Event(ctx, "failed to request service health", log.Error(err), logData)
+		log.Event(ctx, "failed to request service health", log.ERROR, log.Error(err), logData)
 	}
 
 	switch code {
@@ -129,7 +129,7 @@ func closeResponseBody(ctx context.Context, resp *http.Response) {
 	}
 
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.Error(err))
+		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
 	}
 }
 

--- a/hierarchy/hierarchy.go
+++ b/hierarchy/hierarchy.go
@@ -49,7 +49,7 @@ type Client struct {
 // CloseResponseBody closes the response body and logs an error if unsuccessful
 func closeResponseBody(ctx context.Context, resp *http.Response) {
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.Error(err))
+		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
 	}
 }
 

--- a/identity/authentication.go
+++ b/identity/authentication.go
@@ -65,7 +65,7 @@ func (api Client) CheckRequest(req *http.Request, florenceToken, serviceAuthToke
 	}
 	splitTokens(florenceToken, serviceAuthToken, logData)
 
-	log.Event(ctx, "calling AuthAPI to authenticate caller identity", logData)
+	log.Event(ctx, "calling AuthAPI to authenticate caller identity", log.INFO, logData)
 
 	var outboundAuthReq *http.Request
 	var errCreatingReq error
@@ -77,7 +77,7 @@ func (api Client) CheckRequest(req *http.Request, florenceToken, serviceAuthToke
 	}
 
 	if errCreatingReq != nil {
-		log.Event(ctx, "error creating AuthAPI identity http request", logData, log.Error(errCreatingReq))
+		log.Event(ctx, "error creating AuthAPI identity http request", log.ERROR, logData, log.Error(errCreatingReq))
 		return ctx, http.StatusInternalServerError, nil, errCreatingReq
 	}
 
@@ -89,7 +89,7 @@ func (api Client) CheckRequest(req *http.Request, florenceToken, serviceAuthToke
 
 	resp, err := api.HTTPClient.Do(ctx, outboundAuthReq)
 	if err != nil {
-		log.Event(ctx, "HTTPClient.Do returned error making AuthAPI identity request", logData, log.Error(err))
+		log.Event(ctx, "HTTPClient.Do returned error making AuthAPI identity request", log.ERROR, logData, log.Error(err))
 		return ctx, http.StatusInternalServerError, nil, err
 	}
 
@@ -112,7 +112,7 @@ func (api Client) CheckRequest(req *http.Request, florenceToken, serviceAuthToke
 
 	logData["user_identity"] = userIdentity
 	logData["caller_identity"] = userIdentity
-	log.Event(ctx, "caller identity retrieved setting context values", logData)
+	log.Event(ctx, "caller identity retrieved setting context values", log.INFO, logData)
 
 	ctx = context.WithValue(ctx, common.UserIdentityKey, userIdentity)
 	ctx = context.WithValue(ctx, common.CallerIdentityKey, identityResponse.Identifier)
@@ -188,7 +188,7 @@ func closeResponse(ctx context.Context, resp *http.Response, data log.Data) {
 	}
 
 	if errClose := resp.Body.Close(); errClose != nil {
-		log.Event(ctx, "error closing response body", log.Error(errClose), data)
+		log.Event(ctx, "error closing response body", log.ERROR, log.Error(errClose), data)
 	}
 }
 

--- a/importapi/importapi.go
+++ b/importapi/importapi.go
@@ -114,12 +114,12 @@ func (c *Client) GetImportJob(ctx context.Context, importJobID, serviceToken str
 		isFatal = true
 	}
 	if err != nil {
-		log.Event(ctx, "GetImportJob", logData, log.Error(err))
+		log.Event(ctx, "GetImportJob", log.ERROR, logData, log.Error(err))
 		return importJob, isFatal, err
 	}
 
 	if err := json.Unmarshal(jsonBody, &importJob); err != nil {
-		log.Event(ctx, "GetImportJob unmarshal", logData, log.Error(err))
+		log.Event(ctx, "GetImportJob unmarshal", log.ERROR, logData, log.Error(err))
 		return ImportJob{}, true, err
 	}
 
@@ -143,7 +143,7 @@ func (c *Client) UpdateImportJobState(ctx context.Context, jobID, serviceToken s
 		err = errors.New("Bad HTTP response")
 	}
 	if err != nil {
-		log.Event(ctx, "UpdateImportJobState", logData, log.Error(err))
+		log.Event(ctx, "UpdateImportJobState", log.ERROR, logData, log.Error(err))
 		return err
 	}
 	return nil
@@ -163,7 +163,7 @@ func callJSONAPI(ctx context.Context, client rchttp.Clienter, method, path, serv
 
 	URL, err := url.Parse(path)
 	if err != nil {
-		log.Event(ctx, "Failed to create url for API call", logData, log.Error(err))
+		log.Event(ctx, "Failed to create url for API call", log.ERROR, logData, log.Error(err))
 		return nil, 0, err
 	}
 	path = URL.String()
@@ -185,7 +185,7 @@ func callJSONAPI(ctx context.Context, client rchttp.Clienter, method, path, serv
 	}
 	// check above req had no errors
 	if err != nil {
-		log.Event(ctx, "Failed to create request for API", logData, log.Error(err))
+		log.Event(ctx, "Failed to create request for API", log.ERROR, logData, log.Error(err))
 		return nil, 0, err
 	}
 
@@ -194,19 +194,19 @@ func callJSONAPI(ctx context.Context, client rchttp.Clienter, method, path, serv
 
 	resp, err := client.Do(ctx, req)
 	if err != nil {
-		log.Event(ctx, "Failed to action API", logData, log.Error(err))
+		log.Event(ctx, "Failed to action API", log.ERROR, logData, log.Error(err))
 		return nil, 0, err
 	}
 	defer closeResponseBody(ctx, resp)
 
 	logData["httpCode"] = resp.StatusCode
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= 300 {
-		log.Event(ctx, "unexpected status code from API", logData)
+		log.Event(ctx, "unexpected status code from API", log.ERROR, logData)
 	}
 
 	jsonBody, err := getBody(resp)
 	if err != nil {
-		log.Event(ctx, "Failed to read body from API", logData, log.Error(err))
+		log.Event(ctx, "Failed to read body from API", log.ERROR, log.Error(err))
 		return nil, resp.StatusCode, err
 	}
 
@@ -245,6 +245,6 @@ func closeResponseBody(ctx context.Context, resp *http.Response) {
 		return
 	}
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.Error(err))
+		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
 	}
 }

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -50,7 +50,7 @@ func New(url string) *Renderer {
 
 func closeResponseBody(ctx context.Context, resp *http.Response) {
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.Error(err))
+		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
 	}
 }
 

--- a/zebedee/client.go
+++ b/zebedee/client.go
@@ -259,7 +259,7 @@ func (c *Client) createRequestURL(ctx context.Context, path, query string) strin
 	if ctx.Value(common.CollectionIDHeaderKey) != nil {
 		collectionID, ok := ctx.Value(common.CollectionIDHeaderKey).(string)
 		if !ok {
-			log.Event(ctx, "unable to find collection ID header key", log.Error(errCastingCollectionID))
+			log.Event(ctx, "unable to find collection ID header key", log.ERROR, log.Error(errCastingCollectionID))
 		}
 		path += "/" + collectionID
 	}
@@ -270,7 +270,7 @@ func (c *Client) createRequestURL(ctx context.Context, path, query string) strin
 	if ctx.Value(common.LocaleHeaderKey) != nil {
 		localeCode, ok := ctx.Value(common.LocaleHeaderKey).(string)
 		if !ok {
-			log.Event(ctx, "unable to find local header key", log.Error(errCastingLocalCode))
+			log.Event(ctx, "unable to find local header key", log.ERROR, log.Error(errCastingLocalCode))
 		}
 		path += "&lang=" + localeCode
 	}

--- a/zebedee/client_test.go
+++ b/zebedee/client_test.go
@@ -118,7 +118,7 @@ func mockZebedeeServer(port chan int) {
 
 	l, err := net.Listen("tcp", ":0")
 	if err != nil {
-		log.Event(context.Background(), "error listening on local network address", log.Error(err))
+		log.Event(context.Background(), "error listening on local network address", log.FATAL, log.Error(err))
 		os.Exit(2)
 	}
 
@@ -126,7 +126,7 @@ func mockZebedeeServer(port chan int) {
 	close(port)
 
 	if err := http.Serve(l, r); err != nil {
-		log.Event(context.Background(), "error serving http connections", log.Error(err))
+		log.Event(context.Background(), "error serving http connections", log.FATAL, log.Error(err))
 		os.Exit(2)
 	}
 }


### PR DESCRIPTION
### What

- Filter API: allow GET operations with byte arrays, so we can unmarshal to different models
- Filter API: add UpdateFilterOutput (needed by dp-dataset-exporter)
- Filter API: exported ErrInvalidFilterAPIResponse fields

### How to review

- Unit tests should pass
- Make sure code changes make sense.

### Who can review

anyone.