### PR TITLE
Feature/check token identity

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -179,6 +179,7 @@ func (d Items) Less(i, j int) bool {
 
 // Dimension represents a response model for a dimension endpoint
 type Dimension struct {
+	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Links       Links  `json:"links"`
 	Description string `json:"description"`

--- a/dataset/data.go
+++ b/dataset/data.go
@@ -200,6 +200,15 @@ type Option struct {
 	Option      string `json:"option"`
 }
 
+// OptionPost represents an option model to store in the dataset api
+type OptionPost struct {
+	Code     string `json:"code"`
+	CodeList string `json:"code_list,omitempty"`
+	Label    string `json:"label"`
+	Name     string `json:"dimension"`
+	Option   string `json:"option"`
+}
+
 // Methodology represents a methodology document returned by the dataset api
 type Methodology struct {
 	Description string `json:"description"`

--- a/dataset/data.go
+++ b/dataset/data.go
@@ -209,6 +209,12 @@ type OptionPost struct {
 	Option   string `json:"option"`
 }
 
+// JobInstance represents the details necessary to update (PUT) a job instance
+type JobInstance struct {
+	HeaderNames          []string `json:"headers"`
+	NumberOfObservations int      `json:"total_observations"`
+}
+
 // Methodology represents a methodology document returned by the dataset api
 type Methodology struct {
 	Description string `json:"description"`

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -72,7 +72,9 @@ func NewAPIClient(datasetAPIURL string) *Client {
 // setting a number of max retires for the HTTP client
 func NewAPIClientWithMaxRetries(datasetAPIURL string, maxRetries int) *Client {
 	hcClient := healthcheck.NewClient(service, datasetAPIURL)
-	hcClient.Client.SetMaxRetries(maxRetries)
+	if maxRetries > 0 {
+		hcClient.Client.SetMaxRetries(maxRetries)
+	}
 
 	return &Client{
 		cli: hcClient.Client,

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -30,8 +30,9 @@ var (
 	initialState = health.CreateCheckState(service)
 )
 
-var checkResponseBase = func(mockRCHTTPCli *rchttp.ClienterMock) {
+var checkResponseBase = func(mockRCHTTPCli *rchttp.ClienterMock, expectedUri string) {
 	So(len(mockRCHTTPCli.DoCalls()), ShouldEqual, 1)
+	So(mockRCHTTPCli.DoCalls()[0].Req.URL.RequestURI(), ShouldEqual, expectedUri)
 	So(mockRCHTTPCli.DoCalls()[0].Req.Header.Get(common.AuthHeaderKey), ShouldEqual, "Bearer "+serviceAuthToken)
 }
 
@@ -241,7 +242,7 @@ func TestClient_PutVersion(t *testing.T) {
 
 	checkResponse := func(mockRCHTTPCli *rchttp.ClienterMock, expectedVersion Version) {
 
-		checkResponseBase(mockRCHTTPCli)
+		checkResponseBase(mockRCHTTPCli, "/datasets/123/editions/2017/versions/1")
 
 		actualBody, _ := ioutil.ReadAll(mockRCHTTPCli.DoCalls()[0].Req.Body)
 
@@ -439,7 +440,7 @@ func TestClient_GetInstance(t *testing.T) {
 			})
 
 			Convey("and rchttpclient.Do is called 1 time", func() {
-				checkResponseBase(mockRCHTTPCli)
+				checkResponseBase(mockRCHTTPCli, "/instances/123")
 			})
 		})
 	})
@@ -464,7 +465,78 @@ func TestClient_GetInstance(t *testing.T) {
 			})
 
 			Convey("and rchttpclient.Do is called 1 time", func() {
-				checkResponseBase(mockRCHTTPCli)
+				checkResponseBase(mockRCHTTPCli, "/instances/123")
+			})
+		})
+	})
+}
+
+func TestClient_PostInstanceDimensions(t *testing.T) {
+
+	optionsToPost := OptionPost{
+		Name:     "testName",
+		Option:   "testOption",
+		Label:    "testLabel",
+		CodeList: "testCodeList",
+		Code:     "testCode",
+	}
+
+	Convey("given a 200 status is returned", t, func() {
+		mockRCHTTPCli := &rchttp.ClienterMock{
+			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+				}, nil
+			},
+		}
+
+		cli := Client{cli: mockRCHTTPCli, url: "http://localhost:8080"}
+		expectedPayload, err := json.Marshal(optionsToPost)
+		So(err, ShouldBeNil)
+
+		Convey("when PostInstanceDimensions is called", func() {
+			err := cli.PostInstanceDimensions(ctx, serviceAuthToken, "123", optionsToPost)
+
+			Convey("a positive response is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("and rchttpclient.Do is called 1 time", func() {
+				checkResponseBase(mockRCHTTPCli, "/instances/123/dimensions")
+				payload, err := ioutil.ReadAll(mockRCHTTPCli.DoCalls()[0].Req.Body)
+				So(err, ShouldBeNil)
+				So(payload, ShouldResemble, expectedPayload)
+			})
+		})
+	})
+
+	Convey("given a 404 status is returned", t, func() {
+		mockRCHTTPCli := &rchttp.ClienterMock{
+			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte("wrong!"))),
+				}, nil
+			},
+		}
+
+		cli := Client{cli: mockRCHTTPCli, url: "http://localhost:8080"}
+		expectedPayload, err := json.Marshal(optionsToPost)
+		So(err, ShouldBeNil)
+
+		Convey("when PostInstanceDimensions is called", func() {
+			err := cli.PostInstanceDimensions(ctx, serviceAuthToken, "123", optionsToPost)
+
+			Convey("then the expected error is returned", func() {
+				So(err.Error(), ShouldResemble, errors.Errorf("invalid response: 404 from dataset api: http://localhost:8080/instances/123/dimensions, body: wrong!").Error())
+			})
+
+			Convey("and rchttpclient.Do is called 1 time", func() {
+				checkResponseBase(mockRCHTTPCli, "/instances/123/dimensions")
+				payload, err := ioutil.ReadAll(mockRCHTTPCli.DoCalls()[0].Req.Body)
+				So(err, ShouldBeNil)
+				So(payload, ShouldResemble, expectedPayload)
 			})
 		})
 	})


### PR DESCRIPTION
### What

- identity package:
  - Created `CheckTokenIdentity` in identity package. This method validates a token (service and user tokens supported) against `<zebedeeURL>/identity`.
  - Refactor existing method `CheckRequest` to use `CheckTokenIdentity`, which does the same plus some extra functionality after validating the token.

- dataset package:
  -  Constructor with max retries `NewAPIClientWithMaxRetries `, so callers can define max retries for the HTTP Client.
  - Added ID to Dimension model, as expected by dp-dimension-extractor to be returned in the array of Dimensions returned by `GetInstance`
  - Implemented `PostInstanceDimensions` to perform `POST /instances/<id>/dimensions`
  - Implemented `PutInstanceData` to perform `PUT /instances/<id>`

### How to review

- Unit tests should pass and cover enough cases of the new code
- Make sure the code changes make sense (keeping in mind that they are migrated from dp-dimension-extractor, but might be useful for other services)

### Who can review

Anyone.