### PR TITLE
GetInstanceDimensions, PutInstanceDimensionOptionNodeID

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -50,7 +50,7 @@ type Version struct {
 	CollectionID         string               `json:"collection_id"`
 	Downloads            map[string]Download  `json:"downloads"`
 	Edition              string               `json:"edition"`
-	Dimensions           []Dimension          `json:"dimensions"`
+	Dimensions           []VersionDimension   `json:"dimensions"`
 	ID                   string               `json:"id"`
 	InstanceID           string               `json:"instance_id"`
 	LatestChanges        []Change             `json:"latest_changes"`
@@ -61,6 +61,16 @@ type Version struct {
 	Version              int                  `json:"version"`
 	NumberOfObservations int64                `json:"total_observations,omitempty"`
 	ImportTasks          *InstanceImportTasks `json:"import_tasks,omitempty"`
+}
+
+// VersionDimension represents a dimension model nested in the Version model
+type VersionDimension struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Links       Links  `json:"links"`
+	Description string `json:"description"`
+	Label       string `json:"label"`
+	URL         string `json:"href,omitempty"`
 }
 
 // InstanceImportTasks represents all of the tasks required to complete an import job.
@@ -177,17 +187,17 @@ type Contact struct {
 	Email     string `json:"email"`
 }
 
-// Dimensions represent a list of dimensions from the dataset api
-type Dimensions struct {
-	Items Items `json:"items"`
+// VersionDimensions represent a list of versionDimension
+type VersionDimensions struct {
+	Items VersionDimensionItems `json:"items"`
 }
 
-// Items represents a list of dimensions
-type Items []Dimension
+// VersionDimensionItems represents a list of Version Dimensions
+type VersionDimensionItems []VersionDimension
 
-func (d Items) Len() int      { return len(d) }
-func (d Items) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
-func (d Items) Less(i, j int) bool {
+func (d VersionDimensionItems) Len() int      { return len(d) }
+func (d VersionDimensionItems) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
+func (d VersionDimensionItems) Less(i, j int) bool {
 	iRunes := []rune(d[i].Name)
 	jRunes := []rune(d[j].Name)
 
@@ -218,12 +228,17 @@ func (d Items) Less(i, j int) bool {
 
 // Dimension represents a response model for a dimension endpoint
 type Dimension struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Links       Links  `json:"links"`
-	Description string `json:"description"`
+	DimensionID string `json:"dimension"`
+	InstanceID  string `json:"instance_id"`
+	NodeID      string `json:"node_id,omitempty"`
 	Label       string `json:"label"`
-	URL         string `json:"href,omitempty"`
+	Option      string `json:"option"`
+	Links       Links  `json:"links"`
+}
+
+// Dimensions represents a list of dimensions
+type Dimensions struct {
+	Items []Dimension `json:"items"`
 }
 
 // Options represents a list of options from the dataset api

--- a/dataset/data.go
+++ b/dataset/data.go
@@ -61,6 +61,7 @@ type Version struct {
 	Version              int                  `json:"version"`
 	NumberOfObservations int64                `json:"total_observations,omitempty"`
 	ImportTasks          *InstanceImportTasks `json:"import_tasks,omitempty"`
+	CSVHeader            []string             `json:"headers,omitempty"`
 }
 
 // VersionDimension represents a dimension model nested in the Version model

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -654,7 +654,7 @@ func (c *Client) GetVersionMetadata(ctx context.Context, userAuthToken, serviceA
 	return
 }
 
-// GetVersionDimensions will return a list of dimension representations for a version
+// GetVersionDimensions will return a list of dimensions for a given version of a dataset
 func (c *Client) GetVersionDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version string) (m VersionDimensions, err error) {
 	uri := fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s/dimensions", c.url, id, edition, version)
 

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -550,18 +550,7 @@ func (c *Client) GetInstanceDimensions(ctx context.Context, serviceAuthToken, in
 
 	clientlog.Do(ctx, "retrieving instance dimensions", service, uri)
 
-	resp, err := c.doGetWithAuthHeaders(ctx, "", serviceAuthToken, "", uri, nil)
-	if err != nil {
-		return
-	}
-	defer closeResponseBody(ctx, resp)
-
-	if resp.StatusCode != http.StatusOK {
-		err = NewDatasetAPIResponse(resp, uri)
-		return
-	}
-
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := c.GetInstanceDimensionsBytes(ctx, "", serviceAuthToken, instanceID)
 	if err != nil {
 		return
 	}

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -25,14 +25,19 @@ const service = "dataset-api"
 // State - iota enum of possible states
 type State int
 
-// Possible values for a State
+// Possible values for a State of the resource. It can only be one of the following:
+// TODO these states should be enforced in all the 'POST' and 'PUT' operations that can modify states of resources
 const (
 	StateCreated State = iota
 	StateSubmitted
-	StateCompleted
+	StateCompleted        // Instances only
+	StateFailed           // Instances only
+	StateEditionConfirmed // instances and versions only
+	StateAssociated       // not editions
+	StatePublished
 )
 
-var stateValues = []string{"created", "submitted", "completed"}
+var stateValues = []string{"created", "submitted", "completed", "failed", "edition-confirmed", "associated", "published"}
 
 // String returns the string representation of a state
 func (s State) String() string {

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -451,7 +451,7 @@ func TestClient_GetInstance(t *testing.T) {
 	})
 }
 
-func TestClient_GetInstanceDimensions(t *testing.T) {
+func TestClient_GetInstanceDimensionsBytes(t *testing.T) {
 
 	Convey("given a 200 status is returned", t, func() {
 		mockRCHTTPCli := &rchttp.ClienterMock{
@@ -490,7 +490,7 @@ func TestClient_GetInstanceDimensions(t *testing.T) {
 
 		cli := Client{cli: mockRCHTTPCli, url: "http://localhost:8080"}
 
-		Convey("when GetInstanceDimensionsByBytes is called", func() {
+		Convey("when GetInstanceDimensionsBytes is called", func() {
 			_, err := cli.GetInstanceDimensionsBytes(ctx, userAuthToken, serviceAuthToken, "123")
 
 			Convey("then the expected error is returned", func() {


### PR DESCRIPTION
### What

- Implemented methods (migrated from dp-dimension-importer):
  - GetInstanceDimensions
  - PutInstanceDimensionOptionNodeID
- Unit tested, andadded mock constructor
- Modified models. There was a name clash for `Dimensions`. Renamed the existing to `VersionDimension`

### How to review

- Make sure code changes make sense
- Unit tests pass

### Who can review

Anyone