### PR TITLE
Add getHomepageContent method to Zebedee Client

### DIFF
--- a/zebedee/client.go
+++ b/zebedee/client.go
@@ -221,6 +221,21 @@ func (c *Client) GetDataset(ctx context.Context, userAccessToken, uri string) (D
 	return d, nil
 }
 
+func (c *Client) GetHomepageContent(ctx context.Context, userAccessToken, path string) (HomepageContent, error) {
+	reqURL := c.createRequestURL(ctx, "/data", "uri="+path)
+	b, _, err := c.get(ctx, userAccessToken, reqURL)
+	if err != nil {
+		return HomepageContent{}, err
+	}
+
+	var homepageContent HomepageContent
+	if err = json.Unmarshal(b, &homepageContent); err != nil {
+		return homepageContent, err
+	}
+
+	return homepageContent, nil
+}
+
 // GetFileSize retrieves a given filesize from zebedee
 func (c *Client) GetFileSize(ctx context.Context, userAccessToken, uri string) (FileSize, error) {
 	reqURL := c.createRequestURL(ctx, "/filesize", "uri="+uri)

--- a/zebedee/client_test.go
+++ b/zebedee/client_test.go
@@ -65,6 +65,17 @@ func TestUnitClient(t *testing.T) {
 		So(m.Type, ShouldEqual, "dataset_landing_page")
 	})
 
+	Convey("GetHomepageContent() returns a homepage model", t, func() {
+		m, err := cli.GetHomepageContent(ctx, testAccessToken, "/")
+		So(err, ShouldBeNil)
+		So(m, ShouldNotBeEmpty)
+		So(m.Intro.Title, ShouldEqual, "Welcome to the Office for National Statistics")
+		So(len(m.FeaturedContent), ShouldBeGreaterThan, 0)
+		So(m.FeaturedContent[0].Title, ShouldEqual, "Featured Content One")
+		So(m.Description.Keywords[0], ShouldEqual, "keywordOne")
+		So(m.ServiceMessage, ShouldEqual, "")
+	})
+
 	Convey("test get dataset details", t, func() {
 		d, err := cli.GetDataset(ctx, testAccessToken, "12345")
 		So(err, ShouldBeNil)
@@ -149,6 +160,8 @@ func d(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte(`{"type":"dataset","uri":"www.google.com","downloads":[{"file":"test.txt"}],"supplementaryFiles":[{"title":"helloworld","file":"helloworld.txt"}],"versions":[{"uri":"www.google.com"}]}`))
 	case "pageTitle":
 		w.Write([]byte(`{"title":"baby-names","edition":"2017"}`))
+	case "/":
+		w.Write([]byte(`{"intro":{"title":"Welcome to the Office for National Statistics","markdown":"Test markdown"},"featuredContent":[{"title":"Featured Content One","description":"Featured Content One Description","uri":"/one","imageURL":"/one_image"}],"serviceMessage":"","description":{"keywords":[ "keywordOne", "keywordTwo" ],"metaDescription":"","unit":"","preUnit":"","source":""}}`))
 	}
 
 }

--- a/zebedee/client_test.go
+++ b/zebedee/client_test.go
@@ -70,7 +70,7 @@ func TestUnitClient(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(m, ShouldNotBeEmpty)
 		So(m.Intro.Title, ShouldEqual, "Welcome to the Office for National Statistics")
-		So(len(m.FeaturedContent), ShouldBeGreaterThan, 0)
+		So(len(m.FeaturedContent), ShouldEqual, 1)
 		So(m.FeaturedContent[0].Title, ShouldEqual, "Featured Content One")
 		So(m.Description.Keywords[0], ShouldEqual, "keywordOne")
 		So(m.ServiceMessage, ShouldEqual, "")

--- a/zebedee/data.go
+++ b/zebedee/data.go
@@ -133,3 +133,35 @@ type TimeseriesDescription struct {
 	CDID string `json:"cdid"`
 	Unit string `json:"unit"`
 }
+
+// HomepageContent represents the page model of the Zebedee response for the ONS homepage
+type HomepageContent struct {
+	Intro           Intro               `json:"intro"`
+	FeaturedContent []Featured          `json:"featuredContent"`
+	ServiceMessage  string              `json:"serviceMessage"`
+	URI             string              `json:"uri"`
+	Type            string              `json:"type"`
+	Description     HomepageDescription `json:"description"`
+}
+
+type Intro struct {
+	Title    string `json:"title"`
+	Markdown string `json:"markdown"`
+}
+
+type Featured struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	URI         string `json:"uri"`
+	ImageURL    string `json:"imageURL"`
+}
+
+type HomepageDescription struct {
+	Title           string   `json:"title"`
+	Summary         string   `json:"summary"`
+	Keywords        []string `json:"keywords"`
+	MetaDescription string   `json:"metaDescription"`
+	Unit            string   `json:"unit"`
+	PreUnit         string   `json:"preUnit"`
+	Source          string   `json:"source"`
+}


### PR DESCRIPTION
### What

This PR adds a new method, `GetHomepageContent`, and new models (`HomepageContent`) to the Zebedee client. This is so that homepage content, in particular the new `featuredContent` section can be loaded in via the homepage controller and into the renderer.

### How to review

- Check that the code implemented in the method make sense, is idiomatic, and aligns with how other methods are written in the client
- Check that the test case makes sense and passes
- Check that the URI for the homepage content is correct
- Check the models and whether anything may be excluded or ought to be included that is currently missing from them; the structure is largely aligning with what is in the homepage's `data.json`, although with no `sections` array as this is now handled by the `GetTimeseriesMainFigure` method

### Who can review

Anyone but me
