### PR TITLE
Fix/imageurl mapping

### DIFF
--- a/zebedee/client_test.go
+++ b/zebedee/client_test.go
@@ -72,6 +72,7 @@ func TestUnitClient(t *testing.T) {
 		So(m.Intro.Title, ShouldEqual, "Welcome to the Office for National Statistics")
 		So(len(m.FeaturedContent), ShouldEqual, 1)
 		So(m.FeaturedContent[0].Title, ShouldEqual, "Featured Content One")
+		So(m.FeaturedContent[0].ImageID, ShouldEqual, "testImage")
 		So(m.Description.Keywords[0], ShouldEqual, "keywordOne")
 		So(m.ServiceMessage, ShouldEqual, "")
 	})
@@ -161,7 +162,7 @@ func d(w http.ResponseWriter, req *http.Request) {
 	case "pageTitle":
 		w.Write([]byte(`{"title":"baby-names","edition":"2017"}`))
 	case "/":
-		w.Write([]byte(`{"intro":{"title":"Welcome to the Office for National Statistics","markdown":"Test markdown"},"featuredContent":[{"title":"Featured Content One","description":"Featured Content One Description","uri":"/one","imageURL":"/one_image"}],"serviceMessage":"","description":{"keywords":[ "keywordOne", "keywordTwo" ],"metaDescription":"","unit":"","preUnit":"","source":""}}`))
+		w.Write([]byte(`{"intro":{"title":"Welcome to the Office for National Statistics","markdown":"Test markdown"},"featuredContent":[{"title":"Featured Content One","description":"Featured Content One Description","uri":"/one","image":"testImage"}],"serviceMessage":"","description":{"keywords":[ "keywordOne", "keywordTwo" ],"metaDescription":"","unit":"","preUnit":"","source":""}}`))
 	}
 
 }

--- a/zebedee/data.go
+++ b/zebedee/data.go
@@ -153,7 +153,7 @@ type Featured struct {
 	Title       string `json:"title"`
 	Description string `json:"description"`
 	URI         string `json:"uri"`
-	ImageURL    string `json:"imageURL"`
+	ImageID     string `json:"image"`
 }
 
 type HomepageDescription struct {


### PR DESCRIPTION
### What

Small fix to rename `ImageURL` to `ImageID` in the Zebedee `Featured` struct to better convey meaning. This is because Zebedee will only store a reference to the image rather than the image URL itself. The image reference is then used to fetch the image from the image API service.

### How to review

Check that the change makes sense and tests pass

### Who can review

Anyone but me
