### PR TITLE
Implement ImportDownloadVariant

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -219,6 +219,26 @@ func (c *Client) PutImage(ctx context.Context, userAuthToken, serviceAuthToken, 
 	return
 }
 
+//ImportDownloadVariant triggers a download variant import
+func (c *Client) ImportDownloadVariant(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, imageID, variant string) (err error) {
+
+	uri := fmt.Sprintf("%s/images/%s/downloads/%s/import", c.url, imageID, variant)
+
+	clientlog.Do(ctx, "importing image download variant", service, uri)
+
+	resp, err := c.doPostWithAuthHeaders(ctx, userAuthToken, serviceAuthToken, collectionID, uri, []byte{})
+	if err != nil {
+		return
+	}
+	defer closeResponseBody(ctx, resp)
+
+	if resp.StatusCode != http.StatusOK {
+		err = NewImageAPIResponse(resp, uri)
+		return
+	}
+	return
+}
+
 // PublishImage triggers an image publishing
 func (c *Client) PublishImage(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, imageID string) (err error) {
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -522,3 +522,42 @@ func TestClient_PublishImage(t *testing.T) {
 		})
 	})
 }
+
+func TestClient_ImportDownloadVariant(t *testing.T) {
+
+	Convey("given a 200 status is returned", t, func() {
+
+		mockdphttpCli := createHTTPClientMock(http.StatusOK, []byte{})
+		cli := Client{cli: mockdphttpCli, url: "http://localhost:8080"}
+
+		Convey("when ImportDownloadVariant is called", func() {
+			err := cli.ImportDownloadVariant(ctx, userAuthToken, serviceAuthToken, collectionID, "123", "original")
+
+			Convey("a positive response is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("and dphttpclient.Do is called 1 time", func() {
+				checkResponseBase(mockdphttpCli, http.MethodPost, "/images/123/downloads/original/import")
+				So(err, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("given a 404 status is returned", t, func() {
+		mockdphttpCli := createHTTPClientMock(http.StatusNotFound, []byte("wrong!"))
+		cli := Client{cli: mockdphttpCli, url: "http://localhost:8080"}
+
+		Convey("when ImportDownloadVariant is called", func() {
+			err := cli.ImportDownloadVariant(ctx, userAuthToken, serviceAuthToken, collectionID, "123", "original")
+
+			Convey("then the expected error is returned", func() {
+				So(err.Error(), ShouldResemble, errors.Errorf("invalid response: 404 from image api: http://localhost:8080/images/123/downloads/original/import, body: wrong!").Error())
+			})
+
+			Convey("and dphttpclient.Do is called 1 time with expected parameters", func() {
+				checkResponseBase(mockdphttpCli, http.MethodPost, "/images/123/downloads/original/import")
+			})
+		})
+	})
+}


### PR DESCRIPTION
### What

Implemented ImportDownloadVariant in image client, to call endpoint `POST /images/{id}/downloads/{variant}/import`

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

Anyone