### PR TITLE
Add POST images/…/upload to image-api client

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -219,6 +219,30 @@ func (c *Client) PutImage(ctx context.Context, userAuthToken, serviceAuthToken, 
 	return
 }
 
+// PostImageUpload specifies download variants and triggers image import
+func (c *Client) PostImageUpload(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, imageID string, data ImageUpload) (err error) {
+	payload, err := json.Marshal(data)
+	if err != nil {
+		return
+	}
+
+	uri := fmt.Sprintf("%s/images/%s/upload", c.url, imageID)
+
+	clientlog.Do(ctx, "publishing image", service, uri)
+
+	resp, err := c.doPostWithAuthHeaders(ctx, userAuthToken, serviceAuthToken, collectionID, uri, payload)
+	if err != nil {
+		return
+	}
+	defer closeResponseBody(ctx, resp)
+
+	if resp.StatusCode != http.StatusOK {
+		err = NewImageAPIResponse(resp, uri)
+		return
+	}
+	return
+}
+
 //ImportDownloadVariant triggers a download variant import
 func (c *Client) ImportDownloadVariant(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, imageID, variant string) (err error) {
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -484,6 +484,49 @@ func TestClient_PutImage(t *testing.T) {
 	})
 }
 
+func TestClient_PostImageUpload(t *testing.T) {
+
+	data := ImageUpload{
+		Path: "http://s3bucket/abcd.png",
+	}
+
+	Convey("given a 200 status is returned", t, func() {
+
+		mockdphttpCli := createHTTPClientMock(http.StatusOK, []byte{})
+		cli := Client{cli: mockdphttpCli, url: "http://localhost:8080"}
+
+		Convey("when ImportDownloadVariant is called", func() {
+			err := cli.PostImageUpload(ctx, userAuthToken, serviceAuthToken, collectionID, "123", data)
+
+			Convey("a positive response is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("and dphttpclient.Do is called 1 time", func() {
+				checkResponseBase(mockdphttpCli, http.MethodPost, "/images/123/upload")
+				So(err, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("given a 404 status is returned", t, func() {
+		mockdphttpCli := createHTTPClientMock(http.StatusNotFound, []byte("wrong!"))
+		cli := Client{cli: mockdphttpCli, url: "http://localhost:8080"}
+
+		Convey("when ImportDownloadVariant is called", func() {
+			err := cli.PostImageUpload(ctx, userAuthToken, serviceAuthToken, collectionID, "123", data)
+
+			Convey("then the expected error is returned", func() {
+				So(err.Error(), ShouldResemble, errors.Errorf("invalid response: 404 from image api: http://localhost:8080/images/123/upload, body: wrong!").Error())
+			})
+
+			Convey("and dphttpclient.Do is called 1 time with expected parameters", func() {
+				checkResponseBase(mockdphttpCli, http.MethodPost, "/images/123/upload")
+			})
+		})
+	})
+}
+
 func TestClient_PublishImage(t *testing.T) {
 
 	Convey("given a 200 status is returned", t, func() {

--- a/zebedee/client_test.go
+++ b/zebedee/client_test.go
@@ -128,7 +128,7 @@ func mockZebedeeServer(port chan int) {
 	r.Path("/parents").HandlerFunc(parents)
 	r.Path("/filesize").HandlerFunc(filesize)
 
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		log.Event(context.Background(), "error listening on local network address", log.FATAL, log.Error(err))
 		os.Exit(2)


### PR DESCRIPTION
### What

Add POST images/…/upload to image-api client
(Also fix another test for the zebedee client so it doesn't try to listen on an external interface, hence triggering the Mac firewall popup)

### How to review

Ensure a client function fo `POST /images/{id}/upload` has been added.
Ensure unit tests pass and cover functionality.

### Who can review

Anyone but me