### PR TITLE
add new 'site-search' dir for client from dp-search-query

### DIFF
--- a/site-search/data.go
+++ b/site-search/data.go
@@ -1,0 +1,65 @@
+package search
+
+// Response represents the fields for the search results as returned by dp-search-query
+type Response struct {
+	Count        int           `json:"count"`
+	ContentTypes []contentType `json:"content_types"`
+	Items        []contentItem `json:"items"`
+	Suggestions  []string      `json:"suggestions,omitempty"`
+}
+
+type contentType struct {
+	Type  string `json:"type"`
+	Count int    `json:"count"`
+}
+
+type contentItem struct {
+	Description description `json:"description"`
+	Type        string      `json:"type"`
+	URI         string      `json:"uri"`
+	Matches     *matches    `json:"matches,omitempty"`
+}
+
+type description struct {
+	Contact           *contact  `json:"contact,omitempty"`
+	DatasetID         string    `json:"dataset_id,omitempty"`
+	Edition           string    `json:"edition,omitempty"`
+	Headline1         string    `json:"headline1,omitempty"`
+	Headline2         string    `json:"headline2,omitempty"`
+	Headline3         string    `json:"headline3,omitempty"`
+	Keywords          *[]string `json:"keywords,omitempty"`
+	LatestRelease     *bool     `json:"latest_release,omitempty"`
+	Language          string    `json:"language,omitempty"`
+	MetaDescription   string    `json:"meta_description,omitempty"`
+	NationalStatistic *bool     `json:"national_statistic,omitempty"`
+	NextRelease       string    `json:"next_release,omitempty"`
+	PreUnit           string    `json:"pre_unit,omitempty"`
+	ReleaseDate       string    `json:"release_date,omitempty"`
+	Source            string    `json:"source,omitempty"`
+	Summary           string    `json:"summary"`
+	Title             string    `json:"title"`
+	Unit              string    `json:"unit,omitempty"`
+}
+
+type contact struct {
+	Name      string `json:"name"`
+	Telephone string `json:"telephone,omitempty"`
+	Email     string `json:"email"`
+}
+
+type matches struct {
+	Description struct {
+		Summary         *[]matchDetails `json:"summary"`
+		Title           *[]matchDetails `json:"title"`
+		Edition         *[]matchDetails `json:"edition,omitempty"`
+		MetaDescription *[]matchDetails `json:"meta_description,omitempty"`
+		Keywords        *[]matchDetails `json:"keywords,omitempty"`
+		DatasetID       *[]matchDetails `json:"dataset_id,omitempty"`
+	} `json:"description"`
+}
+
+type matchDetails struct {
+	Value string `json:"value,omitempty"`
+	Start int    `json:"start"`
+	End   int    `json:"end"`
+}

--- a/site-search/response_mocks/empty_results.json
+++ b/site-search/response_mocks/empty_results.json
@@ -1,0 +1,5 @@
+{
+    "count": 0,
+    "content_types": [],
+    "items": []
+}

--- a/site-search/response_mocks/results.json
+++ b/site-search/response_mocks/results.json
@@ -1,0 +1,261 @@
+{
+    "count": 5,
+    "took": 36,
+    "content_types": [
+        {
+            "type": "bulletin",
+            "count": 3
+        },
+        {
+            "type": "article",
+            "count": 1
+        },
+        {
+            "type": "reference_tables",
+            "count": 1
+        }
+    ],
+    "items": [
+        {
+            "description": {
+                "contact": {
+                    "name": "Christopher Jenkins",
+                    "telephone": "+44 (0)1633 455474",
+                    "email": "christopher.jenkins@ons.gsi.gov.uk"
+                },
+                "edition": "Q4 2014",
+                "headline1": "Improved methodology has been implemented leading to revisions to the full IPHRP time series. The data presented in this statistical bulletin are presented using the new methodology.",
+                "headline2": "Private rental prices paid by tenants in Great Britain rose by 1.7% in the 12 months to December 2014.",
+                "headline3": "Private rental prices grew by 1.8% in England, 2.0% in Scotland and 0.2% in Wales in the 12 months to December 2014.",
+                "keywords": [
+                    "Inflation",
+                    "Property",
+                    "private landlords",
+                    "rental market",
+                    "housing market"
+                ],
+                "latest_release": true,
+                "language": "English",
+                "national_statistic": false,
+                "release_date": "2015-01-30T00:00:00.000Z",
+                "summary": "The Index of Private Housing Rental Prices (IPHRP) measures the change in price of property rented by private landlords. The index is published as a series of price indices covering Great Britain, its constituent countries and the English regions.",
+                "title": "Index of Private Housing Rental Prices"
+            },
+            "type": "bulletin",
+            "uri": "/peoplepopulationandcommunity/housing/bulletins/indexofprivatehousingrentalprices/2015-01-30",
+            "matches": {
+                "description": {
+                    "summary": [
+                        {
+                            "start": 22,
+                            "end": 28
+                        }
+                    ],
+                    "title": [
+                        {
+                            "start": 18,
+                            "end": 24
+                        }
+                    ],
+                    "keywords": [
+                        {
+                            "value": "housing market",
+                            "start": 1,
+                            "end": 7
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "description": {
+                "contact": {
+                    "name": "Nigel Henretty",
+                    "telephone": "+44 (0)1329 447934",
+                    "email": "hpi@ons.gsi.gov.uk"
+                },
+                "edition": "1995 to 2013",
+                "keywords": [
+                    "regional house prices",
+                    "property prices",
+                    "area with cheapest houses",
+                    "area with most expensive houses"
+                ],
+                "latest_release": true,
+                "meta_description": "A brief overview of average (median) house prices using estimates from the sale prices of residential properties in England and Wales between 1995 and 2013. We look at the trends and features of average house prices paid over this period for 3 different geographies: local authorities, parliamentary constituencies and middle layer super output areas (MSOAs).",
+                "national_statistic": false,
+                "release_date": "2015-02-17T00:00:00.000Z",
+                "summary": "",
+                "title": "House Price Statistics for Small Areas in England and Wales"
+            },
+            "type": "article",
+            "uri": "/peoplepopulationandcommunity/housing/articles/housepricestatisticsforsmallareasinenglandandwales/2015-02-17",
+            "matches": {
+                "description": {
+                    "summary": null,
+                    "title": [
+                        {
+                            "start": 1,
+                            "end": 5
+                        }
+                    ],
+                    "keywords": [
+                        {
+                            "value": "regional house prices",
+                            "start": 10,
+                            "end": 14
+                        },
+                        {
+                            "value": "area with cheapest houses",
+                            "start": 20,
+                            "end": 25
+                        },
+                        {
+                            "value": "area with most expensive houses",
+                            "start": 26,
+                            "end": 31
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "description": {
+                "contact": {
+                    "name": "Kate Davies",
+                    "telephone": "+44 (0)1633 456344",
+                    "email": "construction.statistics@ons.gsi.gov.uk"
+                },
+                "edition": "April 2015 and New Orders Quarter 1 (Jan to Mar) 2015",
+                "headline1": "In April 2015 output in the construction industry decreased by 0.8% compared with March 2015",
+                "headline2": "Repair and maintenance decreased by 4.8%, while all new work increased by 1.6%",
+                "headline3": "It is the 23rd consecutive month of year-on-year growth, output in the construction industry increased by 1.5% compared with April 2014",
+                "keywords": [
+                    "infrastructure",
+                    "public housing",
+                    "private housing",
+                    "non–housing",
+                    "repairs and maintenance"
+                ],
+                "language": "English",
+                "meta_description": "Construction output is a monthly estimate of the output of the construction industry in both the private and public sectors. The estimates are a key component of Gross Domestic Product.",
+                "national_statistic": false,
+                "next_release": "10 July 2015",
+                "release_date": "2015-06-12T00:00:00.000Z",
+                "summary": "Construction output is a monthly estimate of the output of the construction industry in both the private and public sectors. The estimates are a key component of Gross Domestic Product.",
+                "title": "Output in the Construction Industry"
+            },
+            "type": "bulletin",
+            "uri": "/businessindustryandtrade/constructionindustry/bulletins/outputintheconstructionindustry/2015-06-12",
+            "matches": {
+                "description": {
+                    "summary": null,
+                    "title": null,
+                    "keywords": [
+                        {
+                            "value": "public housing",
+                            "start": 8,
+                            "end": 14
+                        },
+                        {
+                            "value": "private housing",
+                            "start": 9,
+                            "end": 15
+                        },
+                        {
+                            "value": "non–housing",
+                            "start": 7,
+                            "end": 13
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "description": {
+                "contact": {
+                    "name": "Kate Davies",
+                    "telephone": "+44 (0)1633 456344",
+                    "email": "construction.statistics@ons.gsi.gov.uk"
+                },
+                "edition": "May 2015",
+                "headline1": "In May 2015, output in the construction industry was estimated to have decreased by 1.3% compared with April 2015. Both all new work, and repair and maintenance contributed to the fall",
+                "headline2": "Repair and maintenance (R&M) decreased by 1.0%. Falls in non-housing R&M (-1.9%) and private housing R&M (-0.8%) were offset slightly by public housing R&M, which increased by 1.8%",
+                "headline3": "Compared with May 2014, output in the construction industry showed an increase of 1.3%. All new work increased by 3.2% while repair and maintenance decreased by 1.7%",
+                "keywords": [
+                    "building, infrastructure, industrial, commercial, housing,building,infrastructure,industrial,commercial,housing"
+                ],
+                "latest_release": true,
+                "meta_description": "Construction output at current price and chained volume measures seasonally adjusted by public and private sector.",
+                "national_statistic": false,
+                "next_release": "14 August 2015",
+                "release_date": "2015-07-09T23:00:00.000Z",
+                "summary": "Construction output at current price and chained volume measures seasonally adjusted by public and private sector.",
+                "title": "Output in the Construction Industry"
+            },
+            "type": "bulletin",
+            "uri": "/businessindustryandtrade/constructionindustry/bulletins/outputintheconstructionindustry/2015-07-10",
+            "matches": {
+                "description": {
+                    "summary": null,
+                    "title": null,
+                    "keywords": [
+                        {
+                            "value": "building, infrastructure, industrial, commercial, housing,building,infrastructure,industrial,commercial,housing",
+                            "start": 51,
+                            "end": 57
+                        },
+                        {
+                            "value": "building, infrastructure, industrial, commercial, housing,building,infrastructure,industrial,commercial,housing",
+                            "start": 105,
+                            "end": 111
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "description": {
+                "contact": {
+                    "name": "Kate Davies",
+                    "telephone": "+44 (0)1633 456344",
+                    "email": "construction.statistics@ons.gsi.gov.uk"
+                },
+                "keywords": [
+                    "infrastructure,public housing,private housing,non–housing,repairs and maintenance"
+                ],
+                "meta_description": "Construction output is a monthly estimate of the output of the construction industry in both the private and public sectors. The estimates are a key component of Gross Domestic Product.",
+                "national_statistic": false,
+                "next_release": "14 August 2015",
+                "release_date": "2015-07-09T23:00:00.000Z",
+                "summary": "Construction output is a monthly estimate of the output of the construction industry in both the private and public sectors. The estimates are a key component of Gross Domestic Product.",
+                "title": "Output in the Construction Industry, May 2015 reference tables"
+            },
+            "type": "reference_tables",
+            "uri": "/businessindustryandtrade/constructionindustry/datasets/outputintheconstructionindustrymay2015referencetables",
+            "matches": {
+                "description": {
+                    "summary": null,
+                    "title": null,
+                    "keywords": [
+                        {
+                            "value": "infrastructure,public housing,private housing,non–housing,repairs and maintenance",
+                            "start": 23,
+                            "end": 29
+                        },
+                        {
+                            "value": "infrastructure,public housing,private housing,non–housing,repairs and maintenance",
+                            "start": 39,
+                            "end": 45
+                        },
+                        {
+                            "value": "infrastructure,public housing,private housing,non–housing,repairs and maintenance",
+                            "start": 53,
+                            "end": 59
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/site-search/site-search.go
+++ b/site-search/site-search.go
@@ -78,12 +78,11 @@ func (c *Client) Checker(ctx context.Context, check *health.CheckState) error {
 // doGet executes clienter.Do GET for the provided uri
 // The url.Values will be added as query parameters in the URL.
 // Returns the http.Response and any error and it is the callers responsibility to ensure response.Body is closed on completion.
-func (c *Client) doGetWithAuthHeaders(ctx context.Context, uri string, values url.Values) (*http.Response, error) {
+func (c *Client) doGetWithAuthHeaders(ctx context.Context, uri string) (*http.Response, error) {
 	req, err := http.NewRequest(http.MethodGet, uri, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.URL.RawQuery = values.Encode()
 	return c.cli.Do(ctx, req)
 }
 
@@ -99,11 +98,13 @@ func NewSearchErrorResponse(resp *http.Response, uri string) (e *ErrInvalidSearc
 // GetSearch returns the search results
 func (c *Client) GetSearch(ctx context.Context, query url.Values) (r Response, err error) {
 	uri := fmt.Sprintf("%s/search", c.url)
-	uri = uri + "?" + query.Encode()
+	if query != nil {
+		uri = uri + "?" + query.Encode()
+	}
 
 	clientlog.Do(ctx, "retrieving search response", service, uri)
 
-	resp, err := c.doGetWithAuthHeaders(ctx, uri, query)
+	resp, err := c.doGetWithAuthHeaders(ctx, uri)
 	if err != nil {
 		return
 	}

--- a/site-search/site-search.go
+++ b/site-search/site-search.go
@@ -1,0 +1,127 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/ONSdigital/dp-api-clients-go/clientlog"
+	healthcheck "github.com/ONSdigital/dp-api-clients-go/health"
+	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
+	dphttp "github.com/ONSdigital/dp-net/http"
+	"github.com/ONSdigital/log.go/log"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+const service = "search-query"
+
+// ErrInvalidSearchResponse is returned when the dp-search-query does not respond
+// with a valid status
+type ErrInvalidSearchResponse struct {
+	expectedCode int
+	actualCode   int
+	uri          string
+}
+
+// Error should be called by the user to print out the stringified version of the error
+func (e ErrInvalidSearchResponse) Error() string {
+	return fmt.Sprintf("invalid response from dp-search-query - should be: %d, got: %d, path: %s",
+		e.expectedCode,
+		e.actualCode,
+		e.uri,
+	)
+}
+
+// Code returns the status code received from dp-search-query if an error is returned
+func (e ErrInvalidSearchResponse) Code() int {
+	return e.actualCode
+}
+
+// compile time check that ErrInvalidSearchResponse satisfies the error interface
+var _ error = ErrInvalidSearchResponse{}
+
+// Client is a dp-search-query client which can be used to make requests to the server
+type Client struct {
+	cli dphttp.Clienter
+	url string
+}
+
+// NewClient creates a new instance of Client with a given search-query api url
+func NewClient(searchAPIURL string) *Client {
+	hcClient := healthcheck.NewClient(service, searchAPIURL)
+
+	return &Client{
+		cli: hcClient.Client,
+		url: searchAPIURL,
+	}
+}
+
+// closeResponseBody closes the response body and logs an error containing the context if unsuccessful
+func closeResponseBody(ctx context.Context, resp *http.Response) {
+	if err := resp.Body.Close(); err != nil {
+		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
+	}
+}
+
+// Checker calls search api health endpoint and returns a check object to the caller.
+func (c *Client) Checker(ctx context.Context, check *health.CheckState) error {
+	hcClient := healthcheck.Client{
+		Client: c.cli,
+		URL:    c.url,
+		Name:   service,
+	}
+
+	return hcClient.Checker(ctx, check)
+}
+
+// doGet executes clienter.Do GET for the provided uri
+// The url.Values will be added as query parameters in the URL.
+// Returns the http.Response and any error and it is the callers responsibility to ensure response.Body is closed on completion.
+func (c *Client) doGetWithAuthHeaders(ctx context.Context, uri string, values url.Values) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.URL.RawQuery = values.Encode()
+	return c.cli.Do(ctx, req)
+}
+
+// NewSearchErrorResponse creates an error response
+func NewSearchErrorResponse(resp *http.Response, uri string) (e *ErrInvalidSearchResponse) {
+	return &ErrInvalidSearchResponse{
+		expectedCode: http.StatusOK,
+		actualCode: resp.StatusCode,
+		uri:        uri,
+	}
+}
+
+// GetSearch returns the search results
+func (c *Client) GetSearch(ctx context.Context, query url.Values) (r Response, err error) {
+	uri := fmt.Sprintf("%s/search", c.url)
+	uri = uri + "?" + query.Encode()
+
+	clientlog.Do(ctx, "retrieving search response", service, uri)
+
+	resp, err := c.doGetWithAuthHeaders(ctx, uri, query)
+	if err != nil {
+		return
+	}
+	defer closeResponseBody(ctx, resp)
+
+	if resp.StatusCode != http.StatusOK {
+		err = NewSearchErrorResponse(resp, uri)
+		return
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+
+	if err = json.Unmarshal(b, &r); err != nil {
+		return
+	}
+
+	return
+}

--- a/site-search/site-search_test.go
+++ b/site-search/site-search_test.go
@@ -1,0 +1,260 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/ONSdigital/dp-api-clients-go/health"
+	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+	dphttp "github.com/ONSdigital/dp-net/http"
+
+	"github.com/pkg/errors"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	testHost         = "http://localhost:8080"
+)
+
+var (
+	ctx          = context.Background()
+	initialState = health.CreateCheckState(service)
+)
+
+var checkResponseBase = func(mockdphttpCli *dphttp.ClienterMock, expectedMethod string, expectedUri string) {
+	So(len(mockdphttpCli.DoCalls()), ShouldEqual, 1)
+	So(mockdphttpCli.DoCalls()[0].Req.URL.RequestURI(), ShouldEqual, expectedUri)
+	So(mockdphttpCli.DoCalls()[0].Req.Method, ShouldEqual, expectedMethod)
+}
+
+func createHTTPClientMock(retCode int, body []byte) *dphttp.ClienterMock {
+	return &dphttp.ClienterMock{
+		DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: retCode,
+				Body:       ioutil.NopCloser(bytes.NewReader(body)),
+			}, nil
+		},
+	}
+}
+
+func TestClient_HealthChecker(t *testing.T) {
+	ctx := context.Background()
+	timePriorHealthCheck := time.Now()
+	path := "/health"
+
+	Convey("given clienter.Do returns an error", t, func() {
+		clientError := errors.New("disciples of the watch obey")
+
+		clienter := &dphttp.ClienterMock{
+			SetPathsWithNoRetriesFunc: func(paths []string) {
+				return
+			},
+			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+				return &http.Response{}, clientError
+			},
+		}
+		clienter.SetPathsWithNoRetries([]string{path, "/healthcheck"})
+
+		searchClient := NewClient(testHost)
+		searchClient.cli = clienter
+		check := initialState
+
+		Convey("when searchClient.Checker is called", func() {
+			err := searchClient.Checker(ctx, &check)
+			So(err, ShouldBeNil)
+
+			Convey("then the expected check is returned", func() {
+				So(check.Name(), ShouldEqual, service)
+				So(check.Status(), ShouldEqual, healthcheck.StatusCritical)
+				So(check.StatusCode(), ShouldEqual, 0)
+				So(check.Message(), ShouldEqual, clientError.Error())
+				So(*check.LastChecked(), ShouldHappenAfter, timePriorHealthCheck)
+				So(check.LastSuccess(), ShouldBeNil)
+				So(*check.LastFailure(), ShouldHappenAfter, timePriorHealthCheck)
+			})
+
+			Convey("and client.Do should be called once with the expected parameters", func() {
+				doCalls := clienter.DoCalls()
+				So(doCalls, ShouldHaveLength, 1)
+				So(doCalls[0].Req.URL.Path, ShouldEqual, path)
+			})
+		})
+	})
+
+	Convey("given clienter.Do returns 400 response", t, func() {
+		clienter := &dphttp.ClienterMock{
+			SetPathsWithNoRetriesFunc: func(paths []string) {
+				return
+			},
+			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: 400,
+				}, nil
+			},
+		}
+		clienter.SetPathsWithNoRetries([]string{path, "/healthcheck"})
+
+		searchClient := NewClient(testHost)
+		searchClient.cli = clienter
+		check := initialState
+
+		Convey("when searchClient.Checker is called", func() {
+			err := searchClient.Checker(ctx, &check)
+			So(err, ShouldBeNil)
+
+			Convey("then the expected check is returned", func() {
+				So(check.Name(), ShouldEqual, service)
+				So(check.Status(), ShouldEqual, healthcheck.StatusCritical)
+				So(check.StatusCode(), ShouldEqual, 400)
+				So(check.Message(), ShouldEqual, service+health.StatusMessage[healthcheck.StatusCritical])
+				So(*check.LastChecked(), ShouldHappenAfter, timePriorHealthCheck)
+				So(check.LastSuccess(), ShouldBeNil)
+				So(*check.LastFailure(), ShouldHappenAfter, timePriorHealthCheck)
+			})
+
+			Convey("and client.Do should be called once with the expected parameters", func() {
+				doCalls := clienter.DoCalls()
+				So(doCalls, ShouldHaveLength, 1)
+				So(doCalls[0].Req.URL.Path, ShouldEqual, path)
+			})
+		})
+	})
+
+	Convey("given clienter.Do returns 500 response", t, func() {
+		clienter := &dphttp.ClienterMock{
+			SetPathsWithNoRetriesFunc: func(paths []string) {
+				return
+			},
+			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: 500,
+				}, nil
+			},
+		}
+		clienter.SetPathsWithNoRetries([]string{path, "/healthcheck"})
+
+		searchClient := NewClient(testHost)
+		searchClient.cli = clienter
+		check := initialState
+
+		Convey("when searchClient.Checker is called", func() {
+			err := searchClient.Checker(ctx, &check)
+			So(err, ShouldBeNil)
+
+			Convey("then the expected check is returned", func() {
+				So(check.Name(), ShouldEqual, service)
+				So(check.Status(), ShouldEqual, healthcheck.StatusCritical)
+				So(check.StatusCode(), ShouldEqual, 500)
+				So(check.Message(), ShouldEqual, service+health.StatusMessage[healthcheck.StatusCritical])
+				So(*check.LastChecked(), ShouldHappenAfter, timePriorHealthCheck)
+				So(check.LastSuccess(), ShouldBeNil)
+				So(*check.LastFailure(), ShouldHappenAfter, timePriorHealthCheck)
+			})
+
+			Convey("and client.Do should be called once with the expected parameters", func() {
+				doCalls := clienter.DoCalls()
+				So(doCalls, ShouldHaveLength, 1)
+				So(doCalls[0].Req.URL.Path, ShouldEqual, path)
+			})
+		})
+	})
+}
+
+func TestClient_GetSearch(t *testing.T) {
+	Convey("given a 200 status is returned with an empty result list", t, func() {
+		searchResp, err := ioutil.ReadFile("./response_mocks/empty_results.json")
+		So(err, ShouldBeNil)
+
+		mockdphttpCli := createHTTPClientMock(http.StatusOK, searchResp)
+		cli := Client{cli: mockdphttpCli, url: "http://localhost:8080"}
+
+		Convey("when GetSearch is called", func() {
+			v := url.Values{}
+			v.Set("q", "a")
+			r, err := cli.GetSearch(ctx, v)
+
+			Convey("a positive response is returned", func() {
+				So(err, ShouldBeNil)
+				So(r.Count, ShouldEqual, 0)
+				So(r.ContentTypes, ShouldBeEmpty)
+				So(r.Items, ShouldBeEmpty)
+			})
+
+			Convey("and dphttpclient.Do is called 1 time", func() {
+				checkResponseBase(mockdphttpCli, http.MethodGet, "/search?q=a")
+			})
+		})
+	})
+
+	Convey("given a 200 status is returned with list of search results", t, func() {
+		searchResp, err := ioutil.ReadFile("./response_mocks/results.json")
+		So(err, ShouldBeNil)
+
+		mockdphttpCli := createHTTPClientMock(http.StatusOK, searchResp)
+		cli := Client{cli: mockdphttpCli, url: "http://localhost:8080"}
+
+		Convey("when GetSearch is called", func() {
+			v := url.Values{}
+			v.Set("q", "housing")
+			r, err := cli.GetSearch(ctx, v)
+
+			Convey("a positive response is returned", func() {
+				So(err, ShouldBeNil)
+				So(r.Count, ShouldEqual, 5)
+				So(r.Items, ShouldNotBeEmpty)
+				So(r.ContentTypes, ShouldNotBeEmpty)
+			})
+
+			Convey("and dphttpclient.Do is called 1 time", func() {
+				checkResponseBase(mockdphttpCli, http.MethodGet, "/search?q=housing")
+			})
+		})
+	})
+
+	Convey("given a 400 status is returned", t, func() {
+		mockdphttpCli := createHTTPClientMock(http.StatusBadRequest, nil)
+		cli := Client{cli: mockdphttpCli, url: "http://localhost:8080"}
+
+		Convey("when GetSearch is called", func() {
+			v := url.Values{}
+			v.Set("limit", "a")
+			_, err := cli.GetSearch(ctx, v)
+
+			Convey("then the expected error is returned", func() {
+				So(err.Error(), ShouldResemble, errors.Errorf("invalid response from dp-search-query - should be: 200, got: 400, path: "+testHost+"/search?limit=a").Error())
+
+			})
+
+			Convey("and dphttpclient.Do is called 1 time", func() {
+				checkResponseBase(mockdphttpCli, http.MethodGet, "/search?limit=a")
+			})
+		})
+	})
+
+	Convey("given a 500 status is returned", t, func() {
+		mockdphttpCli := createHTTPClientMock(http.StatusInternalServerError, nil)
+		cli := Client{cli: mockdphttpCli, url: "http://localhost:8080"}
+
+		Convey("when GetSearch is called", func() {
+			v := url.Values{}
+			v.Set("limit", "housing")
+			_, err := cli.GetSearch(ctx, v)
+
+			Convey("then the expected error is returned", func() {
+				So(err.Error(), ShouldResemble, errors.Errorf("invalid response from dp-search-query - should be: 200, got: 500, path: "+testHost+"/search?limit=housing").Error())
+
+			})
+
+			Convey("and dphttpclient.Do is called 1 time", func() {
+				checkResponseBase(mockdphttpCli, http.MethodGet, "/search?limit=housing")
+			})
+		})
+	})
+}
+


### PR DESCRIPTION
### What

**Describe what you have changed and why.**
- Create `site-search` client based on `dp-search-query`
- Added tests for the functionalities in the `site-search` directory
- Add example results to assist the tests
- Add `data.go` file which has the model of the essential data returned from the `dp-search-query`

### How to review

**Describe the steps required to test the changes.**
- Check If the tests are successful
- Check if the code makes sense (it is very similar to the `search` and `image` directories so you can use that as a guide)

### Who can review

**Describe who worked on the changes, so that other people can review.**
Anyone - Justin made the changes