### PR TITLE
Investigate re-usage of Clienters among different API clients.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,25 @@ Common client code - in go - for ONS APIs:
 
 #### Usage
 
-(WIP) Each client defines two constructor functions: one that creates a new dp-net/http Clienter, and the other that allows you to provide it externally, so that you can reuse it among different clients.
+(WIP) Each client defines two constructor functions: one that creates a new healthcheck client (with a new dp-net/http Clienter), and the other that allows you to provide it externally, so that you can reuse it among different clients.
 
-For example, you may initialise an image API client with a new Clienter:
+For example, you may create a new image API client like so:
 ```
     import  "github.com/ONSdigital/dp-api-clients-go/image"
+
     ...
     imageClient := image.NewAPIClient(<url>)
     ...
 ```
 
-Or you may initialise it providing a Clienter:
+Or you may create it providing a Healthcheck client:
 ```
+    import  "github.com/ONSdigital/dp-api-clients-go/image"
+    import  "github.com/ONSdigital/dp-api-clients-go/health"
+
     ...
-    imageClient := image.NewWithClienter(<url>, <clienter>)
+    hcClient := health.NewClient(<genericName>, <url>)
+    imageClient := image.NewWithHealthClient(hcClient)
     ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,30 @@ Common client code - in go - for ONS APIs:
 * healthcheck -> health
 * hierarchy
 * identity
+* image
 * importapi
 * renderer
 * search
+
+
+#### Usage
+
+(WIP) Each client defines two constructor functions: one that creates a new dp-net/http Clienter, and the other that allows you to provide it externally, so that you can reuse it among different clients.
+
+For example, you may initialise an image API client with a new Clienter:
+```
+    import  "github.com/ONSdigital/dp-api-clients-go/image"
+    ...
+    imageClient := image.NewAPIClient(<url>)
+    ...
+```
+
+Or you may initialise it providing a Clienter:
+```
+    ...
+    imageClient := image.NewWithClienter(<url>, <clienter>)
+    ...
+```
 
 #### Package docs
 

--- a/health/README.md
+++ b/health/README.md
@@ -28,3 +28,12 @@ func main() {
 
     ...
 }
+```
+
+Alternatevely, if you already have a Clienter (instance of dp-net/http Clienter), you can reuse it in your healthcheck client, like so:
+
+```
+    ...
+    hcClient := health.NewClientWithClienter(<name>, <url>, <clienter> dphttp.Clienter)
+    ...
+```

--- a/health/health.go
+++ b/health/health.go
@@ -37,8 +37,13 @@ type Client struct {
 
 // NewClient creates a new instance of Client with a given app url
 func NewClient(name, url string) *Client {
+	return NewClientWithClienter(name, url, dphttp.NewClient())
+}
+
+// NewClientWithClienter creates a new instance of Client with a given app name and url, and the provided clienter
+func NewClientWithClienter(name, url string, clienter dphttp.Clienter) *Client {
 	c := &Client{
-		Client: dphttp.NewClient(),
+		Client: clienter,
 		URL:    url,
 		Name:   name,
 	}


### PR DESCRIPTION
### What

We want to have the capability to re-use a dp-net/http Clienter among different API clients. In this PR, there is the suggested implementation in Image API client, that all clients should follow.

### How to review

- Make sure that the new constructor function in ImageAPI and Health clients allows a Clienter to be reused
- Check if the changes in the README are clear
- Make sure unit tests pass

### Who can review

Anyone