### PR TITLE
Add POST /images/{id}/downloads to image api client

### DIFF
--- a/image/data.go
+++ b/image/data.go
@@ -14,6 +14,7 @@ type Images struct {
 // NewImage represents the fields required to create a new Image
 type NewImage struct {
 	CollectionId string  `json:"collection_id,omitempty"`
+	State        string  `json:"state,omitempty"`
 	Filename     string  `json:"filename,omitempty"`
 	License      License `json:"license,omitempty"`
 	Type         string  `json:"type,omitempty"`
@@ -42,9 +43,9 @@ type Image struct {
 	//- failed_publish
 	Filename string      `json:"filename,omitempty"`
 	License  License     `json:"license,omitempty"`
+	Links    *ImageLinks `json:"links,omitempty"`
 	Upload   ImageUpload `json:"upload,omitempty"`
 	Type     string      `json:"type,omitempty"`
-	Links    *ImageLinks `json:"links,omitempty"`
 }
 
 // ImageUpload represents the fields for an Image Upload
@@ -70,15 +71,15 @@ type ImageDownloads struct {
 // ImageDownload represents the fields for an Image Download
 type ImageDownload struct {
 	Id      string              `json:"id,omitempty"`
-	Size    int                 `json:"size,omitempty"`
+	Height  *int                `json:"height,omitempty"`
+	Href    string              `json:"href,omitempty"`
 	Palette string              `json:"palette,omitempty"`
+	Private string              `json:"private,omitempty"`
+	Public  bool                `json:"public,omitempty"`
+	Size    int                 `json:"size,omitempty"`
 	Type    string              `json:"type,omitempty"`
 	Width   *int                `json:"width,omitempty"`
-	Height  *int                `json:"height,omitempty"`
-	Public  bool                `json:"public,omitempty"`
-	Href    string              `json:"href,omitempty"`
 	Links   *ImageDownloadLinks `json:"links,omitempty"`
-	Private string              `json:"private,omitempty"`
 	State   string              `json:"state,omitempty"`
 	//enum:
 	//- pending

--- a/image/data.go
+++ b/image/data.go
@@ -95,6 +95,20 @@ type ImageDownload struct {
 	PublishCompleted *time.Time `json:"publish_completed,omitempty"`
 }
 
+// ImageDownload represents the fields for an Image Download
+type NewImageDownload struct {
+	Id      string `json:"id,omitempty"`
+	Height  *int   `json:"height,omitempty"`
+	Palette string `json:"palette,omitempty"`
+	Size    int    `json:"size,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Width   *int   `json:"width,omitempty"`
+	State   string `json:"state,omitempty"`
+	//enum:
+	//- importing
+	ImportStarted *time.Time `json:"import_started,omitempty"`
+}
+
 // ImageDownloadLinks represents the fields for the image download HATEOAS links
 type ImageDownloadLinks struct {
 	Self  string `json:"self"`

--- a/image/image.go
+++ b/image/image.go
@@ -133,7 +133,7 @@ func (c *Client) PostImage(ctx context.Context, userAuthToken, serviceAuthToken,
 	}
 	defer closeResponseBody(ctx, resp)
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusCreated {
 		err = NewImageAPIResponse(resp, uri)
 		return
 	}

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -330,11 +330,11 @@ func TestClient_PostImage(t *testing.T) {
 		Type: "animal",
 	}
 
-	Convey("given a 200 status is returned", t, func() {
+	Convey("given a 201 status is returned", t, func() {
 		searchResp, err := ioutil.ReadFile("./response_mocks/image.json")
 		So(err, ShouldBeNil)
 
-		mockdphttpCli := createHTTPClientMock(http.StatusOK, searchResp)
+		mockdphttpCli := createHTTPClientMock(http.StatusCreated, searchResp)
 		cli := createImageAPIWithClienter(mockdphttpCli)
 		expectedPayload, err := json.Marshal(newImage)
 		So(err, ShouldBeNil)


### PR DESCRIPTION
### What

Add POST /images/{id}/downloads to image api client.
- Add `NewImageDowload` model
- Add `PostDownloadVariant` function to client
- Add appropriate tests

Also…
- Tidy up order of other models to match swagger spec in `dp-image-api`
- Fix issue with PostImage function expecting a 200(OK) response from the API instead of 201(Created).
- Add `State` to `NewImage` model

### How to review

Ensure expected changes have been made and that appropriate tests are present.

### Who can review

Anyone but me