### PR TITLE
change contentType struct to be exporter

### DIFF
--- a/site-search/data.go
+++ b/site-search/data.go
@@ -8,6 +8,7 @@ type Response struct {
 	Suggestions  []string      `json:"suggestions,omitempty"`
 }
 
+// ContentType represents the specific content type for the search results with its respective count
 type ContentType struct {
 	Type  string `json:"type"`
 	Count int    `json:"count"`

--- a/site-search/data.go
+++ b/site-search/data.go
@@ -3,12 +3,12 @@ package search
 // Response represents the fields for the search results as returned by dp-search-query
 type Response struct {
 	Count        int           `json:"count"`
-	ContentTypes []contentType `json:"content_types"`
+	ContentTypes []ContentType `json:"content_types"`
 	Items        []contentItem `json:"items"`
 	Suggestions  []string      `json:"suggestions,omitempty"`
 }
 
-type contentType struct {
+type ContentType struct {
 	Type  string `json:"type"`
 	Count int    `json:"count"`
 }


### PR DESCRIPTION
### What

**Describe what you have changed and why.**
- Change the struct `contentType` to be an exporter `ContentType`
- This is needed because this struct is needed to be available in the `dp-frontend-search-controller` to combine the count of search results on a query based on each filter type. 

### How to review

**Describe the steps required to test the changes.**
- Check if the code makes sense

### Who can review

**Describe who worked on the changes, so that other people can review.**
Anyone - Justin made the changes