### PR TITLE
update dimension search endpoint

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -93,7 +93,7 @@ func (c *Client) Dimension(ctx context.Context, datasetID, edition, version, nam
 		}
 	}
 
-	uri := fmt.Sprintf("%s/search/datasets/%s/editions/%s/versions/%s/dimensions/%s?",
+	uri := fmt.Sprintf("%s/dimension-search/datasets/%s/editions/%s/versions/%s/dimensions/%s?",
 		c.hcCli.URL,
 		datasetID,
 		edition,

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -104,7 +104,7 @@ func TestSearchUnit(t *testing.T) {
 
 		Convey("test Dimension returns error if HTTP Status code is not 200", func() {
 
-			searchErr := errors.New("invalid response from search api - should be: 200, got: 400, path: http://localhost:22000/search/datasets/12345/editions/time-series/versions/1/dimensions/geography?limit=1&offset=1&q=Newport")
+			searchErr := errors.New("invalid response from search api - should be: 200, got: 400, path: http://localhost:22000/dimension-search/datasets/12345/editions/time-series/versions/1/dimensions/geography?limit=1&offset=1&q=Newport")
 			mockClient := &dphttp.ClienterMock{
 				GetPathsWithNoRetriesFunc: func() []string { return []string{} },
 				SetPathsWithNoRetriesFunc: func([]string) {},
@@ -201,7 +201,7 @@ func TestSearchUnit(t *testing.T) {
 
 		Convey("test Dimension no limit returns error if HTTP Status code is not 200", func() {
 
-			expectedError := &ErrInvalidSearchAPIResponse{http.StatusOK, http.StatusTeapot, "http://localhost:22000/search/datasets/12345/editions/time-series/versions/1/dimensions/geography?limit=50&offset=1&q=Newport"}
+			expectedError := &ErrInvalidSearchAPIResponse{http.StatusOK, http.StatusTeapot, "http://localhost:22000/dimension-search/datasets/12345/editions/time-series/versions/1/dimensions/geography?limit=50&offset=1&q=Newport"}
 			mockClient := &dphttp.ClienterMock{
 				GetPathsWithNoRetriesFunc: func() []string { return []string{} },
 				SetPathsWithNoRetriesFunc: func([]string) {},


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
When `Dimension` method is called, the URL assigned should start with `/dimension-search` instead `/search`
Therefore, the `URL` has been changed to use `/dimension-search`  
The tests have been added to use the new endpoint

### How to review
**Describe the steps required to test the changes.**
Check if the change has been made correctly (a very small change)
Check if the tests pass

### Who can review
**Describe who worked on the changes, so that other people can review.**
Anyone - Justin made the changes