### PR TITLE
dataset GetOptions with offset and limit

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -244,7 +244,11 @@ type Dimensions struct {
 
 // Options represents a list of options from the dataset api
 type Options struct {
-	Items []Option `json:"items"`
+	Items      []Option `json:"items"`
+	Count      int      `json:"count"`
+	Offset     int      `json:"offset"`
+	Limit      int      `json:"limit"`
+	TotalCount int      `json:"total_count"`
 }
 
 // Option represents a response model for an option

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -675,8 +675,8 @@ func (c *Client) GetVersionDimensions(ctx context.Context, userAuthToken, servic
 }
 
 // GetOptions will return the options for a dimension
-func (c *Client) GetOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string) (m Options, err error) {
-	uri := fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s/dimensions/%s/options", c.hcCli.URL, id, edition, version, dimension)
+func (c *Client) GetOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, offset, limit int) (m Options, err error) {
+	uri := fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s/dimensions/%s/options?offset=%d&limit=%d", c.hcCli.URL, id, edition, version, dimension, offset, limit)
 
 	clientlog.Do(ctx, "retrieving options for dimension", service, uri)
 

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -676,8 +676,11 @@ func (c *Client) GetVersionDimensions(ctx context.Context, userAuthToken, servic
 
 // GetOptions will return the options for a dimension
 func (c *Client) GetOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, offset, limit int) (m Options, err error) {
-	uri := fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s/dimensions/%s/options?offset=%d&limit=%d", c.hcCli.URL, id, edition, version, dimension, offset, limit)
+	if offset < 0 || limit < 0 {
+		return Options{}, errors.New("negative offsets or limits are not allowed")
+	}
 
+	uri := fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s/dimensions/%s/options?offset=%d&limit=%d", c.hcCli.URL, id, edition, version, dimension, offset, limit)
 	clientlog.Do(ctx, "retrieving options for dimension", service, uri)
 
 	resp, err := c.doGetWithAuthHeaders(ctx, userAuthToken, serviceAuthToken, collectionID, uri, nil)

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -753,6 +754,73 @@ func TestClient_PutInstanceDimensionOptionNodeID(t *testing.T) {
 
 			Convey("and dphttpclient.Do is called 1 time with expected parameters", func() {
 				checkResponseBase(httpClient, http.MethodPut, "/instances/123/dimensions/456/options/789/node_id/ABC")
+			})
+		})
+	})
+}
+
+func TestClient_GetOptions(t *testing.T) {
+
+	instanceID := "testInstance"
+	edition := "testEdition"
+	version := "tetVersion"
+	dimension := "testDimension"
+	offset := 1
+	limit := 10
+
+	Convey("given a 200 status is returned", t, func() {
+		testOptions := Options{
+			Items: []Option{
+				{
+					DimensionID: dimension,
+					Label:       "optionLabel",
+					Option:      "testOption",
+				},
+			},
+			Count:      1,
+			Offset:     offset,
+			Limit:      limit,
+			TotalCount: 1,
+		}
+		httpClient := createHTTPClientMock(http.StatusOK, testOptions)
+		datasetClient := newDatasetClient(httpClient)
+
+		Convey("when GetOptions is called", func() {
+			options, err := datasetClient.GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, edition, version, dimension, offset, limit)
+
+			Convey("a positive response is returned, with the expected options", func() {
+				So(err, ShouldBeNil)
+				So(options, ShouldResemble, testOptions)
+			})
+
+			Convey("and dphttpclient.Do is called 1 time with the expected URI", func() {
+				expectedURI := fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/dimensions/%s/options?offset=%d&limit=%d",
+					instanceID, edition, version, dimension, offset, limit)
+				checkResponseBase(httpClient, http.MethodGet, expectedURI)
+			})
+		})
+	})
+
+	Convey("given a 404 status is returned", t, func() {
+		httpClient := createHTTPClientMock(http.StatusNotFound, Options{})
+		datasetClient := newDatasetClient(httpClient)
+
+		Convey("when GetOptions is called", func() {
+			options, err := datasetClient.GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, edition, version, dimension, offset, limit)
+
+			Convey("the expected error response is returned, with an empty options struct", func() {
+				So(err, ShouldResemble, &ErrInvalidDatasetAPIResponse{
+					actualCode: 404,
+					uri:        fmt.Sprintf("http://localhost:8080/datasets/%s/editions/%s/versions/%s/dimensions/%s/options?offset=%d&limit=%d", instanceID, edition, version, dimension, offset, limit),
+					body:       "{\"items\":null,\"count\":0,\"offset\":0,\"limit\":0,\"total_count\":0}",
+				})
+				So(options, ShouldResemble, Options{})
+			})
+
+			Convey("and dphttpclient.Do is called 1 time with the expected URI", func() {
+				expectedURI := fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/dimensions/%s/options?offset=%d&limit=%d",
+					instanceID, edition, version, dimension, offset, limit)
+				checkResponseBase(httpClient, http.MethodGet, expectedURI)
 			})
 		})
 	})

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -785,7 +785,7 @@ func TestClient_GetOptions(t *testing.T) {
 		httpClient := createHTTPClientMock(http.StatusOK, testOptions)
 		datasetClient := newDatasetClient(httpClient)
 
-		Convey("when GetOptions is called", func() {
+		Convey("when GetOptions is called with valid values for limit and offset", func() {
 			options, err := datasetClient.GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, edition, version, dimension, offset, limit)
 
 			Convey("a positive response is returned, with the expected options", func() {
@@ -797,6 +797,26 @@ func TestClient_GetOptions(t *testing.T) {
 				expectedURI := fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/dimensions/%s/options?offset=%d&limit=%d",
 					instanceID, edition, version, dimension, offset, limit)
 				checkResponseBase(httpClient, http.MethodGet, expectedURI)
+			})
+		})
+
+		Convey("when GetOptions is called with negative offset", func() {
+			options, err := datasetClient.GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, edition, version, dimension, -1, limit)
+
+			Convey("the expected error is returned and http dphttpclient.Do is not called", func() {
+				So(err.Error(), ShouldResemble, "negative offsets or limits are not allowed")
+				So(options, ShouldResemble, Options{})
+				So(len(httpClient.DoCalls()), ShouldEqual, 0)
+			})
+		})
+
+		Convey("when GetOptions is called with negative limit", func() {
+			options, err := datasetClient.GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, edition, version, dimension, offset, -1)
+
+			Convey("the expected error is returned and http dphttpclient.Do is not called", func() {
+				So(err.Error(), ShouldResemble, "negative offsets or limits are not allowed")
+				So(options, ShouldResemble, Options{})
+				So(len(httpClient.DoCalls()), ShouldEqual, 0)
 			})
 		})
 	})

--- a/filter/data.go
+++ b/filter/data.go
@@ -12,6 +12,15 @@ type DimensionOption struct {
 	Option              string `json:"option"`
 }
 
+// DimensionOptions represents a list of dimension options from the filter api
+type DimensionOptions struct {
+	Items      []DimensionOption `json:"items"`
+	Count      int               `json:"count"`
+	Offset     int               `json:"offset"`
+	Limit      int               `json:"limit"`
+	TotalCount int               `json:"total_count"`
+}
+
 // CreateBlueprint represents the fields required to create a filter blueprint
 type CreateBlueprint struct {
 	Dataset    Dataset          `json:"dataset"`

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -223,8 +223,12 @@ func (c *Client) GetDimensionsBytes(ctx context.Context, userAuthToken, serviceA
 }
 
 // GetDimensionOptions retrieves a list of the dimension options unmarshalled as an array of DimensionOption structs
-func (c *Client) GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (opts []DimensionOption, err error) {
-	b, err := c.GetDimensionOptionsBytes(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name)
+func (c *Client) GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, offset, limit int) (opts DimensionOptions, err error) {
+	if offset < 0 || limit < 0 {
+		return DimensionOptions{}, errors.New("negative offsets or limits are not allowed")
+	}
+
+	b, err := c.GetDimensionOptionsBytes(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, offset, limit)
 	if err != nil {
 		return opts, err
 	}
@@ -234,8 +238,8 @@ func (c *Client) GetDimensionOptions(ctx context.Context, userAuthToken, service
 }
 
 // GetDimensionOptionsBytes retrieves a list of the dimension options as a byte array
-func (c *Client) GetDimensionOptionsBytes(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) ([]byte, error) {
-	uri := fmt.Sprintf("%s/filters/%s/dimensions/%s/options", c.hcCli.URL, filterID, name)
+func (c *Client) GetDimensionOptionsBytes(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, offset, limit int) ([]byte, error) {
+	uri := fmt.Sprintf("%s/filters/%s/dimensions/%s/options?offset=%d&limit=%d", c.hcCli.URL, filterID, name, offset, limit)
 	clientlog.Do(ctx, "retrieving selected dimension options for filter job", service, uri)
 
 	resp, err := c.doGetWithAuthHeaders(ctx, userAuthToken, serviceAuthToken, collectionID, uri)


### PR DESCRIPTION
### What

- Modified dataset API client to support pagination for getOptions:
  - add limit and offset query params
  - modified returned model to include limit, offset, count and total count

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

Anyone