### PR TITLE
filter GetDimensions response is now mapped to the paginated struct

### DIFF
--- a/filter/data.go
+++ b/filter/data.go
@@ -1,5 +1,14 @@
 package filter
 
+// Dimensions represents a dimensions response from the filter api
+type Dimensions struct {
+	Items      []Dimension `json:"items"`
+	Count      int         `json:"count"`
+	Offset     int         `json:"offset"`
+	Limit      int         `json:"limit"`
+	TotalCount int         `json:"total_count"`
+}
+
 // Dimension represents a dimension response from the filter api
 type Dimension struct {
 	Name string `json:"name"`

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -242,12 +242,8 @@ func (c *Client) GetDimensionsBytes(ctx context.Context, userAuthToken, serviceA
 }
 
 // GetDimensionOptions retrieves a list of the dimension options unmarshalled as an array of DimensionOption structs
-func (c *Client) GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, offset, limit int) (opts DimensionOptions, err error) {
-	if offset < 0 || limit < 0 {
-		return DimensionOptions{}, errors.New("negative offsets or limits are not allowed")
-	}
-
-	b, err := c.GetDimensionOptionsBytes(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, offset, limit)
+func (c *Client) GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, q QueryParams) (opts DimensionOptions, err error) {
+	b, err := c.GetDimensionOptionsBytes(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, q)
 	if err != nil {
 		return opts, err
 	}
@@ -257,8 +253,12 @@ func (c *Client) GetDimensionOptions(ctx context.Context, userAuthToken, service
 }
 
 // GetDimensionOptionsBytes retrieves a list of the dimension options as a byte array
-func (c *Client) GetDimensionOptionsBytes(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, offset, limit int) ([]byte, error) {
-	uri := fmt.Sprintf("%s/filters/%s/dimensions/%s/options?offset=%d&limit=%d", c.hcCli.URL, filterID, name, offset, limit)
+func (c *Client) GetDimensionOptionsBytes(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, q QueryParams) ([]byte, error) {
+	if err := q.Validate(); err != nil {
+		return nil, err
+	}
+
+	uri := fmt.Sprintf("%s/filters/%s/dimensions/%s/options?offset=%d&limit=%d", c.hcCli.URL, filterID, name, q.Offset, q.Limit)
 	clientlog.Do(ctx, "retrieving selected dimension options for filter job", service, uri)
 
 	resp, err := c.doGetWithAuthHeaders(ctx, userAuthToken, serviceAuthToken, collectionID, uri)

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -366,7 +366,8 @@ func TestClient_GetDimensionOptions(t *testing.T) {
 		mockedAPI := getMockfilterAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 400, Body: ""})
 
 		Convey("then GetDimensionOptions returns the expected error", func() {
-			_, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name, offset, limit)
+			q := QueryParams{offset, limit}
+			_, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name, q)
 			So(err, ShouldResemble, &ErrInvalidFilterAPIResponse{
 				ActualCode:   400,
 				ExpectedCode: 200,
@@ -380,7 +381,8 @@ func TestClient_GetDimensionOptions(t *testing.T) {
 		mockedAPI.hcCli.Client.SetMaxRetries(2)
 
 		Convey("then GetDimensionOptions returns the expected error", func() {
-			_, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name, offset, limit)
+			q := QueryParams{offset, limit}
+			_, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name, q)
 			So(err, ShouldResemble, &ErrInvalidFilterAPIResponse{
 				ActualCode:   500,
 				ExpectedCode: 200,
@@ -393,7 +395,8 @@ func TestClient_GetDimensionOptions(t *testing.T) {
 		mockedAPI := getMockfilterAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 200, Body: dimensionBody})
 
 		Convey("then GetDimensionOptions returns the expected Options", func() {
-			opts, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name, offset, limit)
+			q := QueryParams{offset, limit}
+			opts, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name, q)
 			So(err, ShouldBeNil)
 			So(opts, ShouldResemble, DimensionOptions{
 				Items: []DimensionOption{
@@ -410,12 +413,14 @@ func TestClient_GetDimensionOptions(t *testing.T) {
 		})
 
 		Convey("then GetDimensionOptions returns the expected error when a negative offset is provided", func() {
-			_, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name, -1, limit)
+			q := QueryParams{-1, limit}
+			_, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name, q)
 			So(err.Error(), ShouldResemble, "negative offsets or limits are not allowed")
 		})
 
 		Convey("then GetDimensionOptions returns the expected error when a negative limit is provided", func() {
-			_, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name, offset, -1)
+			q := QueryParams{offset, -1}
+			_, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name, q)
 			So(err.Error(), ShouldResemble, "negative offsets or limits are not allowed")
 		})
 	})


### PR DESCRIPTION
### What

- Introduced Dimensions struct in filter client, to match the paginated response from filter API
- Used this struct as the return type for filter.GetDimensions
  - changed unit tests accordingly
- Use QueryParams struct to provide offset and limit to `GetDimensionOptions` and `GetDimensions`

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

Anyone