### PR TITLE
fixed wrong query parameter key (id instead of ids)

### DIFF
--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -753,7 +753,7 @@ func (c *Client) GetOptions(ctx context.Context, userAuthToken, serviceAuthToken
 
 	var uri string
 	if len(q.IDs) > 0 {
-		uri = fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s/dimensions/%s/options?ids=%s", c.hcCli.URL, id, edition, version, dimension, strings.Join(q.IDs, ","))
+		uri = fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s/dimensions/%s/options?id=%s", c.hcCli.URL, id, edition, version, dimension, strings.Join(q.IDs, ","))
 	} else {
 		uri = fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s/dimensions/%s/options?offset=%d&limit=%d", c.hcCli.URL, id, edition, version, dimension, q.Offset, q.Limit)
 	}

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -834,7 +834,7 @@ func TestClient_GetOptions(t *testing.T) {
 			})
 
 			Convey("and dphttpclient.Do is called 1 time with the expected URI, providing the list of IDs and no offset or limit", func() {
-				expectedURI := fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/dimensions/%s/options?ids=testOption,somethingElse",
+				expectedURI := fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/dimensions/%s/options?id=testOption,somethingElse",
 					instanceID, edition, version, dimension)
 				checkResponseBase(httpClient, http.MethodGet, expectedURI)
 			})


### PR DESCRIPTION
### What

-Bug fix: replaced query parameter to filter by id from `ids` to `id`

### How to review

- Make sure the `ids` query param key has been replaced with `id` (sanity check)
- Make sure unit tests pass

### Who can review

Anyone