### PR TITLE
Zebedee client can now be more configurable

### DIFF
--- a/zebedee/client.go
+++ b/zebedee/client.go
@@ -68,12 +68,8 @@ func New(zebedeeURL string) *Client {
 }
 
 // NewWithSetTimeoutAndMaxRetry creates a new Zebedee Client, with a configurable timeout and maximum number of retries
-func NewWithSetTimeoutAndMaxRetry(zebedeeURL string, timeout, retry int) *Client {
-	hcClienter := dphttp.NewClient()
-
-	hcClient := healthcheck.NewClientWithClienter(service, zebedeeURL, hcClienter)
-	hcClient.Client.SetTimeout(time.Duration(timeout) * time.Second)
-	hcClient.Client.SetMaxRetries(retry)
+func NewClientWithClienter(zebedeeURL string, clienter dphttp.Clienter) *Client {
+	hcClient := healthcheck.NewClientWithClienter(service, zebedeeURL, clienter)
 
 	return &Client{
 		hcClient,

--- a/zebedee/client.go
+++ b/zebedee/client.go
@@ -18,6 +18,7 @@ import (
 
 	healthcheck "github.com/ONSdigital/dp-api-clients-go/health"
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
+	dphttp "github.com/ONSdigital/dp-net/http"
 	dprequest "github.com/ONSdigital/dp-net/request"
 )
 
@@ -60,6 +61,19 @@ func New(zebedeeURL string) *Client {
 	}
 	hcClient := healthcheck.NewClient(service, zebedeeURL)
 	hcClient.Client.SetTimeout(time.Duration(timeout) * time.Second)
+
+	return &Client{
+		hcClient,
+	}
+}
+
+// NewWithSetTimeoutAndMaxRetry creates a new Zebedee Client, with a configurable timeout and maximum number of retries
+func NewWithSetTimeoutAndMaxRetry(zebedeeURL string, timeout, retry int) *Client {
+	hcClienter := dphttp.NewClient()
+
+	hcClient := healthcheck.NewClientWithClienter(service, zebedeeURL, hcClienter)
+	hcClient.Client.SetTimeout(time.Duration(timeout) * time.Second)
+	hcClient.Client.SetMaxRetries(retry)
 
 	return &Client{
 		hcClient,


### PR DESCRIPTION
### What

Timeout and maximum retries can now be set in the new constructor

#### Why is this needed?

Currently, there is an insane number of retries between the dp-frontend-router and Zebedee. From client level, web server level and platform level. As such we are able to remove the client level retries. Requests that are failing are staying open too long and this is hindering the dp-frontend-routers performance to the point it causes fall overs. This PR should help to address these issues in conjunction with other improvements.

### How to review

In dp-frontend-router or another service that uses this client run:
go mod edit -replace github.com/ONSdigital/dp-api-clients-go=/{path to your local dp-api-clients-go}

Replacing the {path to your local dp-api-clients-go} with your local path to your copy of the dp-api-clients-go directory.
Then checkout this PR branch.

Try a couple of pages of the website locally and ensure everything still works as expected.

To see how this might be used now in the future checkout this PR https://github.com/ONSdigital/dp-frontend-router/pull/247

### Who can review

Anyone except me
