### PR TITLE
As part of the query parameter validation, the provided IDs are escaped.

### DIFF
--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -91,13 +91,20 @@ type QueryParams struct {
 }
 
 // Validate validates tht no negative values are provided for limit or offset, and that the length of IDs is lower than the maximum
-func (q QueryParams) Validate() error {
+// Also escapes all IDs, so that they can be safely used as query paramters in requests
+func (q *QueryParams) Validate() error {
 	if q.Offset < 0 || q.Limit < 0 {
 		return errors.New("negative offsets or limits are not allowed")
 	}
+
 	if len(q.IDs) > MaxIDs() {
 		return fmt.Errorf("too many query parameters have been provided. Maximum allowed: %d", MaxIDs())
 	}
+
+	for i, id := range q.IDs {
+		q.IDs[i] = url.QueryEscape(id)
+	}
+
 	return nil
 }
 

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -799,7 +799,7 @@ func TestClient_GetOptions(t *testing.T) {
 		datasetClient := newDatasetClient(httpClient)
 
 		Convey("when GetOptions is called with valid values for limit and offset", func() {
-			q := QueryParams{offset, limit, []string{}}
+			q := QueryParams{Offset: offset, Limit: limit, IDs: []string{}}
 			options, err := datasetClient.GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, edition, version, dimension, q)
 
 			Convey("a positive response is returned, with the expected options", func() {
@@ -815,7 +815,7 @@ func TestClient_GetOptions(t *testing.T) {
 		})
 
 		Convey("when GetOptions is called with negative offset", func() {
-			q := QueryParams{-1, limit, []string{}}
+			q := QueryParams{Offset: -1, Limit: limit, IDs: []string{}}
 			options, err := datasetClient.GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, edition, version, dimension, q)
 
 			Convey("the expected error is returned and http dphttpclient.Do is not called", func() {
@@ -826,7 +826,7 @@ func TestClient_GetOptions(t *testing.T) {
 		})
 
 		Convey("when GetOptions is called with negative limit", func() {
-			q := QueryParams{offset, -1, []string{}}
+			q := QueryParams{Offset: offset, Limit: -1, IDs: []string{}}
 			options, err := datasetClient.GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, edition, version, dimension, q)
 
 			Convey("the expected error is returned and http dphttpclient.Do is not called", func() {
@@ -837,7 +837,7 @@ func TestClient_GetOptions(t *testing.T) {
 		})
 
 		Convey("when GetOptions is called with a list of IDs containing an existing ID, along with offset and limit", func() {
-			q := QueryParams{offset, limit, []string{"testOption", "somethingElse"}}
+			q := QueryParams{Offset: offset, Limit: limit, IDs: []string{"testOption", "somethingElse"}}
 			options, err := datasetClient.GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, edition, version, dimension, q)
 
 			Convey("a positive response is returned, with the expected options", func() {
@@ -853,7 +853,7 @@ func TestClient_GetOptions(t *testing.T) {
 		})
 
 		Convey("when GetOptions is called with a list of IDs containing an option with special characters", func() {
-			q := QueryParams{offset, limit, []string{"90+"}}
+			q := QueryParams{Offset: offset, Limit: limit, IDs: []string{"90+"}}
 			options, err := datasetClient.GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, edition, version, dimension, q)
 
 			Convey("a positive response is returned, with the expected options", func() {
@@ -869,7 +869,7 @@ func TestClient_GetOptions(t *testing.T) {
 		})
 
 		Convey("when GetOptions is called with a list of IDs containing more items than the maximum allowed", func() {
-			q := QueryParams{offset, limit, []string{"op1", "op2", "op3", "op4", "op5", "op6"}}
+			q := QueryParams{Offset: offset, Limit: limit, IDs: []string{"op1", "op2", "op3", "op4", "op5", "op6"}}
 			options, err := datasetClient.GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, edition, version, dimension, q)
 
 			Convey("an error is returned, with the expected options", func() {
@@ -888,7 +888,7 @@ func TestClient_GetOptions(t *testing.T) {
 		datasetClient := newDatasetClient(httpClient)
 
 		Convey("when GetOptions is called", func() {
-			q := QueryParams{offset, limit, []string{}}
+			q := QueryParams{Offset: offset, Limit: limit, IDs: []string{}}
 			options, err := datasetClient.GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, edition, version, dimension, q)
 
 			Convey("the expected error response is returned, with an empty options struct", func() {

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -784,11 +784,16 @@ func TestClient_GetOptions(t *testing.T) {
 					Label:       "optionLabel",
 					Option:      "testOption",
 				},
+				{
+					DimensionID: dimension,
+					Label:       "OptionWithSpecialChars",
+					Option:      "90+",
+				},
 			},
-			Count:      1,
+			Count:      2,
 			Offset:     offset,
 			Limit:      limit,
-			TotalCount: 1,
+			TotalCount: 3,
 		}
 		httpClient := createHTTPClientMock(MockedHTTPResponse{http.StatusOK, testOptions})
 		datasetClient := newDatasetClient(httpClient)
@@ -842,6 +847,22 @@ func TestClient_GetOptions(t *testing.T) {
 
 			Convey("and dphttpclient.Do is called 1 time with the expected URI, providing the list of IDs and no offset or limit", func() {
 				expectedURI := fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/dimensions/%s/options?id=testOption,somethingElse",
+					instanceID, edition, version, dimension)
+				checkResponseBase(httpClient, http.MethodGet, expectedURI)
+			})
+		})
+
+		Convey("when GetOptions is called with a list of IDs containing an option with special characters", func() {
+			q := QueryParams{offset, limit, []string{"90+"}}
+			options, err := datasetClient.GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, edition, version, dimension, q)
+
+			Convey("a positive response is returned, with the expected options", func() {
+				So(err, ShouldBeNil)
+				So(options, ShouldResemble, testOptions)
+			})
+
+			Convey("and dphttpclient.Do is called 1 time with the expected URI, providing the list of escaped IDs as query paramters", func() {
+				expectedURI := fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/dimensions/%s/options?id=90%%2B",
 					instanceID, edition, version, dimension)
 				checkResponseBase(httpClient, http.MethodGet, expectedURI)
 			})

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -388,7 +388,7 @@ func TestClient_GetDimensions(t *testing.T) {
 		mockedAPI := getMockfilterAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 200, Body: dimensionBody})
 
 		Convey("Then a request with valid query parameterse returns the expected Dimensions struct", func() {
-			q := QueryParams{1, 10}
+			q := QueryParams{Offset: 1, Limit: 10}
 			dims, err := mockedAPI.GetDimensions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, q)
 			So(err, ShouldBeNil)
 			So(dims, ShouldResemble, Dimensions{
@@ -403,13 +403,13 @@ func TestClient_GetDimensions(t *testing.T) {
 		})
 
 		Convey("Then a request with invalid offset query paratmers returns a validation error", func() {
-			q := QueryParams{-1, 0}
+			q := QueryParams{Offset: -1, Limit: 0}
 			_, err := mockedAPI.GetDimensions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, q)
 			So(err.Error(), ShouldResemble, "negative offsets or limits are not allowed")
 		})
 
 		Convey("Then a request with invalid limit query paratmers returns a validation error", func() {
-			q := QueryParams{0, -1}
+			q := QueryParams{Offset: 0, Limit: -1}
 			_, err := mockedAPI.GetDimensions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, q)
 			So(err.Error(), ShouldResemble, "negative offsets or limits are not allowed")
 		})
@@ -429,7 +429,7 @@ func TestClient_GetDimensionOptions(t *testing.T) {
 		mockedAPI := getMockfilterAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 400, Body: ""})
 
 		Convey("then GetDimensionOptions returns the expected error", func() {
-			q := QueryParams{offset, limit}
+			q := QueryParams{Offset: offset, Limit: limit}
 			_, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name, q)
 			So(err, ShouldResemble, &ErrInvalidFilterAPIResponse{
 				ActualCode:   400,
@@ -447,7 +447,7 @@ func TestClient_GetDimensionOptions(t *testing.T) {
 		mockedAPI.hcCli.Client.SetMaxRetries(2)
 
 		Convey("then GetDimensionOptions returns the expected error", func() {
-			q := QueryParams{offset, limit}
+			q := QueryParams{Offset: offset, Limit: limit}
 			_, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name, q)
 			So(err, ShouldResemble, &ErrInvalidFilterAPIResponse{
 				ActualCode:   500,
@@ -464,7 +464,7 @@ func TestClient_GetDimensionOptions(t *testing.T) {
 		mockedAPI.hcCli.Client.SetMaxRetries(2)
 
 		Convey("then GetDimensionOptions returns the expected Options", func() {
-			q := QueryParams{offset, limit}
+			q := QueryParams{Offset: offset, Limit: limit}
 			opts, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name, q)
 			So(err, ShouldBeNil)
 			So(opts, ShouldResemble, DimensionOptions{
@@ -486,7 +486,7 @@ func TestClient_GetDimensionOptions(t *testing.T) {
 		mockedAPI := getMockfilterAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 200, Body: dimensionBody})
 
 		Convey("then GetDimensionOptions returns the expected Options", func() {
-			q := QueryParams{offset, limit}
+			q := QueryParams{Offset: offset, Limit: limit}
 			opts, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name, q)
 			So(err, ShouldBeNil)
 			So(opts, ShouldResemble, DimensionOptions{
@@ -504,13 +504,13 @@ func TestClient_GetDimensionOptions(t *testing.T) {
 		})
 
 		Convey("then GetDimensionOptions returns the expected error when a negative offset is provided", func() {
-			q := QueryParams{-1, limit}
+			q := QueryParams{Offset: -1, Limit: limit}
 			_, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name, q)
 			So(err.Error(), ShouldResemble, "negative offsets or limits are not allowed")
 		})
 
 		Convey("then GetDimensionOptions returns the expected error when a negative limit is provided", func() {
-			q := QueryParams{offset, -1}
+			q := QueryParams{Offset: offset, Limit: -1}
 			_, err := mockedAPI.GetDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterOutputID, name, q)
 			So(err.Error(), ShouldResemble, "negative offsets or limits are not allowed")
 		})


### PR DESCRIPTION
### What

We identified a bug in develop, where some dimension options failed to be added to filters. After some investigation, we found that the issue was with URL encoding of IDs passed as query parameters when we were validating them.

This PR fixes this bug by escaping all the IDs as part of the query param validation.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass and cover the new functionality

### Who can review

Anyone