### PR TITLE
Add error field to image api model

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright ©‎ 2018, Crown Copyright (Office for National Statistics)
+Copyright ©‎ 2021, Crown Copyright (Office for National Statistics)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,6 @@ Run tests using `make test`
 
 ## Licence
 
-Copyright ©‎ 2019, Crown Copyright (Office for National Statistics) (https://www.ons.gov.uk)
+Copyright ©‎ 2021, Crown Copyright (Office for National Statistics) (https://www.ons.gov.uk)
 
 Released under MIT license, see [LICENSE](LICENSE.md) for details.

--- a/image/data.go
+++ b/image/data.go
@@ -41,6 +41,7 @@ type Image struct {
 	//- deleted
 	//- failed_import
 	//- failed_publish
+	Error    string      `json:"error,omitempty"`
 	Filename string      `json:"filename,omitempty"`
 	License  License     `json:"license,omitempty"`
 	Links    *ImageLinks `json:"links,omitempty"`


### PR DESCRIPTION
### What

Add an error field to the image model (similar to the one in the ImageDownload model). This means that when the image import/publish fail, a descriptive reason can be supplied as well. This requires a correlating change in `dp-image-api` (https://github.com/ONSdigital/dp-image-api/pull/47) 

### How to review

Ensure the new field has been added.

### Who can review

Anyone but me.
