### PR TITLE
Undid the query paramter escaping, as this needs to be service specific.

### DIFF
--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -101,10 +101,6 @@ func (q *QueryParams) Validate() error {
 		return fmt.Errorf("too many query parameters have been provided. Maximum allowed: %d", MaxIDs())
 	}
 
-	for i, id := range q.IDs {
-		q.IDs[i] = url.QueryEscape(id)
-	}
-
 	return nil
 }
 

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -891,22 +891,6 @@ func TestClient_GetOptions(t *testing.T) {
 			})
 		})
 
-		Convey("when GetOptions is called with a list of IDs containing an option with special characters", func() {
-			q := QueryParams{Offset: offset, Limit: limit, IDs: []string{"90+"}}
-			options, err := datasetClient.GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, edition, version, dimension, q)
-
-			Convey("a positive response is returned, with the expected options", func() {
-				So(err, ShouldBeNil)
-				So(options, ShouldResemble, testOptions)
-			})
-
-			Convey("and dphttpclient.Do is called 1 time with the expected URI, providing the list of escaped IDs as query paramters", func() {
-				expectedURI := fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/dimensions/%s/options?id=90%%2B",
-					instanceID, edition, version, dimension)
-				checkResponseBase(httpClient, http.MethodGet, expectedURI)
-			})
-		})
-
 		Convey("when GetOptions is called with a list of IDs containing more items than the maximum allowed", func() {
 			q := QueryParams{Offset: offset, Limit: limit, IDs: []string{"op1", "op2", "op3", "op4", "op5", "op6"}}
 			options, err := datasetClient.GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, edition, version, dimension, q)


### PR DESCRIPTION
### What

Undid the query parameter escaping because some services need it but not others.

### How to review

Make sure only the encoding and test have been removed

### Who can review

anyone