### PR TITLE
Fix zebedee add to collection methods and add new update instance model

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -64,6 +64,24 @@ type Version struct {
 	CSVHeader            []string             `json:"headers,omitempty"`
 }
 
+type UpdateInstance struct {
+	Alerts               *[]Alert             `json:"alerts"`
+	CollectionID         string               `json:"collection_id"`
+	Downloads            map[string]Download  `json:"downloads"`
+	Edition              string               `json:"edition"`
+	Dimensions           []VersionDimension   `json:"dimensions"`
+	ID                   string               `json:"id"`
+	InstanceID           string               `json:"instance_id"`
+	LatestChanges        []Change             `json:"latest_changes"`
+	ReleaseDate          string               `json:"release_date"`
+	State                string               `json:"state"`
+	Temporal             []Temporal           `json:"temporal"`
+	Version              int                  `json:"version"`
+	NumberOfObservations int64                `json:"total_observations,omitempty"`
+	ImportTasks          *InstanceImportTasks `json:"import_tasks,omitempty"`
+	CSVHeader            []string             `json:"headers,omitempty"`
+}
+
 // VersionDimension represents a dimension model nested in the Version model
 type VersionDimension struct {
 	ID          string `json:"id"`

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -535,7 +535,7 @@ func (c *Client) GetInstances(ctx context.Context, userAuthToken, serviceAuthTok
 }
 
 // PutInstance updates an instance
-func (c *Client) PutInstance(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, instanceID string, i Instance) error {
+func (c *Client) PutInstance(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, instanceID string, i UpdateInstance) error {
 	uri := fmt.Sprintf("%s/instances/%s", c.hcCli.URL, instanceID)
 
 	clientlog.Do(ctx, "updating dataset version", service, uri)

--- a/zebedee/client.go
+++ b/zebedee/client.go
@@ -341,6 +341,7 @@ func (c *Client) PutDatasetVersionInCollection(ctx context.Context, userAccessTo
 	uri := fmt.Sprintf("%s/collections/%s/datasets/%s/editions/%s/versions/%s", c.hcCli.URL, collectionID, datasetID, edition, version)
 
 	zebedeeState := CollectionState{State: state}
+	payload, err := json.Marshal(zebedeeState)
 	if err != nil {
 		return errors.Wrap(err, "error while attempting to marshall version")
 	}

--- a/zebedee/client.go
+++ b/zebedee/client.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
 
 	healthcheck "github.com/ONSdigital/dp-api-clients-go/health"
@@ -326,7 +325,6 @@ func (c *Client) PutDatasetInCollection(ctx context.Context, userAccessToken, co
 
 	zebedeeState := CollectionState{State: state}
 	payload, err := json.Marshal(zebedeeState)
-	spew.Dump(zebedeeState)
 	if err != nil {
 		return errors.Wrap(err, "error while attempting to marshall version")
 	}
@@ -343,8 +341,6 @@ func (c *Client) PutDatasetVersionInCollection(ctx context.Context, userAccessTo
 	uri := fmt.Sprintf("%s/collections/%s/datasets/%s/editions/%s/versions/%s", c.hcCli.URL, collectionID, datasetID, edition, version)
 
 	zebedeeState := CollectionState{State: state}
-	payload, err := json.Marshal(zebedeeState)
-	spew.Dump(zebedeeState)
 	if err != nil {
 		return errors.Wrap(err, "error while attempting to marshall version")
 	}

--- a/zebedee/client.go
+++ b/zebedee/client.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
 
 	healthcheck "github.com/ONSdigital/dp-api-clients-go/health"
@@ -323,7 +324,9 @@ func (c *Client) GetTimeseriesMainFigure(ctx context.Context, userAccessToken, c
 func (c *Client) PutDatasetInCollection(ctx context.Context, userAccessToken, collectionID, lang, datasetID, state string) error {
 	uri := fmt.Sprintf("%s/collections/%s/datasets/%s", c.hcCli.URL, collectionID, datasetID)
 
-	payload, err := json.Marshal(state)
+	zebedeeState := CollectionState{State: state}
+	payload, err := json.Marshal(zebedeeState)
+	spew.Dump(zebedeeState)
 	if err != nil {
 		return errors.Wrap(err, "error while attempting to marshall version")
 	}
@@ -339,7 +342,9 @@ func (c *Client) PutDatasetInCollection(ctx context.Context, userAccessToken, co
 func (c *Client) PutDatasetVersionInCollection(ctx context.Context, userAccessToken, collectionID, lang, datasetID, edition, version, state string) error {
 	uri := fmt.Sprintf("%s/collections/%s/datasets/%s/editions/%s/versions/%s", c.hcCli.URL, collectionID, datasetID, edition, version)
 
-	payload, err := json.Marshal(state)
+	zebedeeState := CollectionState{State: state}
+	payload, err := json.Marshal(zebedeeState)
+	spew.Dump(zebedeeState)
 	if err != nil {
 		return errors.Wrap(err, "error while attempting to marshall version")
 	}

--- a/zebedee/data.go
+++ b/zebedee/data.go
@@ -190,5 +190,5 @@ type CollectionItem struct {
 }
 
 type CollectionState struct {
-	State string `json: state`
+	State string `json:"state"`
 }


### PR DESCRIPTION
### What

- Fix Zebedee add to collection methods. Was marshalling state as a string rather than an object
- Add new update instance model. PUTting an instance doesn't allow some fields, so a custom update model has been added so as not to break backwards compatibility. A task has been added to look at consolidating models where possible

### Who can review

Anyone
