### PR TITLE
rename search-query client to search-api client

### DIFF
--- a/site-search/data.go
+++ b/site-search/data.go
@@ -1,6 +1,6 @@
 package search
 
-// Response represents the fields for the search results as returned by dp-search-query
+// Response represents the fields for the search results as returned by dp-search-api
 type Response struct {
 	Count        int           `json:"count"`
 	ContentTypes []ContentType `json:"content_types"`

--- a/site-search/site-search.go
+++ b/site-search/site-search.go
@@ -4,19 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
 	"github.com/ONSdigital/dp-api-clients-go/clientlog"
 	healthcheck "github.com/ONSdigital/dp-api-clients-go/health"
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dphttp "github.com/ONSdigital/dp-net/http"
 	"github.com/ONSdigital/log.go/log"
-	"io/ioutil"
-	"net/http"
-	"net/url"
 )
 
-const service = "search-query"
+const service = "search-api"
 
-// ErrInvalidSearchResponse is returned when the dp-search-query does not respond
+// ErrInvalidSearchResponse is returned when the dp-search-api does not respond
 // with a valid status
 type ErrInvalidSearchResponse struct {
 	expectedCode int
@@ -26,14 +27,14 @@ type ErrInvalidSearchResponse struct {
 
 // Error should be called by the user to print out the stringified version of the error
 func (e ErrInvalidSearchResponse) Error() string {
-	return fmt.Sprintf("invalid response from dp-search-query - should be: %d, got: %d, path: %s",
+	return fmt.Sprintf("invalid response from dp-search-api - should be: %d, got: %d, path: %s",
 		e.expectedCode,
 		e.actualCode,
 		e.uri,
 	)
 }
 
-// Code returns the status code received from dp-search-query if an error is returned
+// Code returns the status code received from dp-search-api if an error is returned
 func (e ErrInvalidSearchResponse) Code() int {
 	return e.actualCode
 }
@@ -41,13 +42,13 @@ func (e ErrInvalidSearchResponse) Code() int {
 // compile time check that ErrInvalidSearchResponse satisfies the error interface
 var _ error = ErrInvalidSearchResponse{}
 
-// Client is a dp-search-query client which can be used to make requests to the server
+// Client is a dp-search-api client which can be used to make requests to the server
 type Client struct {
 	cli dphttp.Clienter
 	url string
 }
 
-// NewClient creates a new instance of Client with a given search-query api url
+// NewClient creates a new instance of Client with a given search-api url
 func NewClient(searchAPIURL string) *Client {
 	hcClient := healthcheck.NewClient(service, searchAPIURL)
 
@@ -90,8 +91,8 @@ func (c *Client) doGetWithAuthHeaders(ctx context.Context, uri string) (*http.Re
 func NewSearchErrorResponse(resp *http.Response, uri string) (e *ErrInvalidSearchResponse) {
 	return &ErrInvalidSearchResponse{
 		expectedCode: http.StatusOK,
-		actualCode: resp.StatusCode,
-		uri:        uri,
+		actualCode:   resp.StatusCode,
+		uri:          uri,
 	}
 }
 

--- a/site-search/site-search_test.go
+++ b/site-search/site-search_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	testHost         = "http://localhost:8080"
+	testHost = "http://localhost:8080"
 )
 
 var (
@@ -227,7 +227,7 @@ func TestClient_GetSearch(t *testing.T) {
 			_, err := cli.GetSearch(ctx, v)
 
 			Convey("then the expected error is returned", func() {
-				So(err.Error(), ShouldResemble, errors.Errorf("invalid response from dp-search-query - should be: 200, got: 400, path: "+testHost+"/search?limit=a").Error())
+				So(err.Error(), ShouldResemble, errors.Errorf("invalid response from dp-search-api - should be: 200, got: 400, path: "+testHost+"/search?limit=a").Error())
 
 			})
 
@@ -247,7 +247,7 @@ func TestClient_GetSearch(t *testing.T) {
 			_, err := cli.GetSearch(ctx, v)
 
 			Convey("then the expected error is returned", func() {
-				So(err.Error(), ShouldResemble, errors.Errorf("invalid response from dp-search-query - should be: 200, got: 500, path: "+testHost+"/search?limit=housing").Error())
+				So(err.Error(), ShouldResemble, errors.Errorf("invalid response from dp-search-api - should be: 200, got: 500, path: "+testHost+"/search?limit=housing").Error())
 
 			})
 
@@ -257,4 +257,3 @@ func TestClient_GetSearch(t *testing.T) {
 		})
 	})
 }
-


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Rename `search-query` client to `search-api` client

### How to review
**Describe the steps required to test the changes.**
- Check if there are any references to `dp-search-query`

### Who can review
**Describe who worked on the changes, so that other people can review.**
Anyone