### PR TITLE
Nomis datasets added

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -18,6 +18,7 @@ type DatasetDetails struct {
 	Methodologies     *[]Methodology    `json:"methodologies,omitempty"`
 	NationalStatistic bool              `json:"national_statistic,omitempty"`
 	NextRelease       string            `json:"next_release,omitempty"`
+	NomisReferenceURL string            `json:"nomis_reference_url,omitempty"`
 	Publications      *[]Publication    `json:"publications,omitempty"`
 	Publisher         *Publisher        `json:"publisher,omitempty"`
 	QMI               Publication       `json:"qmi,omitempty"`
@@ -26,6 +27,7 @@ type DatasetDetails struct {
 	State             string            `json:"state,omitempty"`
 	Theme             string            `json:"theme,omitempty"`
 	Title             string            `json:"title,omitempty"`
+	Type              string            `json:"type,omitempty"`
 	UnitOfMeasure     string            `json:"unit_of_measure,omitempty"`
 	URI               string            `json:"uri,omitempty"`
 	UsageNotes        *[]UsageNote      `json:"usage_notes,omitempty"`
@@ -62,6 +64,7 @@ type Version struct {
 	NumberOfObservations int64                `json:"total_observations,omitempty"`
 	ImportTasks          *InstanceImportTasks `json:"import_tasks,omitempty"`
 	CSVHeader            []string             `json:"headers,omitempty"`
+	UsageNotes           *[]UsageNote         `json:"usage_notes,omitempty"`
 }
 
 type UpdateInstance struct {


### PR DESCRIPTION
### What

Nomis Metadata for datasets are now loadable and presentable on the website (note the user is directed to Nomis for the dataset contents).

It should look something like this:

<img width="510" alt="Screenshot 2021-02-15 at 14 45 29" src="https://user-images.githubusercontent.com/47502916/107960552-b3611f00-6f9c-11eb-9b2a-e0ea8ebc17b7.png">


### How to review

First things first you will need Nomis datasets locally
You will need to navigate in terminal to your local `dp-dataset-api` ensure you have the latest version on the develop branch. Then run `make Nomis` this command will populate your local MongoDB instance with new datasets. These are stored in a similar way to CMD datasets.

You will then need to pull the following locally:
- https://github.com/ONSdigital/dp-frontend-models/pull/86
- https://github.com/ONSdigital/dp-api-clients-go/pull/98
- https://github.com/ONSdigital/dp-frontend-dataset-controller/pull/204
- https://github.com/ONSdigital/dp-frontend-renderer/pull/566

Note that the dataset-controller and renderer will have to have one more update where they use the latest models and dp-api-clients-go, however, they can't use that until those PRs are approved.

In the `dp-frontend-renderer` you will need to add the following to the bottom of your go.mod file

``` go
replace github.com/ONSdigital/dp-api-clients-go => /{local/path/to/}/dp-api-clients-go
```

In the `dp-frontend-dataset-controller` you will need to add the following in the bottom of your go.mod file
```go
replace github.com/ONSdigital/dp-api-clients-go =>  /{local/path/to/}/dp-api-clients-go

replace github.com/ONSdigital/dp-frontend-models => /{local/path/to/}/dp-frontend-models
``` 

You can now check that the Nomis datasets and CMD datasets are working correctly.
A Nomis dataset URL is the same as a CMD one like the following:
`/datasets/NM_144_1/editions/2011/versions/1`

To find a Nomis dataset name the easiest way is to open Robo 3T then under new connection navigate to datasets then collections double click datasets. Replace the 'NM_144_1' with a dataset name in this list, note you will see a mix of CMD and Nomis ones, the Nomis ones all start with 'NM'.


Note there are some issues with the Nomis dataset templates which are going to be resolved on the scraper side there are currently tickets open for these as a separate task. These are:
- Release date in the wrong format
- Usage notes not using correct markdown.
We are changing these on the scraper side rather than the frontend side so that our API users can also benefit from the fix.

There is also a version list page which contains just one entry (the current version of each edition of Nomis. This also has the same issue with the 'date' displaying wrong.

Another thing to note is that the Nomis template file is not reusing the filter landing page template. This is because the future design for the Nomis dataset page looks vastly different to the current CMD one, as such by putting in minor changes on every other line the template file would get into a mess. In addition, the CMD dataset pages are going to get a new design soon too. If they both end up looking similar in the end then we can merge them back together. But, for now, these are two separate dataset landing pages.

### Who can review

Anyone except me
