### PR TITLE
Add pagination support for the `/datasets` endpoint

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -43,7 +43,11 @@ type Dataset struct {
 
 // List represents an object containing a list of datasets
 type List struct {
-	Items []Dataset `json:"items"`
+	Items      []Dataset `json:"items"`
+	Count      int       `json:"count"`
+	Offset     int       `json:"offset"`
+	Limit      int       `json:"limit"`
+	TotalCount int       `json:"total_count"`
 }
 
 // Version represents a version within a dataset


### PR DESCRIPTION
### What
Add pagination support for the `/datasets` endpoint
- Added parameter to the original `getDatasets` function, allowing pagination parameters to be passed in.
- Added a new function `GetDatasetsInBatches`, which gathers all the pages of datasets and returns the entire list. 

### How to review
Review changes / tests

### Who can review
Anyone
