### PR TITLE
Fixed Get instance dimensions when providing query parameters

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -1,6 +1,7 @@
 package batch
 
 import (
+	"errors"
 	"sync"
 	"time"
 )
@@ -13,6 +14,21 @@ type GenericBatchProcessor func(batch interface{}, batchETag string) (abort bool
 
 // ProcessInConcurrentBatches is a generic method to concurrently obtain some resource in batches and then process each batch
 func ProcessInConcurrentBatches(getBatch GenericBatchGetter, processBatch GenericBatchProcessor, batchSize, maxWorkers int) (err error) {
+
+	// validate paramters
+	if getBatch == nil {
+		return errors.New("getBatch function cannot be nil")
+	}
+	if processBatch == nil {
+		return errors.New("processBatch function cannot be nil")
+	}
+	if batchSize <= 0 {
+		return errors.New("batchSize must be a positive value")
+	}
+	if maxWorkers <= 0 {
+		return errors.New("maxWorkers must be a positive value")
+	}
+
 	wg := sync.WaitGroup{}
 	chWait := make(chan struct{})
 	chErr := make(chan error, maxWorkers)
@@ -127,6 +143,18 @@ func ProcessInConcurrentBatches(getBatch GenericBatchGetter, processBatch Generi
 
 // ProcessInBatches is a generic method that splits the provided items in batches and calls processBatch for each batch
 func ProcessInBatches(items []string, processBatch func([]string) error, batchSize int) (processedBatches int, err error) {
+
+	// validate paramters
+	if items == nil {
+		return 0, errors.New("items cannot be nil")
+	}
+	if processBatch == nil {
+		return 0, errors.New("processBatch cannot be nil")
+	}
+	if batchSize <= 0 {
+		return 0, errors.New("batchSize must be a positive value")
+	}
+
 	// Get batch splits for provided items
 	numFullChunks := len(items) / batchSize
 	remainingSize := len(items) % batchSize

--- a/batch/batch_test.go
+++ b/batch/batch_test.go
@@ -195,6 +195,37 @@ func TestProcessInConcurrentBatches(t *testing.T) {
 				So(eTags, ShouldResemble, []string{testETag, testETag, testETag})
 			})
 		})
+
+		Convey("And some testing parameters", func() {
+			batchSize := 10
+			maxWorkers := 1
+			getter := batchGetter(batchSize, []error{nil})
+			processor := batchProcessor([]bool{false}, []error{nil})
+
+			Convey("Then calling ProcessInConcurrentBatches with a nil getBatch function results in the expected error error being returned", func() {
+				err := ProcessInConcurrentBatches(nil, processor, batchSize, maxWorkers)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "getBatch function cannot be nil")
+			})
+
+			Convey("Then calling ProcessInConcurrentBatches with a nil processBatch function results in the expected error error being returned", func() {
+				err := ProcessInConcurrentBatches(getter, nil, batchSize, maxWorkers)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "processBatch function cannot be nil")
+			})
+
+			Convey("Then calling ProcessInConcurrentBatches with a zero batchSize results in the expected error error being returned", func() {
+				err := ProcessInConcurrentBatches(getter, processor, 0, maxWorkers)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "batchSize must be a positive value")
+			})
+
+			Convey("Then calling ProcessInConcurrentBatches with zero maxWorkers results in the expected error error being returned", func() {
+				err := ProcessInConcurrentBatches(getter, processor, batchSize, 0)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "maxWorkers must be a positive value")
+			})
+		})
 	})
 }
 
@@ -226,6 +257,27 @@ func TestProcessInBatches(t *testing.T) {
 				{"3", "4", "5"},
 				{"6", "7", "8"},
 				{"9"}})
+		})
+
+		Convey("Then calling ProcessInBatches nil items results in the expected error error being returned", func() {
+			numChunks, err := ProcessInBatches(nil, processor, 10)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "items cannot be nil")
+			So(numChunks, ShouldEqual, 0)
+		})
+
+		Convey("Then calling ProcessInBatches a nil processor function results in the expected error error being returned", func() {
+			numChunks, err := ProcessInBatches(items, nil, 10)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "processBatch cannot be nil")
+			So(numChunks, ShouldEqual, 0)
+		})
+
+		Convey("Then calling ProcessInBatches zero batchSize results in the expected error error being returned", func() {
+			numChunks, err := ProcessInBatches(items, processor, 0)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "batchSize must be a positive value")
+			So(numChunks, ShouldEqual, 0)
 		})
 	})
 }

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -609,12 +609,18 @@ func (c *Client) GetInstanceBytes(ctx context.Context, userAuthToken, serviceAut
 }
 
 // GetInstanceDimensionsBytes returns a list of dimensions for an instance as bytes from the dataset api
-func (c *Client) GetInstanceDimensionsBytes(ctx context.Context, userAuthToken, serviceAuthToken, instanceID string) (b []byte, err error) {
+func (c *Client) GetInstanceDimensionsBytes(ctx context.Context, serviceAuthToken, instanceID string, q *QueryParams) (b []byte, err error) {
 	uri := fmt.Sprintf("%s/instances/%s/dimensions", c.hcCli.URL, instanceID)
+	if q != nil {
+		if err := q.Validate(); err != nil {
+			return []byte{}, err
+		}
+		uri = fmt.Sprintf("%s?offset=%d&limit=%d", uri, q.Offset, q.Limit)
+	}
 
 	clientlog.Do(ctx, "retrieving instance dimensions", service, uri)
 
-	resp, err := c.doGetWithAuthHeaders(ctx, userAuthToken, serviceAuthToken, "", uri, nil)
+	resp, err := c.doGetWithAuthHeaders(ctx, "", serviceAuthToken, "", uri, nil)
 	if err != nil {
 		return
 	}
@@ -821,17 +827,7 @@ func (c *Client) UpdateInstanceWithNewInserts(ctx context.Context, serviceAuthTo
 
 // GetInstanceDimensions performs a 'GET /instances/<id>/dimensions' and returns the marshalled Dimensions struct
 func (c *Client) GetInstanceDimensions(ctx context.Context, serviceAuthToken, instanceID string, q *QueryParams) (m Dimensions, err error) {
-	uri := fmt.Sprintf("%s/instances/%s/dimensions", c.hcCli.URL, instanceID)
-	if q != nil {
-		if err := q.Validate(); err != nil {
-			return Dimensions{}, err
-		}
-		uri = fmt.Sprintf("%s?offset=%d&limit=%d", uri, q.Offset, q.Limit)
-	}
-
-	clientlog.Do(ctx, "retrieving instance dimensions", service, uri)
-
-	b, err := c.GetInstanceDimensionsBytes(ctx, "", serviceAuthToken, instanceID)
+	b, err := c.GetInstanceDimensionsBytes(ctx, serviceAuthToken, instanceID, q)
 	if err != nil {
 		return
 	}
@@ -840,7 +836,7 @@ func (c *Client) GetInstanceDimensions(ctx context.Context, serviceAuthToken, in
 	return
 }
 
-func (c *Client) GetInstanceDimensionsInBatches(ctx context.Context, userAuthToken, serviceAuthToken, instanceID string, batchSize, maxWorkers int) (dimensions Dimensions, err error) {
+func (c *Client) GetInstanceDimensionsInBatches(ctx context.Context, serviceAuthToken, instanceID string, batchSize, maxWorkers int) (dimensions Dimensions, err error) {
 
 	// Function to aggregate items.
 	// For the first received batch, as we have the total count information, will initialise the final structure of items with a fixed size equal to TotalCount.
@@ -860,7 +856,7 @@ func (c *Client) GetInstanceDimensionsInBatches(ctx context.Context, userAuthTok
 	}
 
 	// call dataset API GetInstanceDimensions in batches and aggregate the responses
-	if err := c.GetInstanceDimensionsBatchProcess(ctx, userAuthToken, serviceAuthToken, instanceID, processBatch, batchSize, maxWorkers); err != nil {
+	if err := c.GetInstanceDimensionsBatchProcess(ctx, serviceAuthToken, instanceID, processBatch, batchSize, maxWorkers); err != nil {
 		return Dimensions{}, err
 	}
 
@@ -868,7 +864,7 @@ func (c *Client) GetInstanceDimensionsInBatches(ctx context.Context, userAuthTok
 }
 
 // GetInstanceDimensionsBatchProcess gets the instance dimensions from the dataset API in batches, calling the provided function for each batch.
-func (c *Client) GetInstanceDimensionsBatchProcess(ctx context.Context, userAuthToken, serviceAuthToken, instanceID string, processBatch InstanceDimensionsBatchProcessor, batchSize, maxWorkers int) error {
+func (c *Client) GetInstanceDimensionsBatchProcess(ctx context.Context, serviceAuthToken, instanceID string, processBatch InstanceDimensionsBatchProcessor, batchSize, maxWorkers int) error {
 
 	// for each batch, obtain the dimensions starting at the provided offset, with a batch size limit
 	batchGetter := func(offset int) (interface{}, int, string, error) {

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -613,7 +613,7 @@ func (c *Client) GetInstanceDimensionsBytes(ctx context.Context, serviceAuthToke
 	uri := fmt.Sprintf("%s/instances/%s/dimensions", c.hcCli.URL, instanceID)
 	if q != nil {
 		if err := q.Validate(); err != nil {
-			return []byte{}, err
+			return nil, err
 		}
 		uri = fmt.Sprintf("%s?offset=%d&limit=%d", uri, q.Offset, q.Limit)
 	}


### PR DESCRIPTION
### What

Bugfix: Get Instance Dimensions was not passing the query paramters to the request - this is currently affecting dimension-importer in develop.

- Fix the bug
- Added unit tests
- Added param validation for batch processing functions, to prevent any panic on invalid situations.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- (info only) I tested the changes by creating a real client, with a connection against my local dataset API.

### Who can review

Anyone