### PR TITLE
Update documentation link to health package to be relative link

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Instead of aggregating the results, you may want to perform some different logic
 
 ## Package docs
 
-* [health](https://github.com/ONSdigital/dp-api-clients-go/tree/feature/client-checker/health)
+* [health](health/README.md#health)
 
 ## Tests
 


### PR DESCRIPTION
### What

Previously being an absolute link - it would fail due to branch being deleted.

Now the absolute link will always work (unless the file is removed) on any branch. It will also prevent the user when clicking the link to jump to a different branch (which would happen if it were an absolute link).

### How to review

Check health link works

### Who can review

Anyone
