### PR TITLE
fix download files in datasets that have absolute url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,8 @@ audit:
 build:
 	go build ./...
 .PHONY: build
+
+.PHONY: lint
+lint:
+	exit
+

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -1,0 +1,15 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: golang
+    tag: 1.15.7
+
+inputs:
+  - name: dp-api-clients-go
+
+run:
+  path: dp-api-clients-go/ci/scripts/lint.sh

--- a/ci/scripts/lint.sh
+++ b/ci/scripts/lint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eux
+
+ cwd=$(pwd)
+
+ pushd $cwd/dp-api-clients-go
+   make lint
+ popd

--- a/zebedee/client.go
+++ b/zebedee/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -225,7 +226,15 @@ func (c *Client) GetDataset(ctx context.Context, userAccessToken, collectionID, 
 	downloads := make([]Download, 0)
 
 	for _, v := range d.Downloads {
-		fs, err := c.GetFileSize(ctx, userAccessToken, collectionID, lang, uri+"/"+v.File)
+		var path string
+
+		if strings.HasPrefix(v.File, uri) {
+			path = v.File
+		} else {
+			path = uri + "/" + v.File
+		}
+
+		fs, err := c.GetFileSize(ctx, userAccessToken, collectionID, lang, path)
 		if err != nil {
 			return d, err
 		}

--- a/zebedee/client_test.go
+++ b/zebedee/client_test.go
@@ -85,6 +85,13 @@ func TestUnitClient(t *testing.T) {
 		So(d.SupplementaryFiles[0].Title, ShouldEqual, "helloworld")
 	})
 
+	Convey("test get dataset details with absolute url in download section", t, func() {
+		d, err := cli.GetDataset(ctx, testAccessToken, "", "", "absoluteDownloadURI")
+		So(err, ShouldBeNil)
+		So(d.URI, ShouldEqual, "localhost")
+		So(d.SupplementaryFiles[0].Title, ShouldEqual, "helloworld")
+	})
+
 	Convey("test getFileSize returns human readable filesize", t, func() {
 		fs, err := cli.GetFileSize(ctx, testAccessToken, "", "", "filesize")
 		So(err, ShouldBeNil)
@@ -156,6 +163,9 @@ func d(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte(`{"downloads":[{"title":"Latest","file":"/employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/datasets/labourdisputesbysectorlabd02/labd02jul2015_tcm77-408195.xls"}],"section":{"markdown":""},"relatedDatasets":[{"uri":"/employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/datasets/labourdisputeslabd01"},{"uri":"/employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/datasets/stoppagesofworklabd03"}],"relatedDocuments":[{"uri":"/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/bulletins/uklabourmarket/2015-07-15"}],"relatedMethodology":[],"type":"dataset_landing_page","uri":"/employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/datasets/labourdisputesbysectorlabd02","description":{"title":"Labour disputes by sector: LABD02","summary":"Labour disputes by sector.","keywords":["strike"],"metaDescription":"Labour disputes by sector.","nationalStatistic":true,"contact":{"email":"richard.clegg@ons.gsi.gov.uk\n","name":"Richard Clegg\n","telephone":"+44 (0)1633 455400 \n"},"releaseDate":"2015-07-14T23:00:00.000Z","nextRelease":"12 August 2015","datasetId":"","unit":"","preUnit":"","source":""}}`))
 	case "12345":
 		w.Write([]byte(`{"type":"dataset","uri":"www.google.com","downloads":[{"file":"test.txt"}],"supplementaryFiles":[{"title":"helloworld","file":"helloworld.txt"}],"versions":[{"uri":"www.google.com"}]}`))
+	case "absoluteDownloadURI":
+		w.Write([]byte(`{"type":"dataset","uri":"localhost","downloads":[{"file":"absoluteDownloadURI/test.txt"}],"supplementaryFiles":[{"title":"helloworld","file":"helloworld.txt"}],"versions":[{"uri":"www.google.com"}]}`))
+
 	case "pageTitle":
 		w.Write([]byte(`{"title":"baby-names","edition":"2017"}`))
 	case "/":
@@ -174,6 +184,21 @@ func parents(w http.ResponseWriter, req *http.Request) {
 }
 
 func filesize(w http.ResponseWriter, req *http.Request) {
+
+	switch uri := req.URL.Query().Get("uri"); uri {
+	case "filesize":
+	case "12345/helloworld.txt":
+	case "12345/test.txt":
+	case "absoluteDownloadURI/test.txt":
+	case "absoluteDownloadURI/helloworld.txt":
+		break
+
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(errors.New("Invalid path for get file size").Error()))
+		return
+	}
+
 	zebedeeResponse := struct {
 		FileSize int `json:"fileSize"`
 	}{


### PR DESCRIPTION
### What

Fixed an issue where an absolute url for a download file in data.json was still appended onto the page url: 

### How to review

Check against existing content. If you are reviewing pls contact me for a URL with an absolute path

### Who can review

Anyone with sufficient knowledge of this repo