### PR TITLE
Replacement for setUserAuthToken introduced

### DIFF
--- a/codelist/codelist.go
+++ b/codelist/codelist.go
@@ -297,7 +297,7 @@ func (c *Client) doGetWithAuthHeaders(ctx context.Context, userAuthToken string,
 }
 
 func setAuthenticationHeaders(req *http.Request, userAuthToken, serviceAuthToken string) error {
-	err := headers.SetUserAuthToken(req, userAuthToken)
+	err := headers.SetAuthToken(req, userAuthToken)
 	if err != nil && err != headers.ErrValueEmpty {
 		return err
 	}

--- a/codelist/codelist_test.go
+++ b/codelist/codelist_test.go
@@ -1368,10 +1368,7 @@ func TestSetAuthenticationHeaders(t *testing.T) {
 		actual, getErr := headers.GetUserAuthToken(req)
 		So(actual, ShouldResemble, testUserAuthToken)
 		So(getErr, ShouldBeNil)
-
-		actual, getErr = headers.GetServiceAuthToken(req)
-		So(actual, ShouldBeEmpty)
-		So(getErr, ShouldResemble, headers.ErrHeaderNotFound)
+		
 	})
 
 	Convey("should set expected user and service auth tokens", t, func() {

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -165,7 +165,7 @@ func (c *Client) UpdateFilterOutputBytes(ctx context.Context, userAuthToken, ser
 		return err
 	}
 
-	headers.SetUserAuthToken(req, userAuthToken)
+	headers.SetAuthToken(req, userAuthToken)
 	headers.SetServiceAuthToken(req, serviceAuthToken)
 	headers.SetDownloadServiceToken(req, downloadServiceToken)
 
@@ -201,7 +201,7 @@ func (c *Client) AddEvent(ctx context.Context, userAuthToken, serviceAuthToken, 
 		return err
 	}
 
-	headers.SetUserAuthToken(req, userAuthToken)
+	headers.SetAuthToken(req, userAuthToken)
 	headers.SetServiceAuthToken(req, serviceAuthToken)
 	headers.SetDownloadServiceToken(req, downloadServiceToken)
 
@@ -446,7 +446,7 @@ func (c *Client) CreateBlueprint(ctx context.Context, userAuthToken, serviceAuth
 	}
 
 	headers.SetCollectionID(req, collectionID)
-	headers.SetUserAuthToken(req, userAuthToken)
+	headers.SetAuthToken(req, userAuthToken)
 	headers.SetServiceAuthToken(req, serviceAuthToken)
 	headers.SetDownloadServiceToken(req, downloadServiceToken)
 
@@ -501,7 +501,7 @@ func (c *Client) UpdateBlueprint(ctx context.Context, userAuthToken, serviceAuth
 		return m, "", err
 	}
 
-	headers.SetUserAuthToken(req, userAuthToken)
+	headers.SetAuthToken(req, userAuthToken)
 	headers.SetServiceAuthToken(req, serviceAuthToken)
 	headers.SetDownloadServiceToken(req, downloadServiceToken)
 	headers.SetIfMatch(req, ifMatch)
@@ -549,7 +549,7 @@ func (c *Client) AddDimensionValue(ctx context.Context, userAuthToken, serviceAu
 	}
 
 	headers.SetCollectionID(req, collectionID)
-	headers.SetUserAuthToken(req, userAuthToken)
+	headers.SetAuthToken(req, userAuthToken)
 	headers.SetServiceAuthToken(req, serviceAuthToken)
 	headers.SetIfMatch(req, ifMatch)
 
@@ -721,7 +721,7 @@ func (c *Client) RemoveDimensionValue(ctx context.Context, userAuthToken, servic
 	})
 
 	headers.SetCollectionID(req, collectionID)
-	headers.SetUserAuthToken(req, userAuthToken)
+	headers.SetAuthToken(req, userAuthToken)
 	headers.SetServiceAuthToken(req, serviceAuthToken)
 	headers.SetIfMatch(req, ifMatch)
 
@@ -759,7 +759,7 @@ func (c *Client) RemoveDimension(ctx context.Context, userAuthToken, serviceAuth
 	}
 
 	headers.SetCollectionID(req, collectionID)
-	headers.SetUserAuthToken(req, userAuthToken)
+	headers.SetAuthToken(req, userAuthToken)
 	headers.SetServiceAuthToken(req, serviceAuthToken)
 	headers.SetIfMatch(req, ifMatch)
 
@@ -796,7 +796,7 @@ func (c *Client) AddDimension(ctx context.Context, userAuthToken, serviceAuthTok
 		return "", err
 	}
 	headers.SetCollectionID(req, collectionID)
-	headers.SetUserAuthToken(req, userAuthToken)
+	headers.SetAuthToken(req, userAuthToken)
 	headers.SetServiceAuthToken(req, serviceAuthToken)
 	headers.SetIfMatch(req, ifMatch)
 
@@ -883,7 +883,7 @@ func (c *Client) SetDimensionValues(ctx context.Context, userAuthToken, serviceA
 	}
 
 	headers.SetCollectionID(req, collectionID)
-	headers.SetUserAuthToken(req, userAuthToken)
+	headers.SetAuthToken(req, userAuthToken)
 	headers.SetServiceAuthToken(req, serviceAuthToken)
 	headers.SetIfMatch(req, ifMatch)
 
@@ -948,7 +948,7 @@ func (c *Client) doGetWithAuthHeaders(ctx context.Context, userAuthToken, servic
 	}
 
 	headers.SetCollectionID(req, collectionID)
-	headers.SetUserAuthToken(req, userAuthToken)
+	headers.SetAuthToken(req, userAuthToken)
 	headers.SetServiceAuthToken(req, serviceAuthToken)
 	return c.hcCli.Client.Do(ctx, req)
 }
@@ -962,7 +962,7 @@ func (c *Client) doGetWithAuthHeadersAndWithDownloadToken(ctx context.Context, u
 	}
 
 	headers.SetCollectionID(req, collectionID)
-	headers.SetUserAuthToken(req, userAuthToken)
+	headers.SetAuthToken(req, userAuthToken)
 	headers.SetServiceAuthToken(req, serviceAuthToken)
 	headers.SetDownloadServiceToken(req, downloadServiceAuthToken)
 	return c.hcCli.Client.Do(ctx, req)
@@ -987,7 +987,7 @@ func (c *Client) doPatchWithAuthHeaders(ctx context.Context, userAuthToken, serv
 
 	// set headers
 	headers.SetCollectionID(req, collectionID)
-	headers.SetUserAuthToken(req, userAuthToken)
+	headers.SetAuthToken(req, userAuthToken)
 	headers.SetServiceAuthToken(req, serviceAuthToken)
 	headers.SetIfMatch(req, ifMatch)
 

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -18,6 +18,9 @@ const (
 	// serviceAuthToken the service auth token header name
 	serviceAuthTokenHeader = "Authorization"
 
+	// Same value as serviceAuthTokenHeader as this is a standard header but not linked to service authentication
+	authTokenHeader = "Authorization"
+
 	// bearerPrefix is the prefix for authorization header values
 	bearerPrefix = "Bearer "
 
@@ -169,14 +172,9 @@ func SetCollectionID(req *http.Request, headerValue string) error {
 	return setRequestHeader(req, collectionIDHeader, headerValue)
 }
 
-// SetUserAuthToken set the user authentication token header on the provided request. If the authentication token is
-// already present it will be overwritten by the new value. If the header value is empty returns ErrValueEmpty
-func SetUserAuthToken(req *http.Request, headerValue string) error {
-	return setRequestHeader(req, userAuthTokenHeader, headerValue)
-}
-
 // SetServiceAuthToken set the service authentication token header on the provided request. If the authentication token is
 // already present it will be overwritten by the new value. If the header value is empty then returns ErrValueEmpty
+// Replaces deprecated SetUserAuthToken function
 func SetServiceAuthToken(req *http.Request, headerValue string) error {
 	if req == nil {
 		return ErrRequestNil
@@ -191,6 +189,20 @@ func SetServiceAuthToken(req *http.Request, headerValue string) error {
 	}
 
 	return setRequestHeader(req, serviceAuthTokenHeader, headerValue)
+}
+
+// SetAccessToken set the access token header on the provided request. If the access token is
+// already present it will be overwritten by the new value. If the header value is empty returns ErrValueEmpty
+func SetAuthToken(req *http.Request, headerValue string) error {
+	// TODO remove the userAuthTokenHeader once the X-Florence-Token has been removed
+	if err := setRequestHeader(req, userAuthTokenHeader, headerValue); err != nil {
+		return err
+	}
+	// Add bearer prefix if not present
+	if !strings.HasPrefix(headerValue, bearerPrefix) {
+		headerValue = bearerPrefix + headerValue
+	}
+	return setRequestHeader(req, authTokenHeader, headerValue)
 }
 
 // SetDownloadServiceToken set the download service auth token header on the provided request. If the authentication

--- a/headers/headers_test.go
+++ b/headers/headers_test.go
@@ -65,7 +65,7 @@ func TestIsNotErrNotFound(t *testing.T) {
 	})
 }
 
-func setterTestCases(t *testing.T, fnName, headerName string, fnUnderTest func(req *http.Request, headerValue string) error) []setHeaderTestCase {
+func setterTestCases(t *testing.T, fnName, headerName string, fnUnderTest func(req *http.Request, headerValue string) error, expectBearer bool) []setHeaderTestCase {
 	return []setHeaderTestCase{
 		{
 			description: fmt.Sprintf("%s should return error if request is nil", fnName),
@@ -114,7 +114,12 @@ func setterTestCases(t *testing.T, fnName, headerName string, fnUnderTest func(r
 			},
 			assertResultFunc: func(err error, val string) {
 				So(err, ShouldBeNil)
-				So(val, ShouldEqual, testHeader2)
+				if expectBearer {
+					So(val, ShouldEqual, bearerPrefix+testHeader2)
+
+				} else {
+					So(val, ShouldEqual, testHeader2)
+				}
 			},
 		},
 		{
@@ -130,19 +135,25 @@ func setterTestCases(t *testing.T, fnName, headerName string, fnUnderTest func(r
 			},
 			assertResultFunc: func(err error, val string) {
 				So(err, ShouldBeNil)
-				So(val, ShouldEqual, testHeader1)
+				if expectBearer {
+					So(val, ShouldEqual, bearerPrefix+testHeader1)
+
+				} else {
+					So(val, ShouldEqual, testHeader1)
+				}
 			},
 		},
 	}
 }
 
 func TestSetCollectionID(t *testing.T) {
-	cases := setterTestCases(t, "SetCollectionID", collectionIDHeader, SetCollectionID)
+	cases := setterTestCases(t, "SetCollectionID", collectionIDHeader, SetCollectionID, false)
 	execSetHeaderTestCases(t, cases)
 }
 
-func TestSetUserAuthToken(t *testing.T) {
-	cases := setterTestCases(t, "SetUserAuthToken", userAuthTokenHeader, SetUserAuthToken)
+func TestSetAuthToken(t *testing.T) {
+	cases := setterTestCases(t, "SetAuthToken", userAuthTokenHeader, SetAuthToken, false)
+	cases = append(cases, setterTestCases(t, "SetAuthToken2", authTokenHeader, SetAuthToken, true)...)
 	execSetHeaderTestCases(t, cases)
 }
 
@@ -220,32 +231,32 @@ func TestSetServiceAuthToken(t *testing.T) {
 }
 
 func TestSetDownloadServiceToken(t *testing.T) {
-	cases := setterTestCases(t, "SetDownloadServiceToken", downloadServiceTokenHeader, SetDownloadServiceToken)
+	cases := setterTestCases(t, "SetDownloadServiceToken", downloadServiceTokenHeader, SetDownloadServiceToken, false)
 	execSetHeaderTestCases(t, cases)
 }
 
 func TestSetUserIdentity(t *testing.T) {
-	cases := setterTestCases(t, "SetUserIdentity", userIdentityHeader, SetUserIdentity)
+	cases := setterTestCases(t, "SetUserIdentity", userIdentityHeader, SetUserIdentity, false)
 	execSetHeaderTestCases(t, cases)
 }
 
 func TestSetRequestID(t *testing.T) {
-	cases := setterTestCases(t, "SetRequestID", requestIDHeader, SetRequestID)
+	cases := setterTestCases(t, "SetRequestID", requestIDHeader, SetRequestID, false)
 	execSetHeaderTestCases(t, cases)
 }
 
 func TestSetLocaleCode(t *testing.T) {
-	cases := setterTestCases(t, "SetLocaleCode", localeCodeHeader, SetLocaleCode)
+	cases := setterTestCases(t, "SetLocaleCode", localeCodeHeader, SetLocaleCode, false)
 	execSetHeaderTestCases(t, cases)
 }
 
 func TestSetIfMatch(t *testing.T) {
-	cases := setterTestCases(t, "SetIfMatch", ifMatchHeader, SetIfMatch)
+	cases := setterTestCases(t, "SetIfMatch", ifMatchHeader, SetIfMatch, false)
 	execSetHeaderTestCases(t, cases)
 }
 
 func TestSetETag(t *testing.T) {
-	cases := setterTestCases(t, "SetETag", eTagHeader, SetETag)
+	cases := setterTestCases(t, "SetETag", eTagHeader, SetETag, false)
 	execSetHeaderTestCases(t, cases)
 }
 

--- a/identity/authentication.go
+++ b/identity/authentication.go
@@ -206,7 +206,7 @@ func createUserAuthRequest(url string, userAuthToken string) (*http.Request, err
 		return nil, err
 	}
 
-	if err := headers.SetUserAuthToken(outboundAuthReq, userAuthToken); err != nil {
+	if err := headers.SetAuthToken(outboundAuthReq, userAuthToken); err != nil {
 		return nil, err
 	}
 

--- a/identity/authentication_test.go
+++ b/identity/authentication_test.go
@@ -356,12 +356,11 @@ func TestHandler_bothTokens(t *testing.T) {
 			So(authFailure, ShouldBeNil)
 			So(status, ShouldEqual, http.StatusOK)
 
-			Convey("Then the identity service is called as expected - verifying florence, but ignoring auth header", func() {
+			Convey("Then the identity service is called as expected - verifying florence", func() {
 				So(len(httpClient.DoCalls()), ShouldEqual, 1)
 				zebedeeReq := httpClient.DoCalls()[0].Req
 				So(zebedeeReq.URL.String(), ShouldEqual, expectedZebedeeURL)
 				So(zebedeeReq.Header[dprequest.FlorenceHeaderKey][0], ShouldEqual, florenceToken)
-				So(len(zebedeeReq.Header[dprequest.AuthHeaderKey]), ShouldEqual, 0)
 			})
 
 			Convey("Then the context returns with expected values", func() {

--- a/recipe/client.go
+++ b/recipe/client.go
@@ -58,7 +58,7 @@ func (c *Client) doGetWithAuthHeaders(ctx context.Context, userAuthToken, servic
 		return nil, err
 	}
 
-	headers.SetUserAuthToken(req, userAuthToken)
+	headers.SetAuthToken(req, userAuthToken)
 	headers.SetServiceAuthToken(req, serviceAuthToken)
 	return c.hcCli.Client.Do(ctx, req)
 }


### PR DESCRIPTION
### What

As part of the new Authentication work, we will be replacing X-Florence-Token which is validated via Zebedee with a new token that uses the Authorization header instead which is validated by the dp-identity-api.

But wait we need a smooth transition! Yes, and so we have a new function for setting authentication header `SetAuthToken` this will set both the old Zebedee token and the Florence token. There is work in progress to make requests to the dp-identity-api that fail auth to then check Zebedee with the X-Florence-Token. This work is WIP.

You may notice that the serviceAuthToken also uses the header `Authorization`! Won't there be a collision? - Yes. The idea behind this work is to handle these collisions later, potentially what we will do is check the dp-identity-api to see if it is a user token, if not then check Zebedee to see if it is a service token. This is an interim solution though.

All places that referred to SetUserAuthToken have been replaced with SetAuthToken

Why SetAuthToken instead of SetUserAuthToken, in the distant future service auth tokens will be removed from Zebedee like we are doing currently with user tokens.

### How to review

Check the code

### Who can review

Anyone except me
