### PR TITLE
update log.go to v2, update logging statements for elastisearch

### DIFF
--- a/clientlog/clientlog.go
+++ b/clientlog/clientlog.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 // Do should be used by clients to log a request to a given service
@@ -13,7 +13,7 @@ import (
 func Do(ctx context.Context, action, service, uri string, data ...log.Data) {
 	d := buildLogData(action, uri, data...)
 
-	log.Event(ctx, fmt.Sprintf("Making request to service: %s", service), log.INFO, d)
+	log.Info(ctx, fmt.Sprintf("Making request to service: %s", service), d)
 }
 
 func buildLogData(action, uri string, data ...log.Data) (d log.Data) {

--- a/clientlog/clientlog_test.go
+++ b/clientlog/clientlog_test.go
@@ -3,7 +3,7 @@ package clientlog
 import (
 	"testing"
 
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/codelist/codelist.go
+++ b/codelist/codelist.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
 	healthcheck "github.com/ONSdigital/dp-api-clients-go/v2/health"
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 const service = "code-list-api"
@@ -316,6 +316,6 @@ func closeResponseBody(ctx context.Context, resp *http.Response) {
 	}
 
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
+		log.Error(ctx, "error closing http response body", err)
 	}
 }

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -19,7 +19,7 @@ import (
 	healthcheck "github.com/ONSdigital/dp-api-clients-go/v2/health"
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dprequest "github.com/ONSdigital/dp-net/request"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/pkg/errors"
 )
 
@@ -1042,7 +1042,7 @@ func (c *Client) PatchInstanceDimensionOption(ctx context.Context, serviceAuthTo
 	uri := fmt.Sprintf("%s/instances/%s/dimensions/%s/options/%s", c.hcCli.URL, instanceID, dimensionID, optionID)
 
 	if nodeID == "" && order == nil {
-		log.Event(ctx, "skipping patch call because no update was provided", log.INFO, log.Data{"uri": uri})
+		log.Info(ctx, "skipping patch call because no update was provided", log.Data{"uri": uri})
 		return ifMatch, nil
 	}
 	patchBody := createInstanceDimensionOptionPatch(nodeID, order)
@@ -1367,6 +1367,6 @@ func (c *Client) doGetWithAuthHeadersAndWithDownloadToken(ctx context.Context, u
 // closeResponseBody closes the response body and logs an error containing the context if unsuccessful
 func closeResponseBody(ctx context.Context, resp *http.Response) {
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
+		log.Error(ctx, "error closing http response body", err)
 	}
 }

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -16,7 +16,7 @@ import (
 	healthcheck "github.com/ONSdigital/dp-api-clients-go/v2/health"
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dprequest "github.com/ONSdigital/dp-net/request"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 const service = "filter-api"
@@ -106,7 +106,7 @@ func closeResponseBody(ctx context.Context, resp *http.Response) {
 		return
 	}
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
+		log.Error(ctx, "error closing http response body", err)
 	}
 }
 
@@ -631,7 +631,7 @@ func (c *Client) PatchDimensionValues(ctx context.Context, userAuthToken, servic
 
 		// abort if no data is provided
 		if len(addValues)+len(removeValues) == 0 {
-			log.Event(ctx, "no PATCH operation has been sent because there aren't values to modify", log.INFO)
+			log.Info(ctx, "no PATCH operation has been sent because there aren't values to modify")
 			return latestETag, nil
 		}
 
@@ -655,11 +655,11 @@ func (c *Client) PatchDimensionValues(ctx context.Context, userAuthToken, servic
 		}
 
 		if err := doPatchCall(patchBody); err != nil {
-			log.Event(ctx, "error sending PATCH operation", log.ERROR, log.Error(err))
+			log.Error(ctx, "error sending PATCH operation", err)
 			return latestETag, err
 		}
 
-		log.Event(ctx, "successfully sent PATCH operation", log.INFO)
+		log.Info(ctx, "successfully sent PATCH operation")
 		return latestETag, nil
 	}
 
@@ -691,7 +691,7 @@ func (c *Client) PatchDimensionValues(ctx context.Context, userAuthToken, servic
 	numChunks, err := batch.ProcessInBatches(addValues, processAddPatch, batchSize)
 	logData := log.Data{"num_successful_batches_added": numChunks}
 	if err != nil {
-		log.Event(ctx, "error sending PATCH operations in batches", log.ERROR, logData, log.Error(err))
+		log.Error(ctx, "error sending PATCH operations in batches", err, logData)
 		return latestETag, err
 	}
 
@@ -699,11 +699,11 @@ func (c *Client) PatchDimensionValues(ctx context.Context, userAuthToken, servic
 	numChunks, err = batch.ProcessInBatches(removeValues, processRemovePatch, batchSize)
 	logData["num_successful_batches_removed"] = numChunks
 	if err != nil {
-		log.Event(ctx, "error sending PATCH operations in batches", log.ERROR, logData, log.Error(err))
+		log.Error(ctx, "error sending PATCH operations in batches", err, logData)
 		return latestETag, err
 	}
 
-	log.Event(ctx, "successfully sent PATCH operations in batches", log.INFO, logData)
+	log.Info(ctx, "successfully sent PATCH operations in batches", logData)
 	return latestETag, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,7 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9
 	github.com/ONSdigital/dp-net v1.0.12
-	github.com/ONSdigital/log.go v1.0.1
-	github.com/ONSdigital/log.go/v2 v2.0.0
+	github.com/ONSdigital/log.go/v2 v2.0.5
 	github.com/golang/mock v1.4.4
 	github.com/gorilla/mux v1.8.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
 github.com/ONSdigital/dp-api-clients-go v1.34.3 h1:nS3ZG3Eql9T68Q0IFehpnqkUy2AFoTDktVgaD90Yj+s=
 github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
-github.com/ONSdigital/dp-api-clients-go/v2 v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
-github.com/ONSdigital/dp-api-clients-go/v2 v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=
@@ -19,8 +17,8 @@ github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQ
 github.com/ONSdigital/log.go v1.0.1-0.20200805145532-1f25087a0744/go.mod h1:y4E9MYC+cV9VfjRD0UBGj8PA7H3wABqQi87/ejrDhYc=
 github.com/ONSdigital/log.go v1.0.1 h1:SZ5wRZAwlt2jQUZ9AUzBB/PL+iG15KapfQpJUdA18/4=
 github.com/ONSdigital/log.go v1.0.1/go.mod h1:dIwSXuvFB5EsZG5x44JhsXZKMd80zlb0DZxmiAtpL4M=
-github.com/ONSdigital/log.go/v2 v2.0.0 h1:ozm2DORFnPwVe1Dmved7ccjNo16z06EOmAXAllZxW3A=
-github.com/ONSdigital/log.go/v2 v2.0.0/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=
+github.com/ONSdigital/log.go/v2 v2.0.5 h1:kl2lF0vr3BQDwPTAUcarDvX4Um3uE3fjVRfLoHAarBc=
+github.com/ONSdigital/log.go/v2 v2.0.5/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=
 github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9/go.mod h1:uPmAp6Sws4L7+Q/OokbWDAK1ibXYhB3PXFP1kol5hPg=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=

--- a/health/health.go
+++ b/health/health.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/v2/clientlog"
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dphttp "github.com/ONSdigital/dp-net/http"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 var (
@@ -87,7 +87,7 @@ func (c *Client) Checker(ctx context.Context, state *health.CheckState) error {
 		code, err = c.get(ctx, "/healthcheck")
 	}
 	if err != nil {
-		log.Event(ctx, "failed to request service health", log.ERROR, log.Error(err), logData)
+		log.Error(ctx, "failed to request service health", err, logData)
 	}
 
 	switch code {
@@ -134,7 +134,7 @@ func closeResponseBody(ctx context.Context, resp *http.Response) {
 	}
 
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
+		log.Error(ctx, "error closing http response body", err)
 	}
 }
 

--- a/hierarchy/hierarchy.go
+++ b/hierarchy/hierarchy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/v2/clientlog"
 	healthcheck "github.com/ONSdigital/dp-api-clients-go/v2/health"
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 const service = "hierarchy-api"
@@ -56,7 +56,7 @@ type Client struct {
 // closeResponseBody closes the response body and logs an error if unsuccessful
 func closeResponseBody(ctx context.Context, resp *http.Response) {
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
+		log.Error(ctx, "error closing http response body", err)
 	}
 }
 

--- a/identity/authentication.go
+++ b/identity/authentication.go
@@ -11,7 +11,7 @@ import (
 	healthcheck "github.com/ONSdigital/dp-api-clients-go/v2/health"
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dprequest "github.com/ONSdigital/dp-net/request"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 
 	"github.com/pkg/errors"
 )
@@ -111,7 +111,7 @@ func (api Client) CheckRequest(req *http.Request, florenceToken, serviceAuthToke
 
 	logData["user_identity"] = userIdentity
 	logData["caller_identity"] = userIdentity
-	log.Event(ctx, "caller identity retrieved setting context values", log.INFO, logData)
+	log.Info(ctx, "caller identity retrieved setting context values", logData)
 
 	ctx = context.WithValue(ctx, dprequest.UserIdentityKey, userIdentity)
 	ctx = context.WithValue(ctx, dprequest.CallerIdentityKey, tokenIdentityResp.Identifier)
@@ -141,7 +141,7 @@ func (api Client) doCheckTokenIdentity(ctx context.Context, token string, tokenT
 
 	url := api.hcCli.URL + "/identity"
 	logData["url"] = url
-	log.Event(ctx, "calling AuthAPI to authenticate caller identity", log.INFO, logData)
+	log.Info(ctx, "calling AuthAPI to authenticate caller identity", logData)
 
 	// Crete request according to the token type
 	var outboundAuthReq *http.Request
@@ -153,14 +153,14 @@ func (api Client) doCheckTokenIdentity(ctx context.Context, token string, tokenT
 		outboundAuthReq, errCreatingReq = createServiceAuthRequest(url, token)
 	}
 	if errCreatingReq != nil {
-		log.Event(ctx, "error creating AuthAPI identity http request", log.ERROR, logData, log.Error(errCreatingReq))
+		log.Error(ctx, "error creating AuthAPI identity http request", errCreatingReq, logData)
 		return nil, http.StatusInternalServerError, nil, errCreatingReq
 	}
 
 	// 'GET /identity' request
 	resp, err := api.hcCli.Client.Do(ctx, outboundAuthReq)
 	if err != nil {
-		log.Event(ctx, "HTTPClient.Do returned error making AuthAPI identity request", log.ERROR, logData, log.Error(err))
+		log.Error(ctx, "HTTPClient.Do returned error making AuthAPI identity request", err, logData)
 		return nil, http.StatusInternalServerError, nil, err
 	}
 	defer closeResponse(ctx, resp, logData)
@@ -243,7 +243,7 @@ func closeResponse(ctx context.Context, resp *http.Response, data log.Data) {
 	}
 
 	if errClose := resp.Body.Close(); errClose != nil {
-		log.Event(ctx, "error closing response body", log.ERROR, log.Error(errClose), data)
+		log.Error(ctx, "error closing response body", errClose, data)
 	}
 }
 

--- a/identity/authentication_test.go
+++ b/identity/authentication_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ONSdigital/dp-mocking/httpmocks"
 	dphttp "github.com/ONSdigital/dp-net/http"
 	dprequest "github.com/ONSdigital/dp-net/request"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/image/image.go
+++ b/image/image.go
@@ -11,7 +11,7 @@ import (
 
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dprequest "github.com/ONSdigital/dp-net/request"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/clientlog"
 	healthcheck "github.com/ONSdigital/dp-api-clients-go/v2/health"
@@ -53,7 +53,7 @@ type Client struct {
 // closeResponseBody closes the response body and logs an error containing the context if unsuccessful
 func closeResponseBody(ctx context.Context, resp *http.Response) {
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
+		log.Error(ctx, "error closing http response body", err)
 	}
 }
 

--- a/importapi/importapi.go
+++ b/importapi/importapi.go
@@ -13,7 +13,7 @@ import (
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dphttp "github.com/ONSdigital/dp-net/http"
 	dprequest "github.com/ONSdigital/dp-net/request"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 const service = "import-api"
@@ -104,7 +104,7 @@ func (c *Client) GetImportJob(ctx context.Context, importJobID, serviceToken str
 
 	jsonBody, err := getBody(resp)
 	if err != nil {
-		log.Event(ctx, "Failed to read body from API", log.ERROR, log.Error(err))
+		log.Error(ctx, "Failed to read body from API", err)
 		return importJob, err
 	}
 
@@ -120,7 +120,7 @@ func (c *Client) GetImportJob(ctx context.Context, importJobID, serviceToken str
 	}
 
 	if err := json.Unmarshal(jsonBody, &importJob); err != nil {
-		log.Event(ctx, "GetImportJob unmarshal", log.ERROR, logData, log.Error(err))
+		log.Error(ctx, "GetImportJob unmarshal", err, logData)
 		return importJob, err
 	}
 
@@ -144,7 +144,7 @@ func (c *Client) UpdateImportJobState(ctx context.Context, jobID, serviceToken s
 
 	resp, err := c.doPut(ctx, uri, serviceToken, 0, jsonUpload)
 	if err != nil {
-		log.Event(ctx, "UpdateImportJobState", log.ERROR, logData, log.Error(err))
+		log.Error(ctx, "UpdateImportJobState", err, logData)
 		return err
 	}
 	defer closeResponseBody(ctx, resp)
@@ -170,7 +170,7 @@ func doCall(ctx context.Context, client dphttp.Clienter, method, uri, serviceTok
 
 	URL, err := url.Parse(uri)
 	if err != nil {
-		log.Event(ctx, "Failed to create url for API call", log.ERROR, logData, log.Error(err))
+		log.Error(ctx, "Failed to create url for API call", err, logData)
 		return nil, err
 	}
 	uri = URL.String()
@@ -192,7 +192,7 @@ func doCall(ctx context.Context, client dphttp.Clienter, method, uri, serviceTok
 	}
 	// check above req had no errors
 	if err != nil {
-		log.Event(ctx, "Failed to create request for API", log.ERROR, logData, log.Error(err))
+		log.Error(ctx, "Failed to create request for API", err, logData)
 		return nil, err
 	}
 
@@ -201,7 +201,7 @@ func doCall(ctx context.Context, client dphttp.Clienter, method, uri, serviceTok
 
 	resp, err := client.Do(ctx, req)
 	if err != nil {
-		log.Event(ctx, "Failed to action API", log.ERROR, logData, log.Error(err))
+		log.Error(ctx, "Failed to action API", err, logData)
 		return nil, err
 	}
 
@@ -240,6 +240,6 @@ func closeResponseBody(ctx context.Context, resp *http.Response) {
 		return
 	}
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
+		log.Error(ctx, "error closing http response body", err)
 	}
 }

--- a/recipe/recipe_test.go
+++ b/recipe/recipe_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/v2/health"
 	dphttp "github.com/ONSdigital/dp-net/http"
 	dprequest "github.com/ONSdigital/dp-net/request"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/v2/clientlog"
 	healthcheck "github.com/ONSdigital/dp-api-clients-go/v2/health"
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 const service = "renderer"
@@ -53,7 +53,7 @@ func NewWithHealthClient(hcCli *healthcheck.Client) *Renderer {
 
 func closeResponseBody(ctx context.Context, resp *http.Response) {
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
+		log.Error(ctx, "error closing http response body", err)
 	}
 }
 

--- a/site-search/site-search.go
+++ b/site-search/site-search.go
@@ -12,7 +12,7 @@ import (
 	healthcheck "github.com/ONSdigital/dp-api-clients-go/v2/health"
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dprequest "github.com/ONSdigital/dp-net/request"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 const service = "search-api"
@@ -65,7 +65,7 @@ func NewWithHealthClient(hcCli *healthcheck.Client) *Client {
 // closeResponseBody closes the response body and logs an error containing the context if unsuccessful
 func closeResponseBody(ctx context.Context, resp *http.Response) {
 	if err := resp.Body.Close(); err != nil {
-		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
+		log.Error(ctx, "error closing http response body", err)
 	}
 }
 

--- a/zebedee/client_test.go
+++ b/zebedee/client_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dphttp "github.com/ONSdigital/dp-net/http"
 	dprequest "github.com/ONSdigital/dp-net/request"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -134,7 +134,7 @@ func mockZebedeeServer(port chan int) {
 
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
-		log.Event(context.Background(), "error listening on local network address", log.FATAL, log.Error(err))
+		log.Fatal(context.Background(), "error listening on local network address", err)
 		os.Exit(2)
 	}
 
@@ -142,7 +142,7 @@ func mockZebedeeServer(port chan int) {
 	close(port)
 
 	if err := http.Serve(l, r); err != nil {
-		log.Event(context.Background(), "error serving http connections", log.FATAL, log.Error(err))
+		log.Fatal(context.Background(), "error serving http connections", err)
 		os.Exit(2)
 	}
 }


### PR DESCRIPTION
### What

Update log.go requirement to v2 in go.mod and imports.

Update logging statements to format that can be parsed by
elastisearch, e.g.

log.Event(ctx, string, log.FATAL, log.Error(something1), something2)
-> log.Fatal(ctx, string, something1, something2)
log.Event(ctx, string, log.ERROR log.Error(something1), something2)
-> log.Error(ctx, string, something1, something2)
log.Event(ctx, string, log.INFO, log.Error(something))
-> log.Info(ctx, string, log.FormatErrors([]error{something}))
log.Event(ctx, string, log.WARN, log.Error(something))
-> log.Warn(ctx, string, log.FormatErrors([]error{something}))
These changes needed to allow error logs to be properly viewed in
kibana.

### How to review

run make test
eyeball changes for obvious errors

### Who can review

Anyone