### PR TITLE
Add IncreaseProcessedInstanceCount call in import api, with unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=bash
 
 test:
-	go test -v -count=1 -race -cover ./...
+	go test -count=1 -race -cover ./...
 
 .PHONY: test
 

--- a/importapi/importapi.go
+++ b/importapi/importapi.go
@@ -61,8 +61,9 @@ var _ error = ErrInvalidAPIResponse{}
 
 // ImportJob comes from the Import API and links an import job to its (other) instances
 type ImportJob struct {
-	JobID string  `json:"id"`
-	Links LinkMap `json:"links,omitempty"`
+	JobID     string               `json:"id"`
+	Links     LinkMap              `json:"links,omitempty"`
+	Processed []ProcessedInstances `json:"processed_instances,omitempty"`
 }
 
 // LinkMap is an array of instance links associated with am import job
@@ -74,6 +75,13 @@ type LinkMap struct {
 type InstanceLink struct {
 	ID   string `json:"id"`
 	Link string `json:"href"`
+}
+
+// ProcessedInstances holds the ID and the number of code lists that have been processed during an import process for an instance
+type ProcessedInstances struct {
+	ID             string `json:"id,omitempty"`
+	RequiredCount  int    `json:"required_count,omitempty"`
+	ProcessedCount int    `json:"processed_count,omitempty"`
 }
 
 // stateData represents a json with a single state filed
@@ -154,6 +162,41 @@ func (c *Client) UpdateImportJobState(ctx context.Context, jobID, serviceToken s
 		return NewAPIResponse(resp, uri)
 	}
 	return nil
+}
+
+func (c *Client) IncreaseProcessedInstanceCount(ctx context.Context, jobID, serviceToken, instanceID string) (procInst []ProcessedInstances, err error) {
+	uri := fmt.Sprintf("%s/jobs/%s/processed/%s", c.url, jobID, instanceID)
+
+	logData := log.Data{
+		"uri":         uri,
+		"job_id":      jobID,
+		"instance_id": instanceID,
+	}
+
+	resp, err := c.doPut(ctx, uri, serviceToken, 0, nil)
+	if err != nil {
+		log.Event(ctx, "error increaseing the instance count in import api", log.ERROR, logData, log.Error(err))
+		return nil, err
+	}
+	defer closeResponseBody(ctx, resp)
+	logData["httpCode"] = resp.StatusCode
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, NewAPIResponse(resp, uri)
+	}
+
+	jsonBody, err := getBody(resp)
+	if err != nil {
+		log.Event(ctx, "failed to read body from api response", log.ERROR, log.Error(err))
+		return nil, err
+	}
+
+	if err := json.Unmarshal(jsonBody, &procInst); err != nil {
+		log.Event(ctx, "failed to unmarshal api response body", log.ERROR, logData, log.Error(err))
+		return nil, err
+	}
+
+	return procInst, nil
 }
 
 func (c *Client) doGet(ctx context.Context, uri, serviceToken string, attempts int, vars url.Values) (*http.Response, error) {

--- a/importapi/importapi_test.go
+++ b/importapi/importapi_test.go
@@ -38,9 +38,7 @@ func TestClient_HealthChecker(t *testing.T) {
 		clientError := errors.New("disciples of the watch obey")
 
 		clienter := &dphttp.ClienterMock{
-			SetPathsWithNoRetriesFunc: func(paths []string) {
-				return
-			},
+			SetPathsWithNoRetriesFunc: func(paths []string) {},
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 				return &http.Response{}, clientError
 			},
@@ -75,9 +73,7 @@ func TestClient_HealthChecker(t *testing.T) {
 
 	Convey("given clienter.Do returns 500 response", t, func() {
 		clienter := &dphttp.ClienterMock{
-			SetPathsWithNoRetriesFunc: func(paths []string) {
-				return
-			},
+			SetPathsWithNoRetriesFunc: func(paths []string) {},
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 500,
@@ -114,9 +110,7 @@ func TestClient_HealthChecker(t *testing.T) {
 
 	Convey("given clienter.Do returns 404 response", t, func() {
 		clienter := &dphttp.ClienterMock{
-			SetPathsWithNoRetriesFunc: func(paths []string) {
-				return
-			},
+			SetPathsWithNoRetriesFunc: func(paths []string) {},
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 404,
@@ -154,9 +148,7 @@ func TestClient_HealthChecker(t *testing.T) {
 
 	Convey("given clienter.Do returns 429 response", t, func() {
 		clienter := &dphttp.ClienterMock{
-			SetPathsWithNoRetriesFunc: func(paths []string) {
-				return
-			},
+			SetPathsWithNoRetriesFunc: func(paths []string) {},
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 429,
@@ -193,9 +185,7 @@ func TestClient_HealthChecker(t *testing.T) {
 
 	Convey("given clienter.Do returns 200 response", t, func() {
 		clienter := &dphttp.ClienterMock{
-			SetPathsWithNoRetriesFunc: func(paths []string) {
-				return
-			},
+			SetPathsWithNoRetriesFunc: func(paths []string) {},
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 200,
@@ -287,7 +277,7 @@ func TestGetImportJob(t *testing.T) {
 		mockedAPI := getMockImportAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 200, Body: jobJSON})
 		job, err := mockedAPI.GetImportJob(ctx, jobID, serviceToken)
 		So(err, ShouldBeNil)
-		So(job, ShouldResemble, ImportJob{JobID: jobID, Links: LinkMap{Instances: []InstanceLink{InstanceLink{ID: "iid1", Link: "iid1link"}}}})
+		So(job, ShouldResemble, ImportJob{JobID: jobID, Links: LinkMap{Instances: []InstanceLink{{ID: "iid1", Link: "iid1link"}}}})
 	})
 
 	Convey("When a multiple-instance import-job is returned", t, func() {
@@ -298,8 +288,8 @@ func TestGetImportJob(t *testing.T) {
 			JobID: jobID,
 			Links: LinkMap{
 				Instances: []InstanceLink{
-					InstanceLink{ID: "iid1", Link: "iid1link"},
-					InstanceLink{ID: "iid2", Link: "iid2link"},
+					{ID: "iid1", Link: "iid1link"},
+					{ID: "iid2", Link: "iid2link"},
 				},
 			},
 		})
@@ -334,5 +324,55 @@ func TestUpdateImportJobState(t *testing.T) {
 		mockedAPI := getMockImportAPI(http.Request{Method: "PUT"}, MockedHTTPResponse{StatusCode: 200, Body: ""})
 		err := mockedAPI.UpdateImportJobState(ctx, jobID, serviceToken, "newState")
 		So(err, ShouldBeNil)
+	})
+}
+
+func TestIncreaseProcessedInstanceCount(t *testing.T) {
+
+	jobID := "job0"
+	instanceID := "inst0"
+
+	Convey("When bad request is returned then the expected error is returned", t, func() {
+		mockedAPI := getMockImportAPI(http.Request{Method: http.MethodPut}, MockedHTTPResponse{StatusCode: http.StatusBadRequest, Body: ""})
+		procInst, err := mockedAPI.IncreaseProcessedInstanceCount(ctx, jobID, serviceToken, instanceID)
+		So(err, ShouldNotBeNil)
+		So(err, ShouldResemble, &ErrInvalidAPIResponse{
+			actualCode: http.StatusBadRequest,
+			uri:        fmt.Sprintf("%s/jobs/job0/processed/inst0", mockedAPI.url),
+			body:       "",
+		})
+		So(procInst, ShouldBeNil)
+	})
+
+	Convey("When server error is returned then the expected error is returned", t, func() {
+		mockedAPI := getMockImportAPI(http.Request{Method: http.MethodPut}, MockedHTTPResponse{StatusCode: http.StatusInternalServerError, Body: ""})
+		procInst, err := mockedAPI.IncreaseProcessedInstanceCount(ctx, jobID, serviceToken, instanceID)
+		So(err, ShouldNotBeNil)
+		So(err, ShouldResemble, &ErrInvalidAPIResponse{
+			actualCode: http.StatusInternalServerError,
+			uri:        fmt.Sprintf("%s/jobs/job0/processed/inst0", mockedAPI.url),
+			body:       "",
+		})
+		So(procInst, ShouldBeNil)
+	})
+
+	Convey("When ok response is returned the expected response is returned without error", t, func() {
+		bodyStr := `[
+			{
+				"id": "inst0",
+				"required_count": 10,
+				"processed_count": 2
+			}
+		]`
+		mockedAPI := getMockImportAPI(http.Request{Method: http.MethodPut}, MockedHTTPResponse{StatusCode: http.StatusOK, Body: bodyStr})
+		procInst, err := mockedAPI.IncreaseProcessedInstanceCount(ctx, jobID, serviceToken, instanceID)
+		So(err, ShouldBeNil)
+		So(procInst, ShouldResemble, []ProcessedInstances{
+			{
+				ID:             instanceID,
+				RequiredCount:  10,
+				ProcessedCount: 2,
+			},
+		})
 	})
 }


### PR DESCRIPTION
### What

Added a new func for the new endpoint in import api :
- endpoint: `PUT /jobs/{id}/processed/{instanceID}`
- method: `IncreaseProcessedInstanceCount`
Added unit tests

### How to review

Make sure code changes make sense and tests pass
(note) I tested it by using it in `dp-import-cantabular-dimension-options`

### Who can review

anyone