### PR TITLE
Add method to put download info to instances (dataset api)

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -113,7 +113,7 @@ type Version struct {
 type UpdateInstance struct {
 	Alerts               *[]Alert             `json:"alerts"`
 	CollectionID         string               `json:"collection_id"`
-	Downloads            map[string]Download  `json:"downloads"`
+	Downloads            DownloadList         `json:"downloads"`
 	Edition              string               `json:"edition"`
 	Dimensions           []VersionDimension   `json:"dimensions"`
 	ID                   string               `json:"id"`
@@ -195,9 +195,9 @@ type Metadata struct {
 
 // DownloadList represents a list of objects of containing information on the downloadable files
 type DownloadList struct {
-	CSV  *Download `bson:"csv,omitempty" json:"csv,omitempty"`
-	CSVW *Download `bson:"csvw,omitempty" json:"csvw,omitempty"`
-	XLS  *Download `bson:"xls,omitempty" json:"xls,omitempty"`
+	CSV  *Download `json:"csv,omitempty"`
+	CSVW *Download `json:"csvw,omitempty"`
+	XLS  *Download `json:"xls,omitempty"`
 }
 
 // Download represents a version download from the dataset api


### PR DESCRIPTION
### What

Improved the Downloads model in UpdateInstance (according to models defined in dp-dataset-api)

### How to review

- Make sure code changes make sense. You may check the dataset api models [here](https://github.com/ONSdigital/dp-dataset-api/blob/develop/models/instance.go#L17)

### Who can review

anyone