### PR TITLE
add parsing for graphql error

### DIFF
--- a/cantabular/static_dataset.go
+++ b/cantabular/static_dataset.go
@@ -29,6 +29,11 @@ func (c *Client) StaticDatasetQuery(ctx context.Context, req StaticDatasetQueryR
 		)
 	}
 
+	logData := log.Data{
+		"url":     fmt.Sprintf("%s/graphql", c.extApiHost),
+		"request": req,
+	}
+
 	vars := map[string]interface{}{
 		// GraphQL package requires self defined scalar types for variables
 		// and arguments
@@ -48,10 +53,15 @@ func (c *Client) StaticDatasetQuery(ctx context.Context, req StaticDatasetQueryR
 		return nil, dperrors.New(
 			fmt.Errorf("failed to make GraphQL query: %w", err),
 			http.StatusInternalServerError,
-			log.Data{
-				"url":     fmt.Sprintf("%s/graphql", c.extApiHost),
-				"request": req,
-			},
+			logData,
+		)
+	}
+
+	if err := q.Dataset.Table.Error; err != "" {
+		return nil, dperrors.New(
+			fmt.Errorf("GraphQL error: %s", err),
+			http.StatusBadRequest,
+			logData,
 		)
 	}
 

--- a/cantabular/static_dataset_test.go
+++ b/cantabular/static_dataset_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"net/http"
 
+
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular/mock"
 	dphttp "github.com/ONSdigital/dp-net/http"

--- a/cantabular/static_dataset_test.go
+++ b/cantabular/static_dataset_test.go
@@ -2,6 +2,7 @@ package cantabular_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"net/http"
 
@@ -68,6 +69,40 @@ func TestStaticDatasetQueryUnHappy(t *testing.T) {
 			Convey("Status Code 503 Service Unavailable should be recoverable from error", func() {
 				_, err := cantabularClient.StaticDatasetQuery(testCtx, req)
 				So(dperrors.StatusCode(err), ShouldEqual, http.StatusServiceUnavailable)
+			})
+		})
+	})
+
+	Convey("Given a GraphQL error from the /graphql endpoint", t, func() {
+		testCtx := context.Background()
+
+		mockHttpClient := &dphttp.ClienterMock{}
+		mockGQLClient := &mock.GraphQLClientMock{
+			QueryFunc: func(ctx context.Context, query interface{}, vars map[string]interface{}) error {
+				if q, ok := query.(*cantabular.StaticDatasetQuery); ok {
+					q.Dataset.Table.Error = "I am error response"
+					return nil
+				}
+				return errors.New("query could not be cast to correct type")
+			},
+		}
+
+		cantabularClient := cantabular.NewClient(
+			cantabular.Config{
+				Host:       "cantabular.host",
+				ExtApiHost: "cantabular.ext.host",
+			},
+			mockHttpClient,
+			mockGQLClient,
+		)
+
+		Convey("When the StaticDatasetQuery method is called", func() {
+			req := cantabular.StaticDatasetQueryRequest{}
+			_, err := cantabularClient.StaticDatasetQuery(testCtx, req)
+			
+			Convey("An error should be returned with status code 400 Bad Request", func() {
+				So(err, ShouldNotBeNil)
+				So(dperrors.StatusCode(err), ShouldEqual, http.StatusBadRequest)
 			})
 		})
 	})


### PR DESCRIPTION
### What

Added parsing for GraphQL errors returned from Cantabular. GraphQL errors don't come back as actual
errors or with an error code, rather you have to check whether the error field in the response has been populated. 
With this change the Cantabular Client will now convert this into an error with the appropriate status code.

### How to review

Check code changes make sense, tests pass.

To test locally you can cause a GraphQL error by modifying the recipe to have too many variables or editing the code to pass incorrect variables.

### Who can review

Anyone
