### PR TITLE
implemented PatchInstanceDimensions

### DIFF
--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -1018,7 +1018,7 @@ func (c *Client) PostInstanceDimensions(ctx context.Context, serviceAuthToken, i
 	return eTag, nil
 }
 
-// PatchInstanceDimensions performs a 'PATCH /instances/<id>/dimensions' with the provided List of Options to patch
+// PatchInstanceDimensions performs a 'PATCH /instances/<id>/dimensions' with the provided List of Options to patch (upsert)
 func (c *Client) PatchInstanceDimensions(ctx context.Context, serviceAuthToken, instanceID string, data []*OptionPost, ifMatch string) (eTag string, err error) {
 	uri := fmt.Sprintf("%s/instances/%s/dimensions", c.hcCli.URL, instanceID)
 
@@ -1029,7 +1029,7 @@ func (c *Client) PatchInstanceDimensions(ctx context.Context, serviceAuthToken, 
 
 	patchBody := []dprequest.Patch{
 		{
-			Op:    dprequest.OpAdd.String(),
+			Op:    dprequest.OpAdd.String(), // this will cause an 'upsert' to be actioned for all provided Options in data
 			Path:  "/-",
 			Value: data,
 		},

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -1020,6 +1020,13 @@ func (c *Client) PostInstanceDimensions(ctx context.Context, serviceAuthToken, i
 
 // PatchInstanceDimensions performs a 'PATCH /instances/<id>/dimensions' with the provided List of Options to patch
 func (c *Client) PatchInstanceDimensions(ctx context.Context, serviceAuthToken, instanceID string, data []*OptionPost, ifMatch string) (eTag string, err error) {
+	uri := fmt.Sprintf("%s/instances/%s/dimensions", c.hcCli.URL, instanceID)
+
+	if len(data) == 0 {
+		log.Info(ctx, "skipping patch call because no update was provided", log.Data{"uri": uri})
+		return ifMatch, nil
+	}
+
 	patchBody := []dprequest.Patch{
 		{
 			Op:    dprequest.OpAdd.String(),
@@ -1028,9 +1035,7 @@ func (c *Client) PatchInstanceDimensions(ctx context.Context, serviceAuthToken, 
 		},
 	}
 
-	uri := fmt.Sprintf("%s/instances/%s/dimensions", c.hcCli.URL, instanceID)
-
-	clientlog.Do(ctx, "patching (upserting) options to instance dimensions", service, uri)
+	clientlog.Do(ctx, "patching (upserting) dimension options to instance", service, uri)
 
 	resp, err := c.doPatchWithAuthHeaders(ctx, "", serviceAuthToken, "", uri, patchBody, ifMatch)
 	if err != nil {


### PR DESCRIPTION
### What

- Created `PatchInstanceDimensions` method to call `PATCH /instances/{id}/dimensions` endpoint
- Unit tested

### How to review

- Make sure code chnges make sense
- Make sure unit tests pass

(info) - I tested the changes by implementing a unit test that does a real connection, against a dataset api instance running locally (using https://github.com/ONSdigital/dp-dataset-api/pull/313):
```
 func TestReal(t *testing.T) {
 	Convey("asdf", t, func() {
 		cli := NewAPIClient("http://localhost:22000")
 		serTok := "<your local service auth token>"
 		instID := "<existing instance ID in your mongoDB>"
 		data := []*OptionPost{
 			{
 				CodeList: "codeList",
 				Option:   "ooop1",
 			},
 			{
 				CodeList: "codeList",
 				Option:   "ooop2",
 			},
 		}
 		_, err := cli.PatchInstanceDimensions(ctx, serTok, instID, data, "*")
 		So(err, ShouldBeNil)
 	})
 }
```

### Who can review

anyone