### PR TITLE
integrate table parsing logic for Cantabular client

### DIFF
--- a/cantabular/table.go
+++ b/cantabular/table.go
@@ -1,9 +1,80 @@
 package cantabular
 
+import (
+	"bufio"
+	"bytes"
+	"encoding/csv"
+	"fmt"
+)
+
 // Table represents the 'table' field from the GraphQL dataset
 // query response
 type Table struct {
 	Dimensions []Dimension `json:"dimensions"`
 	Values     []int       `json:"values"`
 	Error      string      `json:"error,omitempty" `
+}
+
+// ParseTable takes a table from a GraphQL response and parses it into a
+// header and rows of counts (observations) ready to be read line-by-line.
+func (c *Client) ParseTable(table Table) (*bufio.Reader, error){
+	// Create CSV writer with underlying buffer
+	b := new(bytes.Buffer)
+	w := csv.NewWriter(b)
+
+	// Create and write header seperately
+	header := c.createCSVHeader(table.Dimensions)
+
+	w.Write(header)
+	if err := w.Error(); err != nil {
+		return nil, fmt.Errorf("error writing the csv header: %w", err)
+	}
+
+	// Obtain the CSV rows according to the cantabular dimensions and counts
+	for i, count := range table.Values {
+		row := c.createCSVRow(table.Dimensions, i, count)
+		w.Write(row)
+		if err := w.Error(); err != nil {
+			return nil, fmt.Errorf("error writing a csv row: %w", err)
+		}
+	}
+
+	// Flush to make sure all data is present in the byte buffer
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return nil, fmt.Errorf("error flushing the csv writer: %w", err)
+	}
+
+	// Return a reader with the same underlying Byte buffer as written by the csv writter
+	return bufio.NewReader(b), nil
+}
+
+// createCSVHeader creates an array of strings corresponding to a csv header
+// where each column contains the value of the corresponding dimension, with the last column being the 'count'
+func (c *Client) createCSVHeader(dims []Dimension) []string {
+	header := make([]string, len(dims)+1)
+	for i, dim := range dims {
+		header[i] = dim.Variable.Label
+	}
+	header[len(dims)] = "count"
+
+	return header
+}
+
+// createCSVRow creates an array of strings corresponding to a csv row
+// for the provided array of dimension, index and count
+// it assumes that the values are sorted with lower weight for the last dimension and higher weight for the first dimension.
+func (c *Client) createCSVRow(dims []Dimension, index, count int) []string {
+	row := make([]string, len(dims)+1)
+
+	// Iterate dimensions starting from the last one (lower weight)
+	for i := len(dims) - 1; i >= 0; i-- {
+		catIndex := index % dims[i].Count           // Index of the category for the current dimension
+		row[i] = dims[i].Categories[catIndex].Label // The CSV column corresponds to the label of the Category
+		index = index / dims[i].Count               // Modify index for next iteration
+	}
+
+	row[len(dims)] = fmt.Sprintf("%d", count)
+
+	return row
 }

--- a/cantabular/table_test.go
+++ b/cantabular/table_test.go
@@ -1,0 +1,131 @@
+package cantabular_test
+
+import (
+	"bufio"
+	"testing"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestParseQueryResponse(t *testing.T) {
+
+	Convey("Given a Cantabular client", t, func(){
+		var c cantabular.Client
+
+		Convey("When ParseTable is triggered with a valid table", func() {
+			resp := testStaticDatasetQuery()
+			reader, err := c.ParseTable(resp.Dataset.Table)
+
+			Convey("Then the expected reader is returned without error", func() {
+				So(err, ShouldBeNil)
+				validateLines(reader, []string{
+					"City,Number of siblings (3 mappings),Sex,count",
+					"London,No siblings,Male,2",
+					"London,No siblings,Female,0",
+					"London,1 or 2 siblings,Male,1",
+					"London,1 or 2 siblings,Female,3",
+					"London,3 or more siblings,Male,5",
+					"London,3 or more siblings,Female,4",
+					"Liverpool,No siblings,Male,7",
+					"Liverpool,No siblings,Female,6",
+					"Liverpool,1 or 2 siblings,Male,11",
+					"Liverpool,1 or 2 siblings,Female,10",
+					"Liverpool,3 or more siblings,Male,9",
+					"Liverpool,3 or more siblings,Female,13",
+					"Belfast,No siblings,Male,14",
+					"Belfast,No siblings,Female,12",
+					"Belfast,1 or 2 siblings,Male,16",
+					"Belfast,1 or 2 siblings,Female,17",
+					"Belfast,3 or more siblings,Male,15",
+					"Belfast,3 or more siblings,Female,8",
+				})
+			})
+		})
+	})
+}
+
+// validateLines scans the provided reader, line by line, and compares with the corresponding line in the provided array.
+// It also checks that all the expected lines are present in the reader.
+func validateLines(reader *bufio.Reader, expectedLines []string) {
+	i := 0
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		So(scanner.Text(), ShouldEqual, expectedLines[i])
+		i++
+	}
+	So(expectedLines, ShouldHaveLength, i) // Check that there aren't any more expected lines
+	So(scanner.Err(), ShouldBeNil)
+}
+
+// testStaticDatasetQueryResponse returns a valid cantabular StaticDatasetQuery for testing
+func testStaticDatasetQuery() *cantabular.StaticDatasetQuery {
+	return &cantabular.StaticDatasetQuery{
+		Dataset: cantabular.StaticDataset{
+			Table: cantabular.Table{
+				Dimensions: []cantabular.Dimension{
+					{
+						Variable: cantabular.VariableBase{
+							Name:  "city",
+							Label: "City",
+						},
+						Count: 3,
+						Categories: []cantabular.Category{
+							{
+								Code:  "0",
+								Label: "London",
+							},
+							{
+								Code:  "1",
+								Label: "Liverpool",
+							},
+							{
+								Code:  "2",
+								Label: "Belfast",
+							},
+						},
+					},
+					{
+						Variable: cantabular.VariableBase{
+							Name:  "siblings_3",
+							Label: "Number of siblings (3 mappings)",
+						},
+						Count: 3,
+						Categories: []cantabular.Category{
+							{
+								Code:  "0",
+								Label: "No siblings",
+							},
+							{
+								Code:  "1-2",
+								Label: "1 or 2 siblings",
+							},
+							{
+								Code:  "3+",
+								Label: "3 or more siblings",
+							},
+						},
+					},
+					{
+						Variable: cantabular.VariableBase{
+							Name:  "sex",
+							Label: "Sex",
+						},
+						Count: 2,
+						Categories: []cantabular.Category{
+							{
+								Code:  "0",
+								Label: "Male",
+							},
+							{
+								Code:  "1",
+								Label: "Female",
+							},
+						},
+					},
+				},
+				Values: []int{2, 0, 1, 3, 5, 4, 7, 6, 11, 10, 9, 13, 14, 12, 16, 17, 15, 8},
+			},
+		},
+	}
+}


### PR DESCRIPTION
### What

Have ported the response parsing logic and tests from dp-cantabular-csv-exporter so it can be reused in dp-observation-api (and anywhere else that needs it in the future)

### How to review

Check tests pass and code makes sense, only expected code is present.

### Who can review

Anyone
