### PR TITLE
Remove UsageNotes from DatasetDetails struct

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -30,7 +30,6 @@ type DatasetDetails struct {
 	Type              string            `json:"type,omitempty"`
 	UnitOfMeasure     string            `json:"unit_of_measure,omitempty"`
 	URI               string            `json:"uri,omitempty"`
-	UsageNotes        *[]UsageNote      `json:"usage_notes,omitempty"`
 }
 
 // Dataset represents a dataset resource


### PR DESCRIPTION
### What

This has been done because:
1. It should not be in that struct
2. Its in the Version struct
3. recent code updates caused clashes in un-marshalling that showed the issue.

### How to review
Visual inspection

### Who can review

Anyone.