### PR TITLE
Add optionUpdates to PatchInstanceDimensions

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -344,6 +344,15 @@ type OptionPost struct {
 	Order    *int   `json:"order,omitempty"`
 }
 
+// OptionUpdate represents an update for an existing option.
+// The information provided in the struct will be used to generate a patch operation
+type OptionUpdate struct {
+	Option string
+	Name   string
+	Order  *int
+	NodeID string
+}
+
 // JobInstance represents the details necessary to update (PUT) a job instance
 type JobInstance struct {
 	HeaderNames          []string `json:"headers"`


### PR DESCRIPTION
### What

Modified `PatchInstanceDimensions` func to provide updates for multiple existing options (using the latest changes of dataset api)

Trello card https://trello.com/c/fkwR6fiM/5253-cmd-import-use-single-patch-call-per-batch-of-dimension-options

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

anyone