### PR TITLE
improved Stream error handling, closing and var names

### DIFF
--- a/cantabular/static_dataset.go
+++ b/cantabular/static_dataset.go
@@ -104,8 +104,8 @@ func (c *Client) StaticDatasetQueryStreamCSV(ctx context.Context, req StaticData
 	}
 	var rowCount int32
 
-	transform := func(ctx context.Context, r io.Reader, w io.Writer) error {
-		if rowCount, err = GraphQLJSONToCSV(r, w); err != nil {
+	transform := func(ctx context.Context, body io.Reader, pipeWriter io.Writer) error {
+		if rowCount, err = GraphQLJSONToCSV(ctx, body, pipeWriter); err != nil {
 			return err
 		}
 		return nil

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -49,6 +49,11 @@ func Stream(ctx context.Context, body io.ReadCloser, transform Transformer, cons
 	go func() {
 		defer wg.Done()
 		errConsume = consume(ctx, pipeReader)
+		if errConsume != nil {
+			if err := pipeWriter.Close(); err != nil {
+				log.Error(ctx, "stream error: error closing pipe reader from consumer go-routine during error handling", err)
+			}
+		}
 	}()
 
 	wg.Wait()

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -71,7 +71,7 @@ func TestStream(t *testing.T) {
 		var consume = func(ctx context.Context, r io.Reader) error {
 			n, err := r.Read(output)
 			c.So(n, ShouldEqual, 0)
-			c.So(err, ShouldResemble, errors.New("EOF"))
+			c.So(err, ShouldResemble, errTestTransformer)
 			return nil
 		}
 


### PR DESCRIPTION
### What

- Renamed r/w to pipeReader/pipeWriter to improve code readability
- Transformer func calls `CloseWithError` if the transform func returned an error (and `Close` otherwise)
- Fixed tests accordingly: we no longer see the `EOF` error, and any error in the transformer is passed to the consmer.

- Pass the context provided to `StaticDatasetQueryStreamCSV` down to the json streamer iterator, and abort processing if the context is cancelled 

Use XLSX exporter as a reference.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

Anyone