### PR TITLE
Add published index endpoint for search reindexing

### DIFF
--- a/zebedee/client.go
+++ b/zebedee/client.go
@@ -469,6 +469,31 @@ func (c *Client) GetPublishedData(ctx context.Context, uriString string) ([]byte
 	return content, nil
 }
 
+// GetPublishedIndex returns PublishedIndex
+func (c *Client) GetPublishedIndex(ctx context.Context, params *PublishedIndexRequestParams) (PublishedIndex, error) {
+	reqURL := "/publishedindex"
+
+	if params != nil {
+		reqURL = fmt.Sprintf("%s?offset=%d",reqURL, params.Offset)
+		if params.Limit != nil {
+			reqURL = fmt.Sprintf("%s&limit=%d",reqURL, *(params.Limit))
+		}
+	}
+
+	b, _, err := c.get(ctx, "", reqURL)
+
+	if err != nil {
+		return PublishedIndex{}, err
+	}
+
+	var publishedIndex PublishedIndex
+	if err = json.Unmarshal(b, &publishedIndex); err != nil {
+		return publishedIndex, err
+	}
+
+	return publishedIndex, nil
+}
+
 // closeResponseBody closes the response body and logs an error if unsuccessful
 func closeResponseBody(ctx context.Context, resp *http.Response) {
 	if resp.Body != nil {

--- a/zebedee/client.go
+++ b/zebedee/client.go
@@ -474,14 +474,13 @@ func (c *Client) GetPublishedIndex(ctx context.Context, params *PublishedIndexRe
 	reqURL := "/publishedindex"
 
 	if params != nil {
-		reqURL = fmt.Sprintf("%s?offset=%d",reqURL, params.Offset)
+		reqURL = fmt.Sprintf("%s?offset=%d", reqURL, params.Offset)
 		if params.Limit != nil {
-			reqURL = fmt.Sprintf("%s&limit=%d",reqURL, *(params.Limit))
+			reqURL = fmt.Sprintf("%s&limit=%d", reqURL, *(params.Limit))
 		}
 	}
 
 	b, _, err := c.get(ctx, "", reqURL)
-
 	if err != nil {
 		return PublishedIndex{}, err
 	}

--- a/zebedee/client_test.go
+++ b/zebedee/client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -148,6 +147,7 @@ func filesize(w http.ResponseWriter, req *http.Request) {
 }
 
 func TestUnitClient(t *testing.T) {
+	t.Parallel()
 	portChan := make(chan int)
 	go mockZebedeeServer(portChan)
 
@@ -386,6 +386,7 @@ func TestUnitClient(t *testing.T) {
 }
 
 func TestClient_HealthChecker(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	timePriorHealthCheck := time.Now()
 	path := "/health"
@@ -531,7 +532,7 @@ func TestClient_HealthChecker(t *testing.T) {
 }
 
 func TestClient_PublishedDataEndpoint(t *testing.T) {
-
+	t.Parallel()
 	ctx := context.Background()
 	path := "/publisheddata"
 	testURIString := "/employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/datasets/labourdisputesbysectorlabd02"
@@ -610,11 +611,12 @@ func TestClient_PublishedDataEndpoint(t *testing.T) {
 }
 
 func TestClient_PublishedIndexEndpoint(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	path := "/publishedindex"
 
 	Convey("given a 200 response", t, func() {
-		documentContent, err := ioutil.ReadFile("./response_mocks/publishedindex.json")
+		documentContent, err := os.ReadFile("./response_mocks/publishedindex.json")
 		So(err, ShouldBeNil)
 		body := httpmocks.NewReadCloserMock(documentContent, nil)
 		response := httpmocks.NewResponseMock(body, http.StatusOK)
@@ -641,8 +643,6 @@ func TestClient_PublishedIndexEndpoint(t *testing.T) {
 				doCalls := httpClient.DoCalls()
 				So(doCalls, ShouldHaveLength, 1)
 				So(doCalls[0].Req.URL.Path, ShouldEqual, path)
-				//p := doCalls[0].Req.FormValue("offset")
-				//So(p, ShouldEqual, path)
 			})
 		})
 

--- a/zebedee/data.go
+++ b/zebedee/data.go
@@ -226,3 +226,23 @@ type Bulletin struct {
 	Alerts           []Alert     `json:"alerts"`
 	LatestReleaseURI string      `json:"latestReleaseUri"`
 }
+
+// PublishedIndexRequestParams represents request parameters for making paged PublishedIndex requests
+type PublishedIndexRequestParams struct {
+	Limit  *int
+	Offset int
+}
+
+// PublishedIndex represents an index of published content
+type PublishedIndex struct {
+	Count      int                  `json:"count"`
+	Items      []PublishedIndexItem `json:"items"`
+	Limit      int                  `json:"limit"`
+	Offset     int                  `json:"offset"`
+	TotalCount int                  `json:"total_count"`
+}
+
+// PublishedIndexItem represents an individual content item returned from the PublishedIndex endpoint
+type PublishedIndexItem struct {
+	URI string `json:"uri"`
+}

--- a/zebedee/response_mocks/publishedindex.json
+++ b/zebedee/response_mocks/publishedindex.json
@@ -1,0 +1,17 @@
+{
+  "count": 3,
+  "items": [
+    {
+      "uri": "/releases"
+    },
+    {
+      "uri": "/economy/regionalaccounts/grossdisposablehouseholdincome/bulletins/regionalgrossdisposablehouseholdincomegdhi/2014-06-04"
+    },
+    {
+      "uri": "/businessindustryandtrade/tourismindustry/timeseries/gmaa"
+    }
+  ],
+  "limit": 3,
+  "offset": 0,
+  "total_count": 3
+}


### PR DESCRIPTION
### What

Added PublishedIndex endpoint to zebedee client
- Includes paging parameters (although zebedee currently ignores these)
- Corresponding zebedee PR: https://github.com/ONSdigital/zebedee/pull/551

### How to review

Check code and unit tests

### Who can review

Anyone but me