### PR TITLE
Recipe API client must ignore ErrValueEmpty

### DIFF
--- a/recipe/client.go
+++ b/recipe/client.go
@@ -61,11 +61,11 @@ func (c *Client) doGetWithAuthHeaders(ctx context.Context, userAuthToken, servic
 	}
 
 	err = headers.SetAuthToken(req, userAuthToken)
-	if err != nil {
+	if err != nil && err != headers.ErrValueEmpty {
 		return nil, err
 	}
 	err = headers.SetServiceAuthToken(req, serviceAuthToken)
-	if err != nil {
+	if err != nil && err != headers.ErrValueEmpty {
 		return nil, err
 	}
 	return c.hcCli.Client.Do(ctx, req)


### PR DESCRIPTION
### What

Recipe API client now ignores ErrValueEmpty, which is a valid scenario for values that are not supposed to be set (e.g. maybe we want to set service token but not user token)

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- (info) validated with [`dp-import-cantabular-dataset` PR ](https://github.com/ONSdigital/dp-import-cantabular-dataset/pull/32)

### Who can review

anyone