### PR TITLE
add dataset links struct

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -191,6 +191,7 @@ type Instances struct {
 type Metadata struct {
 	Version
 	DatasetDetails
+	DatasetLinks Links `json:"dataset_links,omitempty"`
 }
 
 // DownloadList represents a list of objects of containing information on the downloadable files


### PR DESCRIPTION
### What

Add struct to enable cantabular xlsx exporter to get dataset version links (due to clash with metadata struct also having json name of 'links')

Related to this PR - https://github.com/ONSdigital/dp-dataset-api/pull/344

### How to review

Confirm changes are correct and make sense

### Who can review

Anyone
