### PR TITLE
Implement Cantabular GetDimensions and GetDimensionOptions with graphql

### DIFF
--- a/cantabular/contract.go
+++ b/cantabular/contract.go
@@ -1,5 +1,7 @@
 package cantabular
 
+import "github.com/ONSdigital/dp-api-clients-go/v2/cantabular/gql"
+
 // ErrorResponse models the error response from cantabular
 type ErrorResponse struct {
 	Message string `json:"message"`
@@ -35,4 +37,18 @@ type StaticDatasetQueryRequest struct {
 // unmarshalled into the requests.
 type StaticDatasetQuery struct {
 	Dataset StaticDataset `json:"dataset" graphql:"dataset(name: $name)"`
+}
+
+// GetDimensionsResponse holds the response body for
+// POST [cantabular-ext]/graphql
+// with a ruleBase query to obtain static dataset variables, with 1-level relationships
+type GetDimensionsResponse struct {
+	Dataset gql.Dataset `json:"dataset"`
+}
+
+// GetDimensionOptionsResponse holds the response body for
+// POST [cantabular-ext]/graphql
+// with a query to obtain static dataset variables and categories, without values.
+type GetDimensionOptionsResponse struct {
+	Dataset StaticDatasetDimensionOptions `json:"dataset"`
 }

--- a/cantabular/contract.go
+++ b/cantabular/contract.go
@@ -43,7 +43,7 @@ type StaticDatasetQuery struct {
 // POST [cantabular-ext]/graphql
 // with a ruleBase query to obtain static dataset variables, with 1-level relationships
 type GetDimensionsResponse struct {
-	Dataset gql.Dataset `json:"dataset"`
+	Dataset gql.DatasetVariables `json:"dataset"`
 }
 
 // GetDimensionOptionsResponse holds the response body for

--- a/cantabular/gql/data.go
+++ b/cantabular/gql/data.go
@@ -1,0 +1,30 @@
+package gql
+
+type Dataset struct {
+	RuleBase RuleBase `json:"ruleBase"`
+}
+
+type RuleBase struct {
+	IsSourceOf MapFrom `json:"isSourceOf"`
+	Name       string  `json:"name"`
+}
+
+type MapFrom struct {
+	Edges []Edge `json:"edges"`
+}
+
+type Edge struct {
+	Node Node `json:"node"`
+}
+
+type Node struct {
+	Name       string     `json:"name"`
+	Label      string     `json:"label"`
+	Categories Categories `json:"categories"`
+	MapFrom    []MapFrom  `json:"mapFrom"`
+	FilterOnly string     `json:"filterOnly"`
+}
+
+type Categories struct {
+	TotalCount int `json:"totalCount"`
+}

--- a/cantabular/gql/data.go
+++ b/cantabular/gql/data.go
@@ -1,15 +1,19 @@
 package gql
 
-type Dataset struct {
+type DatasetRuleBase struct {
 	RuleBase RuleBase `json:"ruleBase"`
 }
 
-type RuleBase struct {
-	IsSourceOf MapFrom `json:"isSourceOf"`
-	Name       string  `json:"name"`
+type DatasetVariables struct {
+	Variables Variables `json:"variables"`
 }
 
-type MapFrom struct {
+type RuleBase struct {
+	IsSourceOf Variables `json:"isSourceOf"`
+	Name       string    `json:"name"`
+}
+
+type Variables struct {
 	Edges []Edge `json:"edges"`
 }
 
@@ -18,11 +22,11 @@ type Edge struct {
 }
 
 type Node struct {
-	Name       string     `json:"name"`
-	Label      string     `json:"label"`
-	Categories Categories `json:"categories"`
-	MapFrom    []MapFrom  `json:"mapFrom"`
-	FilterOnly string     `json:"filterOnly"`
+	Name       string      `json:"name"`
+	Label      string      `json:"label"`
+	Categories Categories  `json:"categories"`
+	MapFrom    []Variables `json:"mapFrom"`
+	FilterOnly string      `json:"filterOnly"`
 }
 
 type Categories struct {

--- a/cantabular/gql/error.go
+++ b/cantabular/gql/error.go
@@ -1,0 +1,12 @@
+package gql
+
+type Error struct {
+	Message   string     `json:"message"`
+	Locations []Location `json:"locations"`
+	Path      []string   `json:"path"`
+}
+
+type Location struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}

--- a/cantabular/queries.go
+++ b/cantabular/queries.go
@@ -1,0 +1,62 @@
+package cantabular
+
+// QueryStaticDataset is the graphQL query to obtain static dataset counts
+const QueryStaticDataset = `
+query($dataset: String!, $variables: [String!]!, $filters: [Filter!]) {
+	dataset(name: $dataset) {
+		table(variables: $variables, filters: $filters) {
+			dimensions {
+				count
+				variable { name label }
+				categories { code label }
+			}
+			values
+			error
+		}
+	}
+}`
+
+// QueryDimensionOptions is the graphQL query to obtain static dataset dimension options
+const QueryDimensionOptions = `
+query($dataset: String!, $variables: [String!]!, $filters: [Filter!]) {
+	dataset(name: $dataset) {
+		table(variables: $variables, filters: $filters) {
+			dimensions {
+				variable { name label }
+				categories { code label }
+			}
+			values
+			error
+		}
+	}
+}`
+
+// GraphQL Query to obtain dimensions
+const QueryDimensions = `
+query($dataset: String!) {
+	dataset(name: $dataset) {
+		ruleBase {
+			name
+			isSourceOf {
+		  		edges {
+					node {
+						name
+						mapFrom {
+							edges {
+								node {
+									filterOnly
+									label
+									name
+								}
+							}
+						}
+						label
+						categories {
+							totalCount
+						}
+					}
+				}
+			}
+		}
+	}
+}`

--- a/cantabular/queries.go
+++ b/cantabular/queries.go
@@ -35,25 +35,48 @@ query($dataset: String!, $variables: [String!]!, $filters: [Filter!]) {
 const QueryDimensions = `
 query($dataset: String!) {
 	dataset(name: $dataset) {
-		ruleBase {
-			name
-			isSourceOf {
-		  		edges {
-					node {
-						name
-						mapFrom {
-							edges {
-								node {
-									filterOnly
-									label
-									name
-								}
+		variables {
+			edges {
+				node {
+					name
+					mapFrom {
+						edges {
+							node {
+								filterOnly
+								label
+								name
 							}
 						}
-						label
-						categories {
-							totalCount
+					}
+					label
+					categories {
+						totalCount
+					}
+				}
+			}
+		}
+	}
+}`
+
+const QueryDimensionsByName = `
+query($dataset: String!, $variables: [String!]!) {
+	dataset(name: $dataset) {
+		variables(names: $variables) {
+			edges {
+				node {
+					name
+					mapFrom {
+						edges {
+							node {
+								filterOnly
+								label
+								name
+							}
 						}
+					}
+					label
+					categories {
+						totalCount
 					}
 				}
 			}

--- a/cantabular/static_dataset.go
+++ b/cantabular/static_dataset.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular/gql"
 	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
 	"github.com/ONSdigital/dp-api-clients-go/v2/stream"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -19,26 +21,23 @@ import (
 type Consumer = stream.Consumer
 
 // StaticDataset represents the 'dataset' field from a GraphQL static dataset
-// query response
+// query response, containing a full Table
 type StaticDataset struct {
 	Table Table `json:"table" graphql:"table(variables: $variables)"`
 }
 
-// QueryStaticDataset represents a full graphQL query to be encoded into the body of a plain http post request
-// for a static dataset query
-const QueryStaticDataset = `
-query($dataset: String!, $variables: [String!]!, $filters: [Filter!]) {
-	dataset(name: $dataset) {
-		table(variables: $variables, filters: $filters) {
-			dimensions {
-				count
-				variable { name label }
-				categories { code label } }
-			values
-			error
-		  }
-	 }
-}`
+// StaticDatasetDimensionOptions represents the 'dataset' field from a GraphQL static dataset
+// query response, containing a DimensionsTable, without values
+type StaticDatasetDimensionOptions struct {
+	Table DimensionsTable `json:"table"`
+}
+
+// DimensionsTable represents the 'table' field from the GraphQL dataset response,
+// which contains only dimensions and error fields
+type DimensionsTable struct {
+	Dimensions []Dimension `json:"dimensions"`
+	Error      string      `json:"error,omitempty" `
+}
 
 // StaticDatasetQuery performs a query for a static dataset against the
 // Cantabular Extended API using the /graphql endpoint and returns a StaticDatasetQuery,
@@ -65,11 +64,9 @@ func (c *Client) StaticDatasetQuery(ctx context.Context, req StaticDatasetQueryR
 	}
 
 	gvars := make([]graphql.String, 0)
-
 	for _, v := range req.Variables {
 		gvars = append(gvars, graphql.String(v))
 	}
-
 	vars["variables"] = gvars
 
 	var q StaticDatasetQuery
@@ -92,13 +89,63 @@ func (c *Client) StaticDatasetQuery(ctx context.Context, req StaticDatasetQueryR
 	return &q, nil
 }
 
+// GetDimensions performs a graphQL query to obtain the dimensions for the provided cantabular dataset.
+// It returns a RuleBaseResponse, containing nested edges and nodes according to the query structure
+// The whole response is loaded to memory.
+func (c *Client) GetDimensions(ctx context.Context, dataset string) (*GetDimensionsResponse, error) {
+	req := StaticDatasetQueryRequest{
+		Dataset: dataset,
+	}
+
+	resp := &struct {
+		Data   GetDimensionsResponse `json:"data"`
+		Errors []gql.Error           `json:"errors,omitempty"`
+	}{}
+	if err := c.staticDatasetQueryUnmarshal(ctx, QueryDimensions, req, resp); err != nil {
+		return nil, err
+	}
+
+	if resp != nil && len(resp.Errors) != 0 {
+		return nil, dperrors.New(
+			errors.New("error(s) returned by graphQL query"),
+			http.StatusOK,
+			log.Data{"errors": resp.Errors},
+		)
+	}
+
+	return &resp.Data, nil
+}
+
+// GetDimensionOptions performs a graphQL query to obtain the requested dimension options.
+// It returns a Table with a list of Cantabular dimensions, where 'Variable' is the dimension and 'Categories' are the options
+// The whole response is loaded to memory.
+func (c *Client) GetDimensionOptions(ctx context.Context, req StaticDatasetQueryRequest) (*GetDimensionOptionsResponse, error) {
+	resp := &struct {
+		Data   GetDimensionOptionsResponse `json:"data"`
+		Errors []gql.Error                 `json:"errors,omitempty"`
+	}{}
+	if err := c.staticDatasetQueryUnmarshal(ctx, QueryDimensionOptions, req, resp); err != nil {
+		return nil, err
+	}
+
+	if resp != nil && len(resp.Errors) != 0 {
+		return nil, dperrors.New(
+			errors.New("error(s) returned by graphQL query"),
+			http.StatusOK,
+			log.Data{"errors": resp.Errors},
+		)
+	}
+
+	return &resp.Data, nil
+}
+
 // StaticDatasetQueryStreamCSV performs a StaticDatasetQuery call
 // and then starts 2 go-routines to transform the response body into a CSV stream and
 // consume the transformed output with the provided Consumer concurrently.
 // The number of CSV rows, including the header, is returned along with any error during the process.
 // Use this method if large query responses are expected.
 func (c *Client) StaticDatasetQueryStreamCSV(ctx context.Context, req StaticDatasetQueryRequest, consume Consumer) (int32, error) {
-	responseBody, err := c.staticDatasetQueryLowLevel(ctx, req)
+	res, err := c.staticDatasetQueryLowLevel(ctx, QueryStaticDataset, req)
 	if err != nil {
 		return 0, err
 	}
@@ -110,14 +157,50 @@ func (c *Client) StaticDatasetQueryStreamCSV(ctx context.Context, req StaticData
 		}
 		return nil
 	}
-	return rowCount, stream.Stream(ctx, responseBody, transform, consume)
+	return rowCount, stream.Stream(ctx, res.Body, transform, consume)
+}
+
+// staticDatasetQueryUnmarshal uses staticDatasetQueryLowLevel to perform a graphQL query and then un-marshals the response body to the provided value pointer v
+// This method handles the response body closing.
+func (c *Client) staticDatasetQueryUnmarshal(ctx context.Context, graphQLQuery string, req StaticDatasetQueryRequest, v interface{}) error {
+	url := fmt.Sprintf("%s/graphql", c.extApiHost)
+
+	res, err := c.staticDatasetQueryLowLevel(ctx, graphQLQuery, req)
+	if err != nil {
+		return err
+	}
+	defer closeResponseBody(ctx, res)
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return dperrors.New(
+			fmt.Errorf("failed to read response body: %s", err),
+			res.StatusCode,
+			log.Data{
+				"url": url,
+			},
+		)
+	}
+
+	if err := json.Unmarshal(b, v); err != nil {
+		return dperrors.New(
+			fmt.Errorf("failed to unmarshal response body: %s", err),
+			http.StatusInternalServerError,
+			log.Data{
+				"url":           url,
+				"response_body": string(b),
+			},
+		)
+	}
+
+	return nil
 }
 
 // staticDatasetQueryLowLevel performs a query for a static dataset against the
 // Cantabular Extended API using the /graphql endpoint and the http client directly
 // If the call is successfull, the response body is returned
 // - Important: it's the caller's responsability to close the body once it has been fully processed.
-func (c *Client) staticDatasetQueryLowLevel(ctx context.Context, req StaticDatasetQueryRequest) (io.ReadCloser, error) {
+func (c *Client) staticDatasetQueryLowLevel(ctx context.Context, graphQLQuery string, req StaticDatasetQueryRequest) (*http.Response, error) {
 	url := fmt.Sprintf("%s/graphql", c.extApiHost)
 
 	logData := log.Data{
@@ -129,7 +212,7 @@ func (c *Client) staticDatasetQueryLowLevel(ctx context.Context, req StaticDatas
 	var b bytes.Buffer
 	enc := json.NewEncoder(&b)
 	if err := enc.Encode(map[string]interface{}{
-		"query": QueryStaticDataset,
+		"query": graphQLQuery,
 		"variables": map[string]interface{}{
 			"dataset":   req.Dataset,
 			"variables": req.Variables,
@@ -158,5 +241,5 @@ func (c *Client) staticDatasetQueryLowLevel(ctx context.Context, req StaticDatas
 		return nil, c.errorResponse(url, res)
 	}
 
-	return res.Body, nil
+	return res, nil
 }

--- a/cantabular/static_dataset_test.go
+++ b/cantabular/static_dataset_test.go
@@ -383,6 +383,45 @@ func TestGetDimensionsUnhappy(t *testing.T) {
 	})
 }
 
+func TestGetDimensionsByNameHappy(t *testing.T) {
+	Convey("Given a correct getDimensions response from the /graphql endpoint", t, func() {
+		testCtx := context.Background()
+
+		mockHttpClient := &dphttp.ClienterMock{
+			PostFunc: func(ctx context.Context, url string, contentType string, body io.Reader) (*http.Response, error) {
+				return Response(
+					[]byte(mockRespBodyGetDimensionsByName),
+					http.StatusOK,
+				), nil
+			},
+		}
+
+		cantabularClient := cantabular.NewClient(
+			cantabular.Config{
+				Host:       "cantabular.host",
+				ExtApiHost: "cantabular.ext.host",
+			},
+			mockHttpClient,
+			nil,
+		)
+
+		Convey("When the GetDimensions method is called", func() {
+			resp, err := cantabularClient.GetDimensionsByName(testCtx, cantabular.StaticDatasetQueryRequest{
+				Dataset:   "Teaching-Dataset",
+				Variables: []string{"Age", "Region"},
+			})
+
+			Convey("No error should be returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("And the expected response is returned", func() {
+				So(*resp, ShouldResemble, expectedDimensionsByName)
+			})
+		})
+	})
+}
+
 func TestGetDimensionOptionsHappy(t *testing.T) {
 	Convey("Given a correct getDimensionOptions response from the /graphql endpoint", t, func() {
 		testCtx := context.Background()
@@ -584,44 +623,81 @@ var mockRespBodyGetDimensions = `
 {
 	"data": {
 		"dataset": {
-			"ruleBase": {
-				"isSourceOf": {
-					"edges": [
-						{
-							"node": {
-								"categories": {
-									"totalCount": 2
-								},
-								"label": "Country",
-								"mapFrom": [
-									{
-										"edges": [
-											{
-												"node": {
-													"filterOnly": "false",
-													"label": "Region",
-													"name": "Region"
-												}
-											}
-										]
-									}
-								],
-								"name": "Country"
-							}
-						},
-						{
-							"node": {
-								"categories": {
-									"totalCount": 10
-								},
-								"label": "Region",
-								"mapFrom": [],
-								"name": "Region"
-							}
+			"variables": {
+				"edges": [
+					{
+						"node": {
+							"categories": {
+								"totalCount":8
+							},
+							"label": "Age",
+							"mapFrom": [],
+							"name": "Age"
 						}
-					]
-				},
-				"name": "Region"
+					},
+					{
+						"node": {
+							"categories": {
+								"totalCount":2
+							},
+							"label": "Country",
+							"mapFrom": [
+								{
+									"edges": [
+										{
+											"node": {
+												"filterOnly": "false",
+												"label": "Region",
+												"name": "Region"
+											}
+										}
+									]
+								}
+							],
+							"name": "Country"
+						}
+					},
+					{
+						"node": {
+							"categories": {
+								"totalCount": 6
+							},
+							"label": "Health",
+							"mapFrom": [],
+							"name": "Health"
+						}
+					},
+					{
+						"node": {
+							"categories": {
+								"totalCount":5
+							},
+							"label": "Marital Status",
+							"mapFrom": [],
+							"name": "Marital Status"
+						}
+					},
+					{
+						"node": {
+							"categories": {
+								"totalCount":10
+							},
+							"label": "Region",
+							"mapFrom": [],
+							"name": "Region"
+						}
+					},
+					{
+						"node": {
+							"categories": {
+								"totalCount":2
+							},
+							"label": "Sex",
+							"mapFrom":[],
+							"name":"Sex"
+						}
+					}
+				]
 			}
 		}
 	}
@@ -629,41 +705,128 @@ var mockRespBodyGetDimensions = `
 
 // expectedDimensions is the expected response struct generated from a successful 'get dimensions' query for testing
 var expectedDimensions = cantabular.GetDimensionsResponse{
-	Dataset: gql.Dataset{
-		RuleBase: gql.RuleBase{
-			IsSourceOf: gql.MapFrom{
-				Edges: []gql.Edge{
-					{
-						Node: gql.Node{
-							Name:       "Country",
-							Label:      "Country",
-							Categories: gql.Categories{TotalCount: 2},
-							MapFrom: []gql.MapFrom{
-								{
-									Edges: []gql.Edge{
-										{
-											Node: gql.Node{
-												FilterOnly: "false",
-												Label:      "Region",
-												Name:       "Region",
-											},
+	Dataset: gql.DatasetVariables{
+		Variables: gql.Variables{
+			Edges: []gql.Edge{
+				{
+					Node: gql.Node{
+						Name:       "Age",
+						Label:      "Age",
+						Categories: gql.Categories{TotalCount: 8},
+						MapFrom:    []gql.Variables{},
+					},
+				},
+				{
+					Node: gql.Node{
+						Name:       "Country",
+						Label:      "Country",
+						Categories: gql.Categories{TotalCount: 2},
+						MapFrom: []gql.Variables{
+							{
+								Edges: []gql.Edge{
+									{
+										Node: gql.Node{
+											FilterOnly: "false",
+											Label:      "Region",
+											Name:       "Region",
 										},
 									},
 								},
 							},
 						},
 					},
-					{
-						Node: gql.Node{
-							Name:       "Region",
-							Label:      "Region",
-							Categories: gql.Categories{TotalCount: 10},
-							MapFrom:    []gql.MapFrom{},
-						},
+				},
+				{
+					Node: gql.Node{
+						Name:       "Health",
+						Label:      "Health",
+						Categories: gql.Categories{TotalCount: 6},
+						MapFrom:    []gql.Variables{},
+					},
+				},
+				{
+					Node: gql.Node{
+						Name:       "Marital Status",
+						Label:      "Marital Status",
+						Categories: gql.Categories{TotalCount: 5},
+						MapFrom:    []gql.Variables{},
+					},
+				},
+				{
+					Node: gql.Node{
+						Name:       "Region",
+						Label:      "Region",
+						Categories: gql.Categories{TotalCount: 10},
+						MapFrom:    []gql.Variables{},
+					},
+				},
+				{
+					Node: gql.Node{
+						Name:       "Sex",
+						Label:      "Sex",
+						Categories: gql.Categories{TotalCount: 2},
+						MapFrom:    []gql.Variables{},
 					},
 				},
 			},
-			Name: "Region",
+		},
+	},
+}
+
+// mockRespBodyGetDimensionsByName is a successful 'get dimensions by name' query respose that is returned from a mocked client for testing
+var mockRespBodyGetDimensionsByName = `{
+	"data": {
+		"dataset": {
+			"variables": {
+				"edges": [
+					{
+						"node": {
+							"categories": {
+								"totalCount": 8
+							},
+							"label": "Age",
+							"mapFrom": [],
+							"name": "Age"
+						}
+					},
+					{
+						"node": {
+							"categories": {
+								"totalCount": 10
+							},
+							"label": "Region",
+							"mapFrom": [],
+							"name": "Region"
+						}
+					}
+				]
+			}
+		}
+	}
+}`
+
+// expectedDimensionsByName is the expected response struct generated from a successful 'get dimensions by name' query for testing
+var expectedDimensionsByName = cantabular.GetDimensionsResponse{
+	Dataset: gql.DatasetVariables{
+		Variables: gql.Variables{
+			Edges: []gql.Edge{
+				{
+					Node: gql.Node{
+						Name:       "Age",
+						Label:      "Age",
+						Categories: gql.Categories{TotalCount: 8},
+						MapFrom:    []gql.Variables{},
+					},
+				},
+				{
+					Node: gql.Node{
+						Name:       "Region",
+						Label:      "Region",
+						Categories: gql.Categories{TotalCount: 10},
+						MapFrom:    []gql.Variables{},
+					},
+				},
+			},
 		},
 	},
 }

--- a/cantabular/static_dataset_test.go
+++ b/cantabular/static_dataset_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular/gql"
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular/mock"
 	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
 	dphttp "github.com/ONSdigital/dp-net/http"
@@ -18,117 +19,6 @@ import (
 )
 
 var testCtx = context.Background()
-
-// testCsv is the expected CSV generated from a successful query for testing
-var testCsv = `count,City,Number of siblings
-1,London,No siblings
-0,London,1 sibling
-0,London,2 siblings
-1,London,3 siblings
-0,London,4 siblings
-0,London,5 siblings
-0,London,6 or more siblings
-0,Liverpool,No siblings
-0,Liverpool,1 sibling
-0,Liverpool,2 siblings
-0,Liverpool,3 siblings
-1,Liverpool,4 siblings
-0,Liverpool,5 siblings
-0,Liverpool,6 or more siblings
-0,Belfast,No siblings
-0,Belfast,1 sibling
-1,Belfast,2 siblings
-0,Belfast,3 siblings
-0,Belfast,4 siblings
-1,Belfast,5 siblings
-1,Belfast,6 or more siblings
-`
-
-// mockRespBody is a successful query respose that is returned from a mocked client for testing
-var mockRespBody = `
-{
-	"data": {
-		"dataset": {
-			"table": {
-				"dimensions": [
-					{
-						"categories": [
-							{"code": "0", "label": "London"},
-							{"code": "1", "label": "Liverpool"},
-							{"code": "2", "label": "Belfast"}
-						],
-						"count": 3,
-						"variable": {"label": "City", "name": "city"}
-					},
-					{
-						"categories": [
-							{"code": "0", "label": "No siblings"},
-							{"code": "1", "label": "1 sibling"},
-							{"code": "2", "label": "2 siblings"},
-							{"code": "3", "label": "3 siblings"},
-							{"code": "4", "label": "4 siblings"},
-							{"code": "5", "label": "5 siblings"},
-							{"code": "6", "label": "6 or more siblings"}
-						],
-						"count":7,
-						"variable": {"label": "Number of siblings", "name": "siblings"}
-					}
-				],
-				"error": null,
-				"values": [1,0,0,1,0,0,0,0,0,0,0,1,0,0,0,0,1,0,0,1,1]
-			}
-		}
-	}
-}`
-
-// mockRespBodyNoDataset is an error response that is returned from a mocked client for testing
-// when a wrong Dataset is provided in the query
-var mockRespBodyNoDataset = `
-{
-	"data": {
-		"dataset": null
-	},
-	"errors": [
-		{
-			"message": "404 Not Found: dataset not loaded in this server",
-			"locations": [
-				{
-					"line": 2,
-					"column": 2
-				}
-			],
-			"path": [
-				"dataset"
-			]
-		}
-	]
-}`
-
-// mockRespBodyNoTable is an error response that is returned from a mocked client for testing
-// when a wrong variable is provided in the query
-var mockRespBodyNoTable = `
-{
-	"data": {
-		"dataset": {
-			"table": null
-		}
-	},
-	"errors": [
-		{
-			"message": "400 Bad Request: variable at position 1 does not exist",
-			"locations": [
-				{
-					"line": 3,
-					"column": 3
-				}
-			],
-			"path": [
-				"dataset",
-				"table"
-			]
-		}
-	]
-}`
 
 func TestStream(t *testing.T) {
 	Convey("Given a stream consumer that scans an io.Reader", t, func() {
@@ -146,7 +36,7 @@ func TestStream(t *testing.T) {
 			mockHttpClient := &dphttp.ClienterMock{
 				PostFunc: func(ctx context.Context, url string, contentType string, body io.Reader) (*http.Response, error) {
 					return Response(
-						[]byte(mockRespBody),
+						[]byte(mockRespBodyStaticDataset),
 						http.StatusOK,
 					), nil
 				},
@@ -168,7 +58,7 @@ func TestStream(t *testing.T) {
 				}
 				rowCount, err := cantabularClient.StaticDatasetQueryStreamCSV(testCtx, req, consume)
 				So(err, ShouldBeNil)
-				So(out, ShouldResemble, testCsv)
+				So(out, ShouldResemble, expectedCsv)
 				So(rowCount, ShouldEqual, 22)
 			})
 
@@ -413,3 +303,611 @@ func TestStaticDatasetQueryUnHappy(t *testing.T) {
 		})
 	})
 }
+
+func TestGetDimensionsHappy(t *testing.T) {
+	Convey("Given a correct getDimensions response from the /graphql endpoint", t, func() {
+		testCtx := context.Background()
+
+		mockHttpClient := &dphttp.ClienterMock{
+			PostFunc: func(ctx context.Context, url string, contentType string, body io.Reader) (*http.Response, error) {
+				return Response(
+					[]byte(mockRespBodyGetDimensions),
+					http.StatusOK,
+				), nil
+			},
+		}
+
+		cantabularClient := cantabular.NewClient(
+			cantabular.Config{
+				Host:       "cantabular.host",
+				ExtApiHost: "cantabular.ext.host",
+			},
+			mockHttpClient,
+			nil,
+		)
+
+		Convey("When the GetDimensions method is called", func() {
+			resp, err := cantabularClient.GetDimensions(testCtx, "Teaching-Dataset")
+
+			Convey("No error should be returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("And the expected response is returned", func() {
+				So(*resp, ShouldResemble, expectedDimensions)
+			})
+		})
+	})
+}
+
+func TestGetDimensionsUnhappy(t *testing.T) {
+	Convey("Given a mocked cantabular client that returns a no-dataset graphql error", t, func() {
+		testCtx := context.Background()
+
+		mockHttpClient := &dphttp.ClienterMock{
+			PostFunc: func(ctx context.Context, url string, contentType string, body io.Reader) (*http.Response, error) {
+				return Response(
+					[]byte(mockRespBodyNoDataset),
+					http.StatusOK,
+				), nil
+			},
+		}
+
+		cantabularClient := cantabular.NewClient(
+			cantabular.Config{
+				Host:       "cantabular.host",
+				ExtApiHost: "cantabular.ext.host",
+			},
+			mockHttpClient,
+			nil,
+		)
+
+		Convey("Then the expected error is returned", func() {
+			resp, err := cantabularClient.GetDimensions(testCtx, "InexistentDataset")
+
+			So(err, ShouldResemble, dperrors.New(
+				errors.New("error(s) returned by graphQL query"),
+				http.StatusOK,
+				log.Data{
+					"errors": []gql.Error{
+						{
+							Message:   "404 Not Found: dataset not loaded in this server",
+							Path:      []string{"dataset"},
+							Locations: []gql.Location{{Line: 2, Column: 2}},
+						},
+					},
+				},
+			))
+			So(resp, ShouldBeNil)
+		})
+	})
+}
+
+func TestGetDimensionOptionsHappy(t *testing.T) {
+	Convey("Given a correct getDimensionOptions response from the /graphql endpoint", t, func() {
+		testCtx := context.Background()
+
+		mockHttpClient := &dphttp.ClienterMock{
+			PostFunc: func(ctx context.Context, url string, contentType string, body io.Reader) (*http.Response, error) {
+				return Response(
+					[]byte(mockRespBodyGetDimensionOptions),
+					http.StatusOK,
+				), nil
+			},
+		}
+
+		cantabularClient := cantabular.NewClient(
+			cantabular.Config{
+				Host:       "cantabular.host",
+				ExtApiHost: "cantabular.ext.host",
+			},
+			mockHttpClient,
+			nil,
+		)
+
+		Convey("When the GetDimensionOptions method is called", func() {
+			req := cantabular.StaticDatasetQueryRequest{
+				Dataset:   "Teaching-Dataset",
+				Variables: []string{"Country", "Age", "Occupation"},
+			}
+			resp, err := cantabularClient.GetDimensionOptions(testCtx, req)
+
+			Convey("No error should be returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("And the expected response is returned", func() {
+				So(*resp, ShouldResemble, expectedDimensionOptions)
+			})
+		})
+	})
+}
+
+func TestGetDimensionOptionsUnhappy(t *testing.T) {
+	testCtx := context.Background()
+
+	Convey("Given a mocked cantabular client that returns a no-dataset graphql error", t, func() {
+		mockHttpClient := &dphttp.ClienterMock{
+			PostFunc: func(ctx context.Context, url string, contentType string, body io.Reader) (*http.Response, error) {
+				return Response(
+					[]byte(mockRespBodyNoDataset),
+					http.StatusOK,
+				), nil
+			},
+		}
+
+		cantabularClient := cantabular.NewClient(
+			cantabular.Config{
+				Host:       "cantabular.host",
+				ExtApiHost: "cantabular.ext.host",
+			},
+			mockHttpClient,
+			nil,
+		)
+
+		Convey("When the GetDimensionOptions method is called", func() {
+			req := cantabular.StaticDatasetQueryRequest{
+				Dataset:   "InexistentDataset",
+				Variables: []string{"Country", "Age", "Occupation"},
+			}
+			resp, err := cantabularClient.GetDimensionOptions(testCtx, req)
+
+			Convey("Then the expected error is returned", func() {
+				So(err, ShouldResemble, dperrors.New(
+					errors.New("error(s) returned by graphQL query"),
+					http.StatusOK,
+					log.Data{
+						"errors": []gql.Error{
+							{
+								Message:   "404 Not Found: dataset not loaded in this server",
+								Path:      []string{"dataset"},
+								Locations: []gql.Location{{Line: 2, Column: 2}},
+							},
+						},
+					},
+				))
+				So(resp, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("Given a mocked cantabular client that returns a no-variable graphql error", t, func() {
+		mockHttpClient := &dphttp.ClienterMock{
+			PostFunc: func(ctx context.Context, url string, contentType string, body io.Reader) (*http.Response, error) {
+				return Response(
+					[]byte(mockRespBodyNoVariable),
+					http.StatusOK,
+				), nil
+			},
+		}
+
+		cantabularClient := cantabular.NewClient(
+			cantabular.Config{
+				Host:       "cantabular.host",
+				ExtApiHost: "cantabular.ext.host",
+			},
+			mockHttpClient,
+			nil,
+		)
+
+		Convey("When the GetDimensionOptions method is called", func() {
+			req := cantabular.StaticDatasetQueryRequest{
+				Dataset:   "Teaching-Dataset",
+				Variables: []string{"Country", "Age", "inexistentVariable"},
+			}
+			resp, err := cantabularClient.GetDimensionOptions(testCtx, req)
+
+			Convey("Then the expected error is returned", func() {
+				So(err, ShouldResemble, dperrors.New(
+					errors.New("error(s) returned by graphQL query"),
+					http.StatusOK,
+					log.Data{
+						"errors": []gql.Error{
+							{
+								Message:   "400 Bad Request: variable at position 3 does not exist",
+								Path:      []string{"dataset", "table"},
+								Locations: []gql.Location{{Line: 4, Column: 3}},
+							},
+						},
+					},
+				))
+				So(resp, ShouldBeNil)
+			})
+		})
+	})
+}
+
+// mockRespBodyStaticDataset is a successful static dataset query respose that is returned from a mocked client for testing
+var mockRespBodyStaticDataset = `
+{
+	"data": {
+		"dataset": {
+			"table": {
+				"dimensions": [
+					{
+						"categories": [
+							{"code": "0", "label": "London"},
+							{"code": "1", "label": "Liverpool"},
+							{"code": "2", "label": "Belfast"}
+						],
+						"count": 3,
+						"variable": {"label": "City", "name": "city"}
+					},
+					{
+						"categories": [
+							{"code": "0", "label": "No siblings"},
+							{"code": "1", "label": "1 sibling"},
+							{"code": "2", "label": "2 siblings"},
+							{"code": "3", "label": "3 siblings"},
+							{"code": "4", "label": "4 siblings"},
+							{"code": "5", "label": "5 siblings"},
+							{"code": "6", "label": "6 or more siblings"}
+						],
+						"count":7,
+						"variable": {"label": "Number of siblings", "name": "siblings"}
+					}
+				],
+				"error": null,
+				"values": [1,0,0,1,0,0,0,0,0,0,0,1,0,0,0,0,1,0,0,1,1]
+			}
+		}
+	}
+}`
+
+// expectedCsv is the expected CSV generated from a successful static dataset query for testing
+var expectedCsv = `count,City,Number of siblings
+1,London,No siblings
+0,London,1 sibling
+0,London,2 siblings
+1,London,3 siblings
+0,London,4 siblings
+0,London,5 siblings
+0,London,6 or more siblings
+0,Liverpool,No siblings
+0,Liverpool,1 sibling
+0,Liverpool,2 siblings
+0,Liverpool,3 siblings
+1,Liverpool,4 siblings
+0,Liverpool,5 siblings
+0,Liverpool,6 or more siblings
+0,Belfast,No siblings
+0,Belfast,1 sibling
+1,Belfast,2 siblings
+0,Belfast,3 siblings
+0,Belfast,4 siblings
+1,Belfast,5 siblings
+1,Belfast,6 or more siblings
+`
+
+// mockRespBodyGetDimensions is a successful 'get dimensions' query respose that is returned from a mocked client for testing
+var mockRespBodyGetDimensions = `
+{
+	"data": {
+		"dataset": {
+			"ruleBase": {
+				"isSourceOf": {
+					"edges": [
+						{
+							"node": {
+								"categories": {
+									"totalCount": 2
+								},
+								"label": "Country",
+								"mapFrom": [
+									{
+										"edges": [
+											{
+												"node": {
+													"filterOnly": "false",
+													"label": "Region",
+													"name": "Region"
+												}
+											}
+										]
+									}
+								],
+								"name": "Country"
+							}
+						},
+						{
+							"node": {
+								"categories": {
+									"totalCount": 10
+								},
+								"label": "Region",
+								"mapFrom": [],
+								"name": "Region"
+							}
+						}
+					]
+				},
+				"name": "Region"
+			}
+		}
+	}
+}`
+
+// expectedDimensions is the expected response struct generated from a successful 'get dimensions' query for testing
+var expectedDimensions = cantabular.GetDimensionsResponse{
+	Dataset: gql.Dataset{
+		RuleBase: gql.RuleBase{
+			IsSourceOf: gql.MapFrom{
+				Edges: []gql.Edge{
+					{
+						Node: gql.Node{
+							Name:       "Country",
+							Label:      "Country",
+							Categories: gql.Categories{TotalCount: 2},
+							MapFrom: []gql.MapFrom{
+								{
+									Edges: []gql.Edge{
+										{
+											Node: gql.Node{
+												FilterOnly: "false",
+												Label:      "Region",
+												Name:       "Region",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Node: gql.Node{
+							Name:       "Region",
+							Label:      "Region",
+							Categories: gql.Categories{TotalCount: 10},
+							MapFrom:    []gql.MapFrom{},
+						},
+					},
+				},
+			},
+			Name: "Region",
+		},
+	},
+}
+
+// mockRespBodyGetDimensionOptions is a successful 'get dimension options' query respose that is returned from a mocked client for testing
+var mockRespBodyGetDimensionOptions = `
+{
+    "data": {
+        "dataset": {
+            "table": {
+                "dimensions": [
+                    {
+                        "categories": [
+                            {
+                                "code": "E",
+                                "label": "England"
+                            },
+                            {
+                                "code": "W",
+                                "label": "Wales"
+                            }
+                        ],
+                        "variable": {
+                            "label": "Country",
+                            "name": "Country"
+                        }
+                    },
+                    {
+                        "categories": [
+                            {
+                                "code": "1",
+                                "label": "0 to 15"
+                            },
+                            {
+                                "code": "2",
+                                "label": "16 to 24"
+                            },
+                            {
+                                "code": "3",
+                                "label": "25 to 34"
+                            },
+                            {
+                                "code": "4",
+                                "label": "35 to 44"
+                            },
+                            {
+                                "code": "5",
+                                "label": "45 to 54"
+                            },
+                            {
+                                "code": "6",
+                                "label": "55 to 64"
+                            },
+                            {
+                                "code": "7",
+                                "label": "65 to 74"
+                            },
+                            {
+                                "code": "8",
+                                "label": "75 and over"
+                            }
+                        ],
+                        "variable": {
+                            "label": "Age",
+                            "name": "Age"
+                        }
+                    },
+                    {
+                        "categories": [
+                            {
+                                "code": "1",
+                                "label": "Managers, Directors and Senior Officials"
+                            },
+                            {
+                                "code": "2",
+                                "label": "Professional Occupations"
+                            },
+                            {
+                                "code": "3",
+                                "label": "Associate Professional and Technical Occupations"
+                            },
+                            {
+                                "code": "4",
+                                "label": "Administrative and Secretarial Occupations"
+                            },
+                            {
+                                "code": "5",
+                                "label": "Skilled Trades Occupations"
+                            },
+                            {
+                                "code": "6",
+                                "label": "Caring, Leisure and Other Service Occupations"
+                            },
+                            {
+                                "code": "7",
+                                "label": "Sales and Customer Service Occupations"
+                            },
+                            {
+                                "code": "8",
+                                "label": "Process, Plant and Machine Operatives"
+                            },
+                            {
+                                "code": "9",
+                                "label": "Elementary Occupations"
+                            },
+                            {
+                                "code": "-9",
+                                "label": "N/A"
+                            }
+                        ],
+                        "variable": {
+                            "label": "Occupation",
+                            "name": "Occupation"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}`
+
+// expectedDimensionOptions is the expected response struct generated from a successful 'get dimension options' query for testing
+var expectedDimensionOptions = cantabular.GetDimensionOptionsResponse{
+	Dataset: cantabular.StaticDatasetDimensionOptions{
+		Table: cantabular.DimensionsTable{
+			Dimensions: []cantabular.Dimension{
+				{
+					Variable: cantabular.VariableBase{
+						Name:  "Country",
+						Label: "Country",
+					},
+					Categories: []cantabular.Category{
+						{Code: "E", Label: "England"},
+						{Code: "W", Label: "Wales"},
+					},
+				},
+				{
+					Variable: cantabular.VariableBase{
+						Label: "Age",
+						Name:  "Age",
+					},
+					Categories: []cantabular.Category{
+						{Code: "1", Label: "0 to 15"},
+						{Code: "2", Label: "16 to 24"},
+						{Code: "3", Label: "25 to 34"},
+						{Code: "4", Label: "35 to 44"},
+						{Code: "5", Label: "45 to 54"},
+						{Code: "6", Label: "55 to 64"},
+						{Code: "7", Label: "65 to 74"},
+						{Code: "8", Label: "75 and over"},
+					},
+				},
+				{
+					Variable: cantabular.VariableBase{
+						Name:  "Occupation",
+						Label: "Occupation",
+					},
+					Categories: []cantabular.Category{
+						{Code: "1", Label: "Managers, Directors and Senior Officials"},
+						{Code: "2", Label: "Professional Occupations"},
+						{Code: "3", Label: "Associate Professional and Technical Occupations"},
+						{Code: "4", Label: "Administrative and Secretarial Occupations"},
+						{Code: "5", Label: "Skilled Trades Occupations"},
+						{Code: "6", Label: "Caring, Leisure and Other Service Occupations"},
+						{Code: "7", Label: "Sales and Customer Service Occupations"},
+						{Code: "8", Label: "Process, Plant and Machine Operatives"},
+						{Code: "9", Label: "Elementary Occupations"},
+						{Code: "-9", Label: "N/A"},
+					},
+				},
+			},
+		},
+	},
+}
+
+// mockRespBodyNoDataset is an error response that is returned from a mocked client for testing
+// when a wrong Dataset is provided in the query
+var mockRespBodyNoDataset = `
+{
+	"data": {
+		"dataset": null
+	},
+	"errors": [
+		{
+			"message": "404 Not Found: dataset not loaded in this server",
+			"locations": [
+				{
+					"line": 2,
+					"column": 2
+				}
+			],
+			"path": [
+				"dataset"
+			]
+		}
+	]
+}`
+
+// mockRespBodyNoVariable is an error response that is returned from a mocked client for testing
+// when a wrong Variable name is provided in the query
+var mockRespBodyNoVariable = `
+{
+	"data": {
+		"dataset": null
+	},
+	"errors": [
+		{
+			"message": "400 Bad Request: variable at position 3 does not exist",
+			"locations": [
+				{
+					"line": 4,
+					"column": 3
+				}
+			],
+			"path": [
+				"dataset",
+				"table"
+			]
+		}
+	]
+}`
+
+// mockRespBodyNoTable is an error response that is returned from a mocked client for testing
+// when a wrong variable is provided in the query
+var mockRespBodyNoTable = `
+{
+	"data": {
+		"dataset": {
+			"table": null
+		}
+	},
+	"errors": [
+		{
+			"message": "400 Bad Request: variable at position 1 does not exist",
+			"locations": [
+				{
+					"line": 3,
+					"column": 3
+				}
+			],
+			"path": [
+				"dataset",
+				"table"
+			]
+		}
+	]
+}`


### PR DESCRIPTION
### What

- Implemented GetDimensions for Cantabular using graphQL (query all variables for a provided dataset)
- Implemented GetDimensionsByName for Cantabular using graphQL (query only provided variables for a dataset)
- Implemented GetDimensionOptions for Cantabular using graphQL (query categories for provided variables and dataset)
- Added unit tests

trello card: https://trello.com/c/P1WrnEct/5439-add-method-to-dp-api-clients-go-for-cantabular-flexible-datasets

used by:
- https://github.com/ONSdigital/dp-import-cantabular-dataset/pull/37
- https://github.com/ONSdigital/dp-import-cantabular-dimension-options/pull/36

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

- (tried locally, no need to reproduce) You can run Cantabular server and API ext locally, and replace the unit test mocks with a real Cantabular connection like so, to validate that the client will behave as expected:
```
cantabularClient := cantabular.NewClient(
  cantabular.Config{
    Host:       "http://localhost:8491",
    ExtApiHost: "http://localhost:8492",
  },
  dphttp.NewClient(),
  nil,
)
```

__
(tried against large dataset in develop, no need to reproduce)
- dp ssh to cantabular api-ext: `dp ssh develop publishing 5 -p 8492:10.201.4.101:12100`
- Modified the `GetDimensionOptionsHappy` test to:
  - use a real client as described above
  - do the following request:
```
req := cantabular.StaticDatasetQueryRequest{
  Dataset:   "People-Households",
  Variables: []string{"oa"},
}

var m0, m1 runtime.MemStats

t0 := time.Now()
runtime.ReadMemStats(&m0)
resp, err := cantabularClient.GetDimensionOptions(testCtx, req)
runtime.ReadMemStats(&m1)
t1 := time.Since(t0)

fmt.Println("Time:      ", t1.String())
fmt.Println("Alloc:     ", m1.Alloc-m0.Alloc)
fmt.Println("TotalAlloc:", m1.TotalAlloc-m0.TotalAlloc)
fmt.Println("HeapAlloc: ", m1.HeapAlloc-m0.HeapAlloc)
```

  - debugging the code, I see `181407` categories that are queried and unmarshaled.
  - The results of a few runs are as follow:
  
| Time                  | Alloc          | TotalAlloc   | HeapAlloc
| --------------- | ---------- | ----------- | ------------
| 5.404870996s | 33181576 | 82444032  | 33181576
| 7.233135859s | 33182528 | 82444000  | 33182528
| 7.479702024s | 33183840 | 82444632  | 33183840
| 6.505728501s | 33183672 | 82443600  | 33183672
| 8.37185516s | 33185192 | 82444600  | 33185192
| 5.802228546s | 33186392 | 82443704  | 33186392
| 5.238508307s | 33185024 | 82444120  | 33185024
| 6.788198018s | 33185080 | 82443720  | 33185080
| 6.428873483s | 33182512 | 82444504  | 33182512
| 5.019777482s | 33182960 | 82441504  | 33182960

### Who can review

anyone