### PR TITLE
do not error on empty values when setting headers (for all headers)

### DIFF
--- a/cantabular/client.go
+++ b/cantabular/client.go
@@ -136,8 +136,8 @@ func (c *Client) checkHealth(ctx context.Context, state *healthcheck.CheckState,
 		log.Error(ctx, "failed to request service health", err, logData)
 	} else {
 		code = res.StatusCode
-		defer closeResponseBody(ctx, res)
 	}
+	defer closeResponseBody(ctx, res)
 
 	switch code {
 	case 0: // When there is a problem with the client return error in message

--- a/cantabular/codebook.go
+++ b/cantabular/codebook.go
@@ -81,7 +81,7 @@ func (c *Client) GetCodebook(ctx context.Context, req GetCodebookRequest) (*GetC
 
 // closeResponseBody closes the response body and logs an error if unsuccessful
 func closeResponseBody(ctx context.Context, resp *http.Response) {
-	if resp.Body != nil {
+	if resp != nil && resp.Body != nil {
 		if err := resp.Body.Close(); err != nil {
 			log.Error(ctx, "error closing http response body", err)
 		}

--- a/codelist/codelist.go
+++ b/codelist/codelist.go
@@ -298,12 +298,12 @@ func (c *Client) doGetWithAuthHeaders(ctx context.Context, userAuthToken string,
 
 func setAuthenticationHeaders(req *http.Request, userAuthToken, serviceAuthToken string) error {
 	err := headers.SetAuthToken(req, userAuthToken)
-	if err != nil && err != headers.ErrValueEmpty {
+	if err != nil {
 		return err
 	}
 
 	err = headers.SetServiceAuthToken(req, serviceAuthToken)
-	if err != nil && err != headers.ErrValueEmpty {
+	if err != nil {
 		return err
 	}
 

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -58,7 +58,7 @@ var (
 	// ErrHeaderNotFound returned if the requested header is not present in the provided request
 	ErrHeaderNotFound = errors.New("header not found")
 
-	// ErrValueEmpty returned if an empty value is passed to a SetX header function
+	// ErrValueEmpty returned if an empty value is passed when a non-empty value is required
 	ErrValueEmpty = errors.New("header not set as value was empty")
 
 	// ErrRequestNil return if SetX header function is called with a nil request
@@ -173,21 +173,25 @@ func getResponseHeader(resp *http.Response, headerName string) (string, error) {
 }
 
 // SetCollectionID set the collection ID header on the provided request. If the collection ID header is already present
-// in the request it will be overwritten by the new value. If the header value is empty returns ErrValueEmpty
+// in the request it will be overwritten by the new value. Empty values are allowed for this header
 func SetCollectionID(req *http.Request, headerValue string) error {
-	return setRequestHeader(req, collectionIDHeader, headerValue)
+	err := setRequestHeader(req, collectionIDHeader, headerValue)
+	if err != nil && err != ErrValueEmpty {
+		return err
+	}
+	return nil
 }
 
 // SetServiceAuthToken set the service authentication token header on the provided request. If the authentication token is
-// already present it will be overwritten by the new value. If the header value is empty then returns ErrValueEmpty
-// Replaces deprecated SetUserAuthToken function
+// already present it will be overwritten by the new value. Empty values are allowed for this header.
+// Replaces deprecated SetUserAuthToken function.
 func SetServiceAuthToken(req *http.Request, headerValue string) error {
 	if req == nil {
 		return ErrRequestNil
 	}
 
 	if len(headerValue) == 0 {
-		return ErrValueEmpty
+		return nil
 	}
 
 	if !strings.HasPrefix(headerValue, bearerPrefix) {
@@ -198,12 +202,17 @@ func SetServiceAuthToken(req *http.Request, headerValue string) error {
 }
 
 // SetAuthToken set the access token header on the provided request. If the access token is
-// already present it will be overwritten by the new value. If the header value is empty returns ErrValueEmpty
+// already present it will be overwritten by the new value. Empty values are allowed for this header.
 func SetAuthToken(req *http.Request, headerValue string) error {
 	// TODO remove the userAuthTokenHeader once the X-Florence-Token has been removed
-	if err := setRequestHeader(req, userAuthTokenHeader, headerValue); err != nil {
+	err := setRequestHeader(req, userAuthTokenHeader, headerValue)
+	if err == ErrValueEmpty {
+		return nil
+	}
+	if err != nil {
 		return err
 	}
+
 	// Add bearer prefix if not present
 	if !strings.HasPrefix(headerValue, bearerPrefix) {
 		headerValue = bearerPrefix + headerValue
@@ -212,51 +221,83 @@ func SetAuthToken(req *http.Request, headerValue string) error {
 }
 
 // SetIDTokenHeader set the ID token  header on the provided request. If the authentication
-// token is already present it will be overwritten by the new value. If the header value is empty returns ErrValueEmpty
+// token is already present it will be overwritten by the new value. Empty values are allowed for this header.
 func SetIDTokenHeader(req *http.Request, headerValue string) error {
-	return setRequestHeader(req, idTokenHeader, headerValue)
+	err := setRequestHeader(req, idTokenHeader, headerValue)
+	if err != nil && err != ErrValueEmpty {
+		return err
+	}
+	return nil
 }
 
 // SetRefreshTokenHeader set the refresh token header on the provided request. If the authentication
-// token is already present it will be overwritten by the new value. If the header value is empty returns ErrValueEmpty
+// token is already present it will be overwritten by the new value. Empty values are allowed for this header.
 func SetRefreshTokenHeader(req *http.Request, headerValue string) error {
-	return setRequestHeader(req, refreshTokenHeader, headerValue)
+	err := setRequestHeader(req, refreshTokenHeader, headerValue)
+	if err != nil && err != ErrValueEmpty {
+		return err
+	}
+	return nil
 }
 
 // SetDownloadServiceToken set the download service auth token header on the provided request. If the authentication
-// token is already present it will be overwritten by the new value. If the header value is empty returns ErrValueEmpty
+// token is already present it will be overwritten by the new value. Empty values are allowed for this header.
 func SetDownloadServiceToken(req *http.Request, headerValue string) error {
-	return setRequestHeader(req, downloadServiceTokenHeader, headerValue)
+	err := setRequestHeader(req, downloadServiceTokenHeader, headerValue)
+	if err != nil && err != ErrValueEmpty {
+		return err
+	}
+	return nil
 }
 
 // SetUserIdentity set the user identity header on the provided request. If a user identity token is already present it
-// will be overwritten by the new value. If the header value is empty returns ErrValueEmpty
+// will be overwritten by the new value. Empty values are allowed for this header.
 func SetUserIdentity(req *http.Request, headerValue string) error {
-	return setRequestHeader(req, userIdentityHeader, headerValue)
+	err := setRequestHeader(req, userIdentityHeader, headerValue)
+	if err != nil && err != ErrValueEmpty {
+		return err
+	}
+	return nil
 }
 
 // SetRequestID set the unique request ID header on the provided request. If a request ID header is already present it
-// will be overwritten by the new value. If the header value is empty returns ErrValueEmpty
+// will be overwritten by the new value. Empty values are allowed for this header.
 func SetRequestID(req *http.Request, headerValue string) error {
-	return setRequestHeader(req, requestIDHeader, headerValue)
+	err := setRequestHeader(req, requestIDHeader, headerValue)
+	if err != nil && err != ErrValueEmpty {
+		return err
+	}
+	return nil
 }
 
 // SetLocaleCode set the locale code header on the provided request. If this header is already present it
-// will be overwritten by the new value. If the header value is empty returns ErrValueEmpty
+// will be overwritten by the new value. Empty values are allowed for this header.
 func SetLocaleCode(req *http.Request, headerValue string) error {
-	return setRequestHeader(req, localeCodeHeader, headerValue)
+	err := setRequestHeader(req, localeCodeHeader, headerValue)
+	if err != nil && err != ErrValueEmpty {
+		return err
+	}
+	return nil
 }
 
 // SetIfMatch set the If-Match header on the provided request. If this header is already present it
-// will be overwritten by the new value. If the header value is empty returns ErrValueEmpty
+// will be overwritten by the new value. Empty values are allowed for this header.
 func SetIfMatch(req *http.Request, headerValue string) error {
-	return setRequestHeader(req, ifMatchHeader, headerValue)
+	err := setRequestHeader(req, ifMatchHeader, headerValue)
+	if err != nil && err != ErrValueEmpty {
+		return err
+	}
+	return nil
 }
 
 // SetETag set the ETag header on the provided request. If this header is already present it
-// will be overwritten by the new value. If the header value is empty returns ErrValueEmpty
+// will be overwritten by the new value. Empty values are allowed for this header.
 func SetETag(req *http.Request, headerValue string) error {
-	return setRequestHeader(req, eTagHeader, headerValue)
+	err := setRequestHeader(req, eTagHeader, headerValue)
+	if err != nil && err != ErrValueEmpty {
+		return err
+	}
+	return nil
 }
 
 func setRequestHeader(req *http.Request, headerName string, headerValue string) error {

--- a/headers/headers_test.go
+++ b/headers/headers_test.go
@@ -97,7 +97,7 @@ func setterTestCases(t *testing.T, fnName, headerName string, fnUnderTest func(r
 				return r.Header.Get(headerName)
 			},
 			assertResultFunc: func(err error, val string) {
-				So(err, ShouldResemble, ErrValueEmpty)
+				So(err, ShouldBeNil)
 				So(val, ShouldBeEmpty)
 			},
 		},
@@ -189,7 +189,7 @@ func TestSetServiceAuthToken(t *testing.T) {
 				return r.Header.Get(serviceAuthTokenHeader)
 			},
 			assertResultFunc: func(err error, val string) {
-				So(err, ShouldResemble, ErrValueEmpty)
+				So(err, ShouldBeNil)
 				So(val, ShouldBeEmpty)
 			},
 		},

--- a/recipe/client.go
+++ b/recipe/client.go
@@ -61,11 +61,11 @@ func (c *Client) doGetWithAuthHeaders(ctx context.Context, userAuthToken, servic
 	}
 
 	err = headers.SetAuthToken(req, userAuthToken)
-	if err != nil && err != headers.ErrValueEmpty {
+	if err != nil {
 		return nil, err
 	}
 	err = headers.SetServiceAuthToken(req, serviceAuthToken)
-	if err != nil && err != headers.ErrValueEmpty {
+	if err != nil {
 		return nil, err
 	}
 	return c.hcCli.Client.Do(ctx, req)


### PR DESCRIPTION
### What

Bugfix: 
When the headers error handling was fixed, it caused that errors setting headers were being returned to the caller.
Most callers assumed that empty values would be allowed, so that fix broke some expectations of callers, because by default, all headers would expect non-empty values, and fail with `ErrValueEmpty` otherwise.

In this PR we ignore `ErrValueEmpty` when trying to set any header, but the error type has been kept and returned by the lower level func `setRequestHeader` so that if a header becomes mandatory, we can just forward this error to the caller in the future.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

anyone