### PR TITLE
extract cantabular status code from error message

### DIFF
--- a/cantabular/client.go
+++ b/cantabular/client.go
@@ -132,12 +132,13 @@ func (c *Client) checkHealth(ctx context.Context, state *healthcheck.CheckState,
 	code := 0
 
 	res, err := c.httpGet(ctx, reqURL)
+	defer closeResponseBody(ctx, res)
+
 	if err != nil {
 		log.Error(ctx, "failed to request service health", err, logData)
 	} else {
 		code = res.StatusCode
 	}
-	defer closeResponseBody(ctx, res)
 
 	switch code {
 	case 0: // When there is a problem with the client return error in message

--- a/cantabular/dimensions.go
+++ b/cantabular/dimensions.go
@@ -3,7 +3,6 @@ package cantabular
 import (
 	"context"
 	"errors"
-	"net/http"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular/gql"
 	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
@@ -25,7 +24,7 @@ func (c *Client) GetDimensions(ctx context.Context, dataset string) (*GetDimensi
 	if resp != nil && len(resp.Errors) != 0 {
 		return nil, dperrors.New(
 			errors.New("error(s) returned by graphQL query"),
-			http.StatusOK,
+			resp.Errors[0].StatusCode(),
 			log.Data{"errors": resp.Errors},
 		)
 	}
@@ -48,7 +47,7 @@ func (c *Client) GetGeographyDimensions(ctx context.Context, dataset string) (*G
 	if resp != nil && len(resp.Errors) != 0 {
 		return nil, dperrors.New(
 			errors.New("error(s) returned by graphQL query"),
-			http.StatusOK,
+			resp.Errors[0].StatusCode(),
 			log.Data{"errors": resp.Errors},
 		)
 	}
@@ -76,7 +75,7 @@ func (c *Client) GetDimensionsByName(ctx context.Context, req GetDimensionsByNam
 	if resp != nil && len(resp.Errors) != 0 {
 		return nil, dperrors.New(
 			errors.New("error(s) returned by graphQL query"),
-			http.StatusOK,
+			resp.Errors[0].StatusCode(),
 			log.Data{"errors": resp.Errors},
 		)
 	}
@@ -105,7 +104,7 @@ func (c *Client) GetDimensionOptions(ctx context.Context, req GetDimensionOption
 	if resp != nil && len(resp.Errors) != 0 {
 		return nil, dperrors.New(
 			errors.New("error(s) returned by graphQL query"),
-			http.StatusOK,
+			resp.Errors[0].StatusCode(),
 			log.Data{"errors": resp.Errors},
 		)
 	}

--- a/cantabular/dimensions.go
+++ b/cantabular/dimensions.go
@@ -17,7 +17,11 @@ func (c *Client) GetDimensions(ctx context.Context, dataset string) (*GetDimensi
 		Errors []gql.Error           `json:"errors,omitempty"`
 	}{}
 
-	if err := c.queryUnmarshal(ctx, QueryDimensions, QueryData{Dataset: dataset}, resp); err != nil {
+	data := QueryData{
+		Dataset: dataset,
+	}
+
+	if err := c.queryUnmarshal(ctx, QueryDimensions, data, resp); err != nil {
 		return nil, err
 	}
 
@@ -40,7 +44,11 @@ func (c *Client) GetGeographyDimensions(ctx context.Context, dataset string) (*G
 		Errors []gql.Error                    `json:"errors,omitempty"`
 	}{}
 
-	if err := c.queryUnmarshal(ctx, QueryGeographyDimensions, QueryData{Dataset: dataset}, resp); err != nil {
+	data := QueryData{
+		Dataset: dataset,
+	}
+
+	if err := c.queryUnmarshal(ctx, QueryGeographyDimensions, data, resp); err != nil {
 		return nil, err
 	}
 
@@ -97,7 +105,7 @@ func (c *Client) GetDimensionOptions(ctx context.Context, req GetDimensionOption
 		Variables: req.DimensionNames,
 	}
 
-	if err := c.queryUnmarshal(ctx, QueryDimensionOptions, QueryData(data), resp); err != nil {
+	if err := c.queryUnmarshal(ctx, QueryDimensionOptions, data, resp); err != nil {
 		return nil, err
 	}
 

--- a/cantabular/gql/error.go
+++ b/cantabular/gql/error.go
@@ -1,10 +1,37 @@
 package gql
 
+import (
+	"net/http"
+	"strconv"
+)
+
 type Error struct {
 	Message   string     `json:"message"`
 	Locations []Location `json:"locations"`
 	Path      []string   `json:"path"`
 }
+
+// StatusCode returns the status code defined at the begining of the Error message.
+// For example: a status 404 is extracted from '404 Not Found: dataset not loaded in this server'.
+// If no status code is provided, then a value of 502 bad gateway is returned.
+func (e *Error) StatusCode() int {
+	if len(e.Message) < 3 {
+		return http.StatusBadGateway
+	}
+
+	statusCode, err := strconv.Atoi(e.Message[:3])
+	if err != nil {
+		return http.StatusBadGateway
+	}
+
+	if http.StatusText(statusCode) == "" {
+		return http.StatusBadGateway
+	}
+
+	return statusCode
+}
+
+// 404 Not Found: dataset not loaded in this server
 
 type Location struct {
 	Line   int `json:"line"`

--- a/cantabular/gql/error_test.go
+++ b/cantabular/gql/error_test.go
@@ -1,0 +1,33 @@
+package gql_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular/gql"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestChecker(t *testing.T) {
+
+	Convey("A valid status code at the begining of the error message is correctly reported", t, func() {
+		err := gql.Error{Message: "404 Not Found: dataset not loaded in this server"}
+		So(err.StatusCode(), ShouldEqual, http.StatusNotFound)
+	})
+
+	Convey("A valid orted", t, func() {
+		err := gql.Error{Message: ""}
+		So(err.StatusCode(), ShouldEqual, http.StatusBadGateway)
+	})
+
+	Convey("A valid orted", t, func() {
+		err := gql.Error{Message: "678 Wrong code"}
+		So(err.StatusCode(), ShouldEqual, http.StatusBadGateway)
+	})
+
+	Convey("A valid orted", t, func() {
+		err := gql.Error{Message: "Some other error message"}
+		So(err.StatusCode(), ShouldEqual, http.StatusBadGateway)
+	})
+
+}

--- a/cantabular/queries.go
+++ b/cantabular/queries.go
@@ -70,7 +70,7 @@ query($dataset: String!) {
 	}
 }`
 
-// QueryDimensions is the graphQL query to obtain dimensions by name (subset of variables, without categories)
+// QueryDimensionsByName is the graphQL query to obtain dimensions by name (subset of variables, without categories)
 const QueryDimensionsByName = `
 query($dataset: String!, $variables: [String!]!) {
 	dataset(name: $dataset) {
@@ -156,10 +156,10 @@ func (c *Client) queryUnmarshal(ctx context.Context, graphQLQuery string, data Q
 	url := fmt.Sprintf("%s/graphql", c.extApiHost)
 
 	res, err := c.postQuery(ctx, graphQLQuery, data)
+	defer closeResponseBody(ctx, res)
 	if err != nil {
 		return err
 	}
-	defer closeResponseBody(ctx, res)
 
 	b, err := ioutil.ReadAll(res.Body)
 	if err != nil {

--- a/cantabular/static_dataset_dimension.go
+++ b/cantabular/static_dataset_dimension.go
@@ -61,9 +61,11 @@ func (it *Iterator) Next() error {
 }
 
 // CategoryAtColumn returns the i-th coordinate of the current cell
-func (it *Iterator) CategoryAtColumn(i int) Category {
-	it.checkNotAtEnd()
-	return it.dims[i].Categories[it.dimIndices[i]]
+func (it *Iterator) CategoryAtColumn(i int) (Category, error) {
+	if err := it.checkNotAtEnd(); err != nil {
+		return Category{}, err
+	}
+	return it.dims[i].Categories[it.dimIndices[i]], nil
 }
 
 func (it *Iterator) checkNotAtEnd() error {

--- a/cantabular/static_dataset_test.go
+++ b/cantabular/static_dataset_test.go
@@ -148,7 +148,7 @@ func TestStream(t *testing.T) {
 		Convey("And an http client that refuses to connect", func() {
 			mockHttpClient := &dphttp.ClienterMock{
 				PostFunc: func(ctx context.Context, url string, contentType string, body io.Reader) (*http.Response, error) {
-					return nil, errors.New(`Post "cantabular.ext.host/graphql": dial tcp 127.0.0.1:8493: connect: connection refused`)
+					return nil, errors.New(`post "cantabular.ext.host/graphql": dial tcp 127.0.0.1:8493: connect: connection refused`)
 				},
 			}
 
@@ -167,7 +167,7 @@ func TestStream(t *testing.T) {
 					Variables: []string{"city", "siblings"},
 				}
 				_, err := cantabularClient.StaticDatasetQueryStreamCSV(testCtx, req, consume)
-				So(err.Error(), ShouldResemble, `failed to make GraphQL query: failed to make request: Post "cantabular.ext.host/graphql": dial tcp 127.0.0.1:8493: connect: connection refused`)
+				So(err.Error(), ShouldResemble, `failed to make GraphQL query: failed to make request: post "cantabular.ext.host/graphql": dial tcp 127.0.0.1:8493: connect: connection refused`)
 				So(out, ShouldEqual, "")
 			})
 		})

--- a/cantabular/static_dataset_test.go
+++ b/cantabular/static_dataset_test.go
@@ -391,7 +391,7 @@ var mockRespBodyNoDataset = `
 // expectedNoDatasetErr is the expected error returned by a client when a no-dataset response is received from cantabular
 var expectedNoDatasetErr = dperrors.New(
 	errors.New("error(s) returned by graphQL query"),
-	http.StatusOK,
+	http.StatusNotFound,
 	log.Data{
 		"errors": []gql.Error{
 			{
@@ -442,7 +442,7 @@ var mockRespBodyNoVariable = `
 
 var expectedNoVariableErr = dperrors.New(
 	errors.New("error(s) returned by graphQL query"),
-	http.StatusOK,
+	http.StatusBadRequest,
 	log.Data{
 		"errors": []gql.Error{
 			{


### PR DESCRIPTION
### What

Modified StatusCode in returned Cantabular error to pass the error code defined in the Cantabular error message (instead of propagating the status code 200 OK, which is returned by cantabular itself)

Needed in order to return the right status in the cantabular dimensions api:
[Trello card](https://trello.com/c/tSdkHCF2/5452-get-area-types-implement-endpoint-8)

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

anyone