### PR TITLE
#818: Add ancestry (for breadcrumbs) to areas api - stubbed

### DIFF
--- a/areas/areas.go
+++ b/areas/areas.go
@@ -112,6 +112,7 @@ func (c *Client) GetRelations(ctx context.Context, userAuthToken, serviceAuthTok
 	if err != nil {
 		return
 	}
+
 	defer closeResponseBody(ctx, res)
 
 	if res.StatusCode != http.StatusOK {
@@ -124,6 +125,15 @@ func (c *Client) GetRelations(ctx context.Context, userAuthToken, serviceAuthTok
 		return
 	}
 	err = json.Unmarshal(b, &relations)
+	return
+}
+
+// GetAncestors gets ancestors data from areas api
+func (c *Client) GetAncestors(code string) (ancestors []Ancestor, err error) {
+	err = json.Unmarshal([]byte(StubbedAncestorAPIResponse(code)), &ancestors)
+	if err != nil {
+		return
+	}
 	return
 }
 

--- a/areas/areas_test.go
+++ b/areas/areas_test.go
@@ -262,6 +262,7 @@ func TestClient_GetRelations(t *testing.T) {
 				"href": "/v1/area/E12000003"
 			}
 		]`
+	expected := []Relation{Relation{AreaCode: "E12000001", AreaName: "North East", Href: "/v1/area/E12000001"}, Relation{AreaCode: "E12000002", AreaName: "North West", Href: "/v1/area/E12000002"}, Relation{AreaCode: "E12000003", AreaName: "Yorkshire and The Humbe", Href: "/v1/area/E12000003"}}
 	acceptedLang := "en-GB,en-US;q=0.9,en;q=0.8"
 	Convey("When a bad request is returned", t, func() {
 		mockedApi := getMockAreaAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: http.StatusBadRequest, Body: ""})
@@ -273,7 +274,7 @@ func TestClient_GetRelations(t *testing.T) {
 		mockedApi := getMockAreaAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: http.StatusOK, Body: relationsBody})
 		relations, err := mockedApi.GetRelations(ctx, userAuthToken, serviceAuthToken, collectionID, "E92000001", acceptedLang)
 		So(err, ShouldBeNil)
-		So(relations, ShouldResemble, relations)
+		So(relations, ShouldResemble, expected)
 	})
 	Convey("given a 200 status with valid empty body is returned", t, func() {
 		mockedApi := getMockAreaAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: http.StatusOK, Body: "[]"})
@@ -282,6 +283,48 @@ func TestClient_GetRelations(t *testing.T) {
 			Convey("a positive response is returned with empty instance", func() {
 				So(err, ShouldBeNil)
 				So(instance, ShouldResemble, []Relation{})
+			})
+		})
+	})
+}
+
+func TestClient_GetAncestors(t *testing.T) {
+	expectedDidsburyEast := []Ancestor{Ancestor{Name: "England", Level: "", Code: "E92000001", Ancestors: []Ancestor{}, Siblings: []Ancestor{}, Children: []Ancestor{}}, Ancestor{Name: "North West", Level: "", Code: "E12000002", Ancestors: []Ancestor{}, Siblings: []Ancestor{}, Children: []Ancestor{}}, Ancestor{Name: "Manchester", Level: "", Code: "E08000003", Ancestors: []Ancestor{}, Siblings: []Ancestor{}, Children: []Ancestor{}}, Ancestor{Name: "Didsbury East", Level: "", Code: "E05011362", Ancestors: []Ancestor{}, Siblings: []Ancestor{}, Children: []Ancestor{}}}
+	expectedManchester := []Ancestor{Ancestor{Name: "England", Level: "", Code: "E92000001", Ancestors: []Ancestor{}, Siblings: []Ancestor{}, Children: []Ancestor{}}, Ancestor{Name: "North West", Level: "", Code: "E12000002", Ancestors: []Ancestor{}, Siblings: []Ancestor{}, Children: []Ancestor{}}, Ancestor{Name: "Manchester", Level: "", Code: "E08000003", Ancestors: []Ancestor{}, Siblings: []Ancestor{}, Children: []Ancestor{}}}
+	expectedNorthWest := []Ancestor{Ancestor{Name: "England", Level: "", Code: "E92000001", Ancestors: []Ancestor{}, Siblings: []Ancestor{}, Children: []Ancestor{}}, Ancestor{Name: "North West", Level: "", Code: "E12000002", Ancestors: []Ancestor{}, Siblings: []Ancestor{}, Children: []Ancestor{}}}
+	expectedEngland := []Ancestor{Ancestor{Name: "England", Level: "", Code: "E92000001", Ancestors: []Ancestor{}, Siblings: []Ancestor{}, Children: []Ancestor{}}}
+
+	Convey("Didsbury East code returns correct response body", t, func() {
+		mockedApi := getMockAreaAPI(http.Request{Method: http.MethodGet}, MockedHTTPResponse{StatusCode: http.StatusOK, Body: nil}) // TODO unstub
+		instance, err := mockedApi.GetAncestors("E05011362")
+		So(err, ShouldBeNil)
+		So(instance, ShouldResemble, expectedDidsburyEast)
+	})
+	Convey("Manchester code returns correct response body", t, func() {
+		mockedApi := getMockAreaAPI(http.Request{Method: http.MethodGet}, MockedHTTPResponse{StatusCode: http.StatusOK, Body: nil}) // TODO unstub
+		instance, err := mockedApi.GetAncestors("E08000003")
+		So(err, ShouldBeNil)
+		So(instance, ShouldResemble, expectedManchester)
+	})
+	Convey("NorthWest code returns correct response body", t, func() {
+		mockedApi := getMockAreaAPI(http.Request{Method: http.MethodGet}, MockedHTTPResponse{StatusCode: http.StatusOK, Body: nil}) // TODO unstub
+		instance, err := mockedApi.GetAncestors("E12000002")
+		So(err, ShouldBeNil)
+		So(instance, ShouldResemble, expectedNorthWest)
+	})
+	Convey("England code returns correct response body", t, func() {
+		mockedApi := getMockAreaAPI(http.Request{Method: http.MethodGet}, MockedHTTPResponse{StatusCode: http.StatusOK, Body: nil}) // TODO unstub
+		instance, err := mockedApi.GetAncestors("E92000001")
+		So(err, ShouldBeNil)
+		So(instance, ShouldResemble, expectedEngland)
+	})
+	Convey("given a 200 status with valid empty body is returned", t, func() {
+		mockedApi := getMockAreaAPI(http.Request{Method: http.MethodGet}, MockedHTTPResponse{StatusCode: http.StatusOK, Body: "{}"})
+		Convey("when GetRelations is called", func() {
+			instance, err := mockedApi.GetAncestors("<RANDOM>")
+			Convey("a positive response is returned with empty instance", func() {
+				So(err, ShouldBeNil)
+				So(instance, ShouldResemble, []Ancestor{}) // TODO this will fail when un stubbed - should be []Ancestor{}
 			})
 		})
 	})

--- a/areas/data.go
+++ b/areas/data.go
@@ -18,3 +18,12 @@ type Relation struct {
 	AreaName string `json:"area_name,omitempty"`
 	Href     string `json:"href,omitempty"`
 }
+
+type Ancestor struct {
+	Name      string     `json:"name,omitempty"`
+	Level     string     `json:"level,omitempty"`
+	Code      string     `json:"code,omitempty"`
+	Ancestors []Ancestor `json:"ancestors"`
+	Siblings  []Ancestor `json:"siblings"`
+	Children  []Ancestor `json:"children"`
+}

--- a/areas/geo_data.go
+++ b/areas/geo_data.go
@@ -1,0 +1,55 @@
+package areas
+
+import "fmt"
+
+// Temporary stubbed data
+
+const (
+	DidsburyEast = `{
+      "name": "Didsbury East",
+      "level": "",
+      "code": "E05011362",
+      "ancestors": [],
+      "siblings": [],
+      "children": []
+    }`
+	Manchester = `{
+      "name": "Manchester",
+      "level": "",
+      "code": "E08000003",
+      "ancestors": [],
+      "siblings": [],
+      "children": []
+    }`
+	NorthWest = `{
+      "name": "North West",
+      "level": "",
+      "code": "E12000002",
+      "ancestors": [],
+      "siblings": [],
+      "children": []
+    }`
+	England = `{
+      "name": "England",
+      "level": "",
+      "code": "E92000001",
+      "ancestors": [],
+      "siblings": [],
+      "children": []
+    }`
+)
+
+func StubbedAncestorAPIResponse(code string) string {
+	switch code {
+	case "E05011362":
+		return fmt.Sprintf(`[%s, %s, %s, %s]`, England, NorthWest, Manchester, DidsburyEast)
+	case "E08000003":
+		return fmt.Sprintf(`[%s, %s, %s]`, England, NorthWest, Manchester)
+	case "E12000002":
+		return fmt.Sprintf(`[%s, %s]`, England, NorthWest)
+	case "E92000001":
+		return fmt.Sprintf(`[%s]`, England)
+	default:
+		return `[]`
+	}
+}


### PR DESCRIPTION
### What
breadcrumbs areas api client

Describe what you have changed and why.
Added a new method to make a stubbed http request to the areas api to fetch the area breadcrumb ancestors
### How to review
Check that the breadcrumbs returns an indexed based list of ancestors whereby 0 index is the root parent & each next index is a child.

There are no references for the accessToken or userToken in `GetAncestors(code string) (ancestors []areas.Ancestor, err error)` as we are not hitting a remote api yet.

### Describe the steps required to test the changes.
The model for the mapper in `dp-frontend-area-profiles` was:
```
type AreaModel struct {
	coreModel.Page
	Name      string           `json:"name"`
	Level     string           `json:"level"`
	Code      string           `json:"code"`
	Ancestors []AreaModel  `json:"ancestors"`
	Siblings  []AreaModel      `json:"siblings"`
	Children  []AreaModel      `json:"children"`
	Relations []areas.Relation `json:"relations"`
}
```

I created an ancestor model in the PR and now the model in `dp-frontend-area-profiles` looks like:
```
type AreaModel struct {
	coreModel.Page
	Name      string           `json:"name"`
	Level     string           `json:"level"`
	Code      string           `json:"code"`
	Ancestors []areas.Ancestor `json:"ancestors"` // This is now replacing []AreaModel
	Siblings  []AreaModel      `json:"siblings"`
	Children  []AreaModel      `json:"children"`
	Relations []areas.Relation `json:"relations"`
}
```
the model from `dp-frontend-area-profiles` is a recursive data structure where as the requirement is now a flat data structure e.g
```
[
    {
      "name": "North West",
     ...
    },
    {
      "name": "England",
      ...
    }
  ]
```
This would be for `Area > England > North West`
the full object is now
```
type Ancestor struct {
	Name      string     `json:"name,omitempty"`
	Level     string     `json:"level,omitempty"`
	Code      string     `json:"code,omitempty"`
	Ancestors []Ancestor `json:"ancestors"`
	Siblings  []Ancestor `json:"siblings"`
	Children  []Ancestor `json:"children"`
}
```

Which gives back for example:

```
    {
      "name": "England",
      "level": "",
      "code": "E92000001",
      "ancestors": [],
      "siblings": [],
      "children": [],
      "relations": []
    }
```

I have added the extra members to the `Ancestor` object (To be compatible with the AreaModel) because then if we do require the extra recursion we have it there. It could be that the `Page` model  renders other components on the page based on the existing  recursive  data structure from the ancestor member on `AreaModel` but that i cannot currently confirm that.

### Who can review
team 404
Describe who worked on the changes, so that other people can review.
myself
