### PR TITLE
add statusCode callback to cantabuar api client

### DIFF
--- a/cantabular/client.go
+++ b/cantabular/client.go
@@ -190,3 +190,14 @@ func (c *Client) errorResponse(url string, res *http.Response) error {
 		},
 	)
 }
+
+// StatusCode provides a callback function whereby users can check a returned
+// error for an embedded HTTP status code
+func (c *Client) StatusCode(err error) int {
+	var cerr coder
+	if errors.As(err, &cerr) {
+		return cerr.Code()
+	}
+
+	return 0
+}

--- a/cantabular/client_test.go
+++ b/cantabular/client_test.go
@@ -13,6 +13,26 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+type testError struct{
+	err        error
+	statusCode int
+}
+
+func (e *testError) Error() string {
+	if e. err == nil{
+		return "nil"
+	}
+	return e.err.Error()
+}
+
+func (e *testError) Unwrap() error {
+	return e.err
+}
+
+func (e *testError) Code() int {
+	return e.statusCode
+}
+
 func TestChecker(t *testing.T) {
 	testCtx := context.Background()
 
@@ -172,6 +192,27 @@ func TestChecker(t *testing.T) {
 				So(*check.LastFailure(), ShouldHappenBetween, beforeCall, time.Now().UTC())
 				So(err, ShouldBeNil)
 			})
+		})
+	})
+}
+
+func TestStatusCode(t *testing.T) {
+	client := cantabular.NewClient(
+		cantabular.Config{},
+		nil,
+		nil,
+	)
+
+	Convey("Given an error with embedded status code", t, func() {
+		err := &testError{
+			statusCode: http.StatusTeapot,
+		}
+
+		Convey("When StatusCode(err) is called", func() {
+			status := client.StatusCode(err)
+			expected := http.StatusTeapot
+
+			So(status, ShouldEqual, expected)
 		})
 	})
 }

--- a/cantabular/interface.go
+++ b/cantabular/interface.go
@@ -18,3 +18,7 @@ type httpClient interface {
 type GraphQLClient interface {
 	Query(ctx context.Context, query interface{}, vars map[string]interface{}) error
 }
+
+type coder interface{
+	Code() int
+}


### PR DESCRIPTION
### What

Added statusCode callback to cantabular api client. Allows users to check any status code returned by the client
in case of an error thrown.

### How to review

Check change makes sense, test passes

### Who can review

Anyone
