### PR TITLE
Add ImportMessage attribute to interactives client

### DIFF
--- a/interactives/data.go
+++ b/interactives/data.go
@@ -36,6 +36,7 @@ type InteractiveFile struct {
 
 type InteractiveUpdate struct {
 	ImportSuccessful *bool       `json:"import_successful,omitempty"`
+	ImportMessage    string      `json:"import_message,omitempty"`
 	Interactive      Interactive `json:"interactive,omitempty"`
 }
 


### PR DESCRIPTION
Add import message - mainly for reporting error message back when failure.