### PR TITLE
Add CreateFlexibleBlueprint method to dp-api-clients-go

### DIFF
--- a/filter/data.go
+++ b/filter/data.go
@@ -39,11 +39,21 @@ type DimensionOptions struct {
 	TotalCount int               `json:"total_count"`
 }
 
-// CreateBlueprint represents the fields required to create a filter blueprint
-type CreateBlueprint struct {
+// createBlueprint represents the fields required to create a filter blueprint
+type createBlueprint struct {
 	Dataset    Dataset          `json:"dataset"`
 	Dimensions []ModelDimension `json:"dimensions"`
 	FilterID   string           `json:"filter_id"`
+}
+
+type createFlexBlueprintRequest struct {
+	Dataset        Dataset          `json:"dataset"`
+	Dimensions     []ModelDimension `json:"dimensions"`
+	PopulationType string           `json:"population_type"`
+}
+
+type createFlexBlueprintResponse struct {
+	FilterID string `json:"filter_id"`
 }
 
 // Dataset represents the dataset fields required to create a filter blueprint

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -429,20 +429,23 @@ func (c *Client) CreateFlexibleBlueprint(ctx context.Context, userAuthToken, ser
 		return "", "", err
 	}
 
-	cb := createFlexBlueprintRequest{Dataset: Dataset{DatasetID: datasetID, Edition: edition, Version: ver}, PopulationType: population_type}
-
-	var dimensions []ModelDimension
-	for _, name := range names {
-		dimensions = append(dimensions, ModelDimension{Name: name})
+	dimensions := make([]ModelDimension, len(names))
+	for i, name := range names {
+		dimensions[i] = ModelDimension{Name: name}
 	}
 
-	cb.Dimensions = dimensions
+	cb := createFlexBlueprintRequest{
+		Dimensions:     dimensions,
+		Dataset:        Dataset{DatasetID: datasetID, Edition: edition, Version: ver},
+		PopulationType: population_type,
+	}
+
 	reqBody, err := json.Marshal(cb)
 	if err != nil {
 		return "", "", err
 	}
 
-	respBody, eTag, err := c.postToFilters(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version, reqBody)
+	respBody, eTag, err := c.postBlueprint(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version, reqBody)
 	if err != nil {
 		return "", "", err
 	}
@@ -462,20 +465,22 @@ func (c *Client) CreateBlueprint(ctx context.Context, userAuthToken, serviceAuth
 		return "", "", err
 	}
 
-	cb := createBlueprint{Dataset: Dataset{DatasetID: datasetID, Edition: edition, Version: ver}}
-
-	var dimensions []ModelDimension
-	for _, name := range names {
-		dimensions = append(dimensions, ModelDimension{Name: name})
+	dimensions := make([]ModelDimension, len(names))
+	for i, name := range names {
+		dimensions[i] = ModelDimension{Name: name}
 	}
 
-	cb.Dimensions = dimensions
+	cb := createBlueprint{
+		Dimensions: dimensions,
+		Dataset:    Dataset{DatasetID: datasetID, Edition: edition, Version: ver},
+	}
+
 	reqBody, err := json.Marshal(cb)
 	if err != nil {
 		return "", "", err
 	}
 
-	respBody, eTag, err := c.postToFilters(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version, reqBody)
+	respBody, eTag, err := c.postBlueprint(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version, reqBody)
 	if err != nil {
 		return "", "", err
 	}
@@ -487,7 +492,7 @@ func (c *Client) CreateBlueprint(ctx context.Context, userAuthToken, serviceAuth
 	return cb.FilterID, eTag, nil
 }
 
-func (c *Client) postToFilters(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version string, reqBody []byte) ([]byte, string, error) {
+func (c *Client) postBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version string, reqBody []byte) ([]byte, string, error) {
 
 	uri := c.hcCli.URL + "/filters"
 	clientlog.Do(ctx, "attempting to create filter blueprint", service, uri, log.Data{

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -422,6 +422,10 @@ func (c *Client) GetDimensionOptionsBatchProcess(ctx context.Context, userAuthTo
 	return eTag, batch.ProcessInConcurrentBatches(batchGetter, batchProcessor, batchSize, maxWorkers)
 }
 
+func (c *Client) CreateFlexibleFilterBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version string, names []string, populationType string) (filterID, eTag string, err error) {
+	return "", "", nil
+}
+
 // CreateBlueprint creates a filter blueprint and returns the associated filterID and eTag
 func (c *Client) CreateBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version string, names []string) (filterID, eTag string, err error) {
 	ver, err := strconv.Atoi(version)


### PR DESCRIPTION
### What

Added CreateFlexibleBlueprint function to accept population type field
Refactored code to share implementation between CreateFlexibleBlueprint and CreateBlueprint
Corrected tests for CreateBlueprint
Added tests for CreateFlexibleBlueprint

### How to review

Refactoring is sound
New functionality is present
Tests cover functionality

### Who can review

gophers other than @goofballLogic 