### PR TITLE
Create AddFlexDimension method on Flex client (Ticket #5602)

### DIFF
--- a/filter/data.go
+++ b/filter/data.go
@@ -58,6 +58,13 @@ type createFlexBlueprintResponse struct {
 	FilterID string `json:"filter_id"`
 }
 
+// createFlexDimensionRequest represents the fields required to add a dimension to a flex filter
+type createFlexDimensionRequest struct {
+	Name       string   `json:"name"`
+	IsAreaType bool     `json:"is_area_type"`
+	Options    []string `json:"options"`
+}
+
 // Dataset represents the dataset fields required to create a filter blueprint
 type Dataset struct {
 	DatasetID string `json:"id"`


### PR DESCRIPTION
### What

Adds a new client method to the `filter` API client which conforms to the new endpoint as implemented [here](https://github.com/ONSdigital/dp-cantabular-filter-flex-api/pull/25).

We can't simply add new fields to the existing `AddDimension` method since:
- It would be a breaking change to the signature.
- CMD requests don't need the additional fields, so it would nonsensical to have to pass placeholder/empty values.
- The new endpoint doesn't have the `/{name}` suffix, instead including the name only in the request body.
- Passing additional fields in the body may break CMD consumers (e.g. if they are using `Decoder.DisallowUnknownFields`).

Ticket: https://trello.com/c/MuClZX8t

### How to review

Confirm the client meets the spec of the new [endpoint](https://github.com/ONSdigital/dp-cantabular-filter-flex-api/pull/25) and meets the ticket requirements.

### Who can review

Anyone, although probably ideal if the original authors of the endpoint also had a look.
