### PR TITLE
Add full edition details api

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -209,6 +209,16 @@ type Download struct {
 	Public  string `json:"public,omitempty"`
 	Private string `json:"private,omitempty"`
 }
+type EditionsDetails struct {
+	ID      string  `json:"id"`
+	Next    Edition `json:"next,omitempty"`
+	Current Edition `json:"current"`
+	Edition
+}
+
+type EditionItems struct {
+	Items []EditionsDetails `json:"items"`
+}
 
 // Edition represents an edition within a dataset
 type Edition struct {

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -413,6 +413,36 @@ func (c *Client) GetEdition(ctx context.Context, userAuthToken, serviceAuthToken
 }
 
 // GetEditions returns all editions for a dataset
+func (c *Client) GetFullEditionsDetails(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID string) (m []EditionsDetails, err error) {
+	uri := fmt.Sprintf("%s/datasets/%s/editions", c.hcCli.URL, datasetID)
+
+	clientlog.Do(ctx, "retrieving dataset editions", service, uri)
+
+	resp, err := c.doGetWithAuthHeaders(ctx, userAuthToken, serviceAuthToken, collectionID, uri, nil, "")
+	if err != nil {
+		return
+	}
+	defer closeResponseBody(ctx, resp)
+
+	if resp.StatusCode != http.StatusOK {
+		err = NewDatasetAPIResponse(resp, uri)
+		return
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+
+	var body EditionItems
+	if err = json.Unmarshal(b, &body); err != nil {
+		return nil, err
+	}
+	m = body.Items
+	return
+}
+
+// GetEditions returns all editions for a dataset
 func (c *Client) GetEditions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID string) (m []Edition, err error) {
 	uri := fmt.Sprintf("%s/datasets/%s/editions", c.hcCli.URL, datasetID)
 


### PR DESCRIPTION
### What

This PR creates the edition details object with current and next edition details. Also this implements the full edition details api maintaining backwards compatibility with ```GetEditions``` which actually returns the next editions only. 

### How to review

This is already used and tested by the indexing script of the dp-search-api

### Who can review

Anyone except me (but @nshumoogum  will be preferred because of the familiarity with the context)
