### PR TITLE
Add PopulationType field to Filter Model

### DIFF
--- a/filter/data.go
+++ b/filter/data.go
@@ -74,18 +74,19 @@ type Dataset struct {
 
 // Model represents a model returned from the filter api
 type Model struct {
-	FilterID    string              `json:"filter_id"`
-	InstanceID  string              `json:"instance_id"`
-	Links       Links               `json:"links"`
-	DatasetID   string              `json:"dataset_id"`
-	Dataset     Dataset             `json:"dataset,omitempty"`
-	Edition     string              `json:"edition"`
-	Version     string              `json:"version"`
-	State       string              `json:"state"`
-	Dimensions  []ModelDimension    `json:"dimensions,omitempty"`
-	Downloads   map[string]Download `json:"downloads,omitempty"`
-	Events      []Event             `json:"events,omitempty"`
-	IsPublished bool                `json:"published"`
+	FilterID       string              `json:"filter_id"`
+	InstanceID     string              `json:"instance_id"`
+	Links          Links               `json:"links"`
+	DatasetID      string              `json:"dataset_id"`
+	Dataset        Dataset             `json:"dataset,omitempty"`
+	Edition        string              `json:"edition"`
+	Version        string              `json:"version"`
+	State          string              `json:"state"`
+	Dimensions     []ModelDimension    `json:"dimensions,omitempty"`
+	Downloads      map[string]Download `json:"downloads,omitempty"`
+	Events         []Event             `json:"events,omitempty"`
+	IsPublished    bool                `json:"published"`
+	PopulationType string              `json:"population_type,omitempty"`
 }
 
 // Links represents a links object on the filter api response

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -1806,6 +1806,19 @@ func TestClient_GetJobState(t *testing.T) {
 		So(eTag, ShouldResemble, testETag)
 	})
 
+	Convey("When a Job contains flexible fields", t, func() {
+		const populationType = "Example"
+		flexibleJobBody := fmt.Sprintf(`{ "population_type": "%s" }`, populationType)
+
+		mockedAPI := getMockfilterAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 200, Body: flexibleJobBody})
+		jobResponse, _, err := mockedAPI.GetJobState(ctx, testUserAuthToken, testServiceToken, testDownloadServiceToken, testCollectionID, filterID)
+		So(err, ShouldBeNil)
+
+		Convey("then the population type should be returned", func() {
+			So(jobResponse.PopulationType, ShouldEqual, populationType)
+		})
+	})
+
 	Convey("When bad request is returned", t, func() {
 		mockedAPI := getMockfilterAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: 400, Body: ""})
 		_, _, err := mockedAPI.GetJobState(ctx, testUserAuthToken, testServiceToken, testDownloadServiceToken, testCollectionID, filterID)


### PR DESCRIPTION
### What

Adds the `PopulationType` field [provided by](https://github.com/ONSdigital/dp-cantabular-filter-flex-api/blob/ed2eb6652e835d0532440b0e47acb3e02305c0b3/swagger.yaml#L531) the Cantabular Filter-Flex API. I'm presuming adding a field here and using `omitempty` should be fine/compatible with CMD.

We need this in order to determine the underlying Cantabular dataset to pass to `GetGeographyDimensions` for [5569](https://trello.com/c/yOjZDYAj/5569-create-front-end-to-display-list-of-area-types). While it's possible to determine with an additional call to the Dataset API, since the data is already here we may as well avoid an extra request.

### How to review

Double check the new field matches the API spec.

### Who can review

Anyone.
