### PR TITLE
Add Dimensions API client

### DIFF
--- a/dimension/area_types.go
+++ b/dimension/area_types.go
@@ -1,0 +1,12 @@
+package dimension
+
+// AreaType is an area-type model with ID and Label
+type AreaType struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+// GetAreaTypesResponse is the response object for GET /area-types
+type GetAreaTypesResponse struct {
+	AreaTypes []AreaType `json:"area-types"`
+}

--- a/dimension/client.go
+++ b/dimension/client.go
@@ -1,0 +1,136 @@
+// Package dimension provides an HTTP client for the Cantabular Dimension API
+package dimension
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/clientlog"
+	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
+	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
+	"github.com/ONSdigital/dp-api-clients-go/v2/health"
+	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+	"github.com/ONSdigital/log.go/v2/log"
+)
+
+const service = "cantabular-dimension-api"
+
+// Client is a Cantabular Dimension API client
+type Client struct {
+	hcCli   *health.Client
+	baseURL *url.URL
+}
+
+// NewClient creates a new instance of Client with a given Dimensions API URL
+func NewClient(dimensionsAPIURL string) (*Client, error) {
+	client := health.NewClient(service, dimensionsAPIURL)
+	return NewWithHealthClient(client)
+}
+
+// NewWithHealthClient creates a new instance of Client,
+// reusing the URL and Clienter from the provided health check client
+func NewWithHealthClient(hcCli *health.Client) (*Client, error) {
+	client := health.NewClientWithClienter(service, hcCli.URL, hcCli.Client)
+	baseURL, err := url.Parse(client.URL)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing URL: %w", err)
+	}
+
+	return &Client{hcCli: client, baseURL: baseURL}, nil
+}
+
+// Checker calls recipe api health endpoint and returns a check object to the caller
+func (c *Client) Checker(ctx context.Context, check *healthcheck.CheckState) error {
+	return c.hcCli.Checker(ctx, check)
+}
+
+// GetAreaTypes retrieves the Cantabular area-types associated with a dataset
+func (c *Client) GetAreaTypes(ctx context.Context, userAuthToken, serviceAuthToken, datasetID string) (GetAreaTypesResponse, error) {
+	logData := log.Data{
+		"method":     http.MethodGet,
+		"dataset_id": datasetID,
+	}
+
+	query := url.Values{"dataset": []string{datasetID}}.Encode()
+	reqURL := c.baseURL.ResolveReference(&url.URL{Path: "/area-types", RawQuery: query}).String()
+
+	clientlog.Do(ctx, "getting area types", service, reqURL, logData)
+
+	req, err := newRequest(ctx, http.MethodGet, reqURL, nil, userAuthToken, serviceAuthToken)
+	if err != nil {
+		return GetAreaTypesResponse{}, dperrors.New(
+			fmt.Errorf("failed to create request: %w", err),
+			http.StatusBadRequest,
+			logData,
+		)
+	}
+
+	resp, err := c.hcCli.Client.Do(ctx, req)
+	if err != nil {
+		return GetAreaTypesResponse{}, dperrors.New(
+			fmt.Errorf("failed to get response from Dimensions API: %w", err),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Error(ctx, "error closing http response body", err)
+		}
+	}()
+
+	if resp.StatusCode == http.StatusNotFound {
+		var errorResp ErrorResp
+		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err == nil {
+			return GetAreaTypesResponse{}, dperrors.New(
+				fmt.Errorf("error response from Dimensions API (%d): %w", resp.StatusCode, errorResp),
+				http.StatusInternalServerError,
+				logData,
+			)
+		}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Best effort — an empty body is fine for the error message
+		body, _ := io.ReadAll(resp.Body)
+		return GetAreaTypesResponse{}, dperrors.New(
+			fmt.Errorf("error response from Dimensions API (%d): %s", resp.StatusCode, body),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	var areaTypes GetAreaTypesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&areaTypes); err != nil {
+		return GetAreaTypesResponse{}, dperrors.New(
+			fmt.Errorf("unable to deserialize area types response: %w", err),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	return areaTypes, nil
+}
+
+// newRequest creates a new http.Request with auth headers
+func newRequest(ctx context.Context, method string, url string, body io.Reader, userAuthToken, serviceAuthToken string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if err := headers.SetAuthToken(req, userAuthToken); err != nil {
+		return nil, fmt.Errorf("failed to set auth token header: %w", err)
+	}
+
+	if err := headers.SetServiceAuthToken(req, serviceAuthToken); err != nil {
+		return nil, fmt.Errorf("failed to set service token header: %w", err)
+	}
+
+	return req, nil
+}

--- a/dimension/client_test.go
+++ b/dimension/client_test.go
@@ -1,0 +1,257 @@
+package dimension
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
+	"github.com/ONSdigital/dp-api-clients-go/v2/health"
+	dphttp "github.com/ONSdigital/dp-net/http"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewClient(t *testing.T) {
+	const invalidURL = "a#$%^&*(url$#$%%^("
+
+	Convey("Given NewClient is passed an invalid URL", t, func() {
+		_, err := NewClient(invalidURL)
+
+		Convey("the constructor should return an error", func() {
+			So(err, ShouldBeError)
+		})
+	})
+
+	Convey("Given NewWithHealthClient is passed an invalid URL", t, func() {
+		_, err := NewWithHealthClient(health.NewClientWithClienter("", invalidURL, newStubClient(nil, nil)))
+
+		Convey("the constructor should return an error", func() {
+			So(err, ShouldBeError)
+		})
+	})
+}
+
+func TestGetAreaTypes(t *testing.T) {
+	Convey("Given a valid request", t, func() {
+		stubClient := newStubClient(&http.Response{Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil)
+		client := newHealthClient(stubClient)
+
+		_, _ = client.GetAreaTypes(context.Background(), "", "", "test")
+
+		Convey("it should call the area types endpoint, serializing the dataset query", func() {
+			calls := stubClient.DoCalls()
+			So(calls, ShouldNotBeEmpty)
+			So(calls[0].Req.URL.String(), ShouldEqual, "/area-types?dataset=test")
+		})
+	})
+
+	Convey("Given authentication tokens", t, func() {
+		const userAuthToken = "user"
+		const serviceAuthToken = "service"
+
+		stubClient := newStubClient(&http.Response{Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil)
+		client := newHealthClient(stubClient)
+
+		_, _ = client.GetAreaTypes(context.Background(), userAuthToken, serviceAuthToken, "test")
+
+		Convey("it should set the auth headers on the request", func() {
+			calls := stubClient.DoCalls()
+			So(calls, ShouldNotBeEmpty)
+
+			So(calls[0].Req, shouldHaveAuthHeaders, userAuthToken, serviceAuthToken)
+		})
+	})
+
+	Convey("Given a valid area types response payload", t, func() {
+		areaTypes := GetAreaTypesResponse{
+			AreaTypes: []AreaType{{ID: "test", Label: "Test"}},
+		}
+
+		resp, err := json.Marshal(areaTypes)
+		So(err, ShouldBeNil)
+
+		stubClient := newStubClient(&http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewReader(resp)),
+		}, nil)
+
+		client := newHealthClient(stubClient)
+
+		types, err := client.GetAreaTypes(context.Background(), "", "", "test")
+
+		Convey("it should return a list of area types", func() {
+			So(err, ShouldBeNil)
+			So(types, ShouldResemble, areaTypes)
+		})
+	})
+
+	Convey("Given the dimensions API returns an error", t, func() {
+		stubClient := newStubClient(nil, errors.New("oh no"))
+
+		client := newHealthClient(stubClient)
+
+		_, err := client.GetAreaTypes(context.Background(), "", "", "test")
+
+		Convey("it should return an internal error", func() {
+			So(err, shouldBeDPError, http.StatusInternalServerError)
+		})
+	})
+
+	Convey("Given the dimensions API returns a status code of 404", t, func() {
+		stubClient := newStubClient(&http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{ "errors": ["not found"] }`))),
+		}, nil)
+
+		client := newHealthClient(stubClient)
+
+		_, err := client.GetAreaTypes(context.Background(), "", "", "test")
+
+		Convey("the error chain should contain the original Errors type", func() {
+			So(err, shouldBeDPError, http.StatusInternalServerError)
+
+			var respErr ErrorResp
+			ok := errors.As(err, &respErr)
+			So(ok, ShouldBeTrue)
+			So(respErr, ShouldResemble, ErrorResp{Errors: []string{"not found"}})
+		})
+	})
+
+	Convey("Given the dimensions API returns a status code other than 200/400", t, func() {
+		stubClient := newStubClient(&http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{ "area-types": [] }`))),
+		}, nil)
+
+		client := newHealthClient(stubClient)
+
+		_, err := client.GetAreaTypes(context.Background(), "", "", "test")
+
+		Convey("it should return an internal error", func() {
+			So(err, shouldBeDPError, http.StatusInternalServerError)
+		})
+	})
+
+	Convey("Given the response cannot be deserialized", t, func() {
+		stubClient := newStubClient(&http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{ "area-types" `))),
+		}, nil)
+
+		client := newHealthClient(stubClient)
+
+		_, err := client.GetAreaTypes(context.Background(), "", "", "test")
+
+		Convey("it should return an internal error", func() {
+			So(err, shouldBeDPError, http.StatusInternalServerError)
+		})
+	})
+
+	Convey("Given the request cannot be created", t, func() {
+		client := newHealthClient(newStubClient(nil, nil))
+
+		_, err := client.GetAreaTypes(nil, "", "", "test")
+
+		Convey("it should return a client error", func() {
+			So(err, shouldBeDPError, http.StatusBadRequest)
+		})
+	})
+}
+
+// newHealthClient creates a new Client from an existing Clienter
+func newHealthClient(client dphttp.Clienter) *Client {
+	stubClientWithHealth := health.NewClientWithClienter("", "", client)
+	healthClient, err := NewWithHealthClient(stubClientWithHealth)
+	if err != nil {
+		panic(err)
+	}
+
+	return healthClient
+}
+
+// newStubClient creates a stub Clienter which always responds to `Do` with the
+// provided response/error.
+func newStubClient(response *http.Response, err error) *dphttp.ClienterMock {
+	return &dphttp.ClienterMock{
+		DoFunc: func(_ context.Context, _ *http.Request) (*http.Response, error) {
+			return response, err
+		},
+		SetPathsWithNoRetriesFunc: func(paths []string) {},
+		GetPathsWithNoRetriesFunc: func() []string {
+			return []string{"/healthcheck"}
+		},
+	}
+}
+
+// shouldBeDPError is a GoConvey matcher that asserts the passed in error
+// includes a dperrors.Error within the chain, and optionally that the status
+// code matches the expected value.
+// Usage:`So(err, shouldBeDPError)`
+//       `So(err, shouldBeDPError, 404)`
+func shouldBeDPError(actual interface{}, expected ...interface{}) string {
+	err, ok := actual.(error)
+	if !ok {
+		return "expected to find error"
+	}
+
+	var dpErr *dperrors.Error
+	if ok := errors.As(err, &dpErr); !ok {
+		return "did not find dperrors.Error in the chain"
+	}
+
+	if len(expected) == 0 {
+		return ""
+	}
+
+	statusCode, ok := expected[0].(int)
+	if !ok {
+		return "status code could not be parsed"
+	}
+
+	if statusCode != dpErr.Code() {
+		return fmt.Sprintf("expected status code %d, got %d", statusCode, dpErr.Code())
+	}
+
+	return ""
+}
+
+// shouldHaveAuthHeaders is a GoConvey matcher that asserts the values of the
+// auth headers on a request match the expected values.
+// Usage: `So(request, shouldHaveAuthHeaders, "userToken", "serviceToken")`
+func shouldHaveAuthHeaders(actual interface{}, expected ...interface{}) string {
+	req, ok := actual.(*http.Request)
+	if !ok {
+		return "expected to find http.Request"
+	}
+
+	if len(expected) != 2 {
+		return "expected a user header and a service header"
+	}
+
+	expUserHeader, ok := expected[0].(string)
+	if !ok {
+		return "user header must be a string"
+	}
+
+	expSvcHeader, ok := expected[1].(string)
+	if !ok {
+		return "service header must be a string"
+	}
+
+	florenceToken := req.Header.Get("X-Florence-Token")
+	if florenceToken != expUserHeader {
+		return fmt.Sprintf("expected X-Florence-Token value %s, got %s", florenceToken, expUserHeader)
+	}
+
+	svcHeader := req.Header.Get("Authorization")
+	if svcHeader != fmt.Sprintf("Bearer %s", expSvcHeader) {
+		return fmt.Sprintf("expected Authorization value %s, got %s", svcHeader, expSvcHeader)
+	}
+
+	return ""
+}

--- a/dimension/client_test.go
+++ b/dimension/client_test.go
@@ -39,14 +39,15 @@ func TestNewClient(t *testing.T) {
 func TestGetAreaTypes(t *testing.T) {
 	Convey("Given a valid request", t, func() {
 		stubClient := newStubClient(&http.Response{Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil)
-		client := newHealthClient(stubClient)
+		client, err := NewWithHealthClient(health.NewClientWithClienter("", "http://test.test:2000/v1", stubClient))
+		So(err, ShouldBeNil)
 
 		_, _ = client.GetAreaTypes(context.Background(), "", "", "test")
 
 		Convey("it should call the area types endpoint, serializing the dataset query", func() {
 			calls := stubClient.DoCalls()
 			So(calls, ShouldNotBeEmpty)
-			So(calls[0].Req.URL.String(), ShouldEqual, "/area-types?dataset=test")
+			So(calls[0].Req.URL.String(), ShouldEqual, "http://test.test:2000/v1/area-types?dataset=test")
 		})
 	})
 

--- a/dimension/error.go
+++ b/dimension/error.go
@@ -1,0 +1,12 @@
+package dimension
+
+import "strings"
+
+// ErrorResp represents an error response containing a list of errors
+type ErrorResp struct {
+	Errors []string `json:"errors"`
+}
+
+func (e ErrorResp) Error() string {
+	return strings.Join(e.Errors, ", ")
+}


### PR DESCRIPTION
### What

Adds a new API client for the Dimension API. Only includes one method currently, `GetAreaTypes`, which is required for [5569](https://trello.com/c/yOjZDYAj).

### How to review

Check the client matches the schema [defined by the API](https://github.com/ONSdigital/dp-cantabular-dimension-api/blob/e28c30655025a372204796efef9b5acdcdf00be8/swagger.yaml#L10).

### Who can review

Anyone.
