### PR TITLE
Should be [][][]float32 but sent as a string

### DIFF
--- a/areas/data.go
+++ b/areas/data.go
@@ -2,14 +2,14 @@ package areas
 
 // AreaDetails represents a response area model from the areas api
 type AreaDetails struct {
-	Code          string                 `json:"code,omitempty"`
-	Name          string                 `json:"name,omitempty"`
-	DateStarted   string                 `json:"date_start,omitempty"`
-	DateEnd       string                 `json:"date_end,omitempty"`
-	WelshName     string                 `json:"name_welsh,omitempty"`
-	GeometricData map[string]interface{} `json:"geometry"`
-	Visible       bool                   `json:"visible,omitempty"`
-	AreaType      string                 `json:"area_type,omitempty"`
+	Code          string `json:"code,omitempty"`
+	Name          string `json:"name,omitempty"`
+	DateStarted   string `json:"date_start,omitempty"`
+	DateEnd       string `json:"date_end,omitempty"`
+	WelshName     string `json:"name_welsh,omitempty"`
+	GeometricData string `json:"geometry"`
+	Visible       bool   `json:"visible,omitempty"`
+	AreaType      string `json:"area_type,omitempty"`
 }
 
 // Relation represents a response relation model from area api


### PR DESCRIPTION
### What

Describe what you have changed and why.
The geometry field sent from areas api should probably be sending a [][][]float32 but its actually been sent as a string.
### How to review

Describe the steps required to test the changes.
just check that the geometry field is now type string
### Who can review
anyone
Describe who worked on the changes, so that other people can review.
myself
