### PR TITLE
Return TotalCount from area-types endpoint

### DIFF
--- a/dimension/area_types.go
+++ b/dimension/area_types.go
@@ -2,8 +2,9 @@ package dimension
 
 // AreaType is an area-type model with ID and Label
 type AreaType struct {
-	ID    string `json:"id"`
-	Label string `json:"label"`
+	ID         string `json:"id"`
+	Label      string `json:"label"`
+	TotalCount int    `json:"total_count"`
 }
 
 // GetAreaTypesResponse is the response object for GET /area-types

--- a/dimension/client_test.go
+++ b/dimension/client_test.go
@@ -70,7 +70,7 @@ func TestGetAreaTypes(t *testing.T) {
 
 	Convey("Given a valid area types response payload", t, func() {
 		areaTypes := GetAreaTypesResponse{
-			AreaTypes: []AreaType{{ID: "test", Label: "Test"}},
+			AreaTypes: []AreaType{{ID: "test", Label: "Test", TotalCount: 5}},
 		}
 
 		resp, err := json.Marshal(areaTypes)


### PR DESCRIPTION
### What

Returns the newly exposed `total_count` property from [https://github.com/ONSdigital/dp-cantabular-dimension-api/pull/9](https://github.com/ONSdigital/dp-cantabular-dimension-api/pull/9) as `TotalCount` on the dimension client.
#### Context
This is to enable the area selection radio buttons to display the count in the label.
https://trello.com/c/yOjZDYAj/5569-create-front-end-to-display-list-of-area-types

### How to review

Check the code.

### Who can review

Anyone.
