### PR TITLE
Removes getAncestor

### DIFF
--- a/areas/areas.go
+++ b/areas/areas.go
@@ -129,33 +129,6 @@ func (c *Client) GetRelations(ctx context.Context, userAuthToken, serviceAuthTok
 	return
 }
 
-// GetAncestors gets ancestors data from areas api
-func (c *Client) GetAncestors(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, areaID, acceptLang string) (ancestors Ancestors, err error) {
-	uri := fmt.Sprintf("%s/v1/areas/%s", c.hcCli.URL, areaID)
-	clientlog.Do(ctx, "retrieving ancestors", service, uri)
-	resp, err := c.doGetWithAuthHeaders(ctx, userAuthToken, serviceAuthToken, collectionID, uri, nil, "", acceptLang)
-	if err != nil {
-		return
-	}
-	defer closeResponseBody(ctx, resp)
-
-	if resp.StatusCode != http.StatusOK {
-		err = NewAreaAPIResponse(resp, uri)
-		return
-	}
-
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return
-	}
-
-	err = json.Unmarshal(b, &ancestors.Ancestors)
-	if err != nil {
-		return
-	}
-	return
-}
-
 // NewAreaAPIResponse creates an error response, optionally adding body to e when status is 404
 func NewAreaAPIResponse(resp *http.Response, uri string) (e *ErrInvalidAreaAPIResponse) {
 	e = &ErrInvalidAreaAPIResponse{

--- a/areas/areas_test.go
+++ b/areas/areas_test.go
@@ -290,56 +290,6 @@ func TestClient_GetRelations(t *testing.T) {
 	})
 }
 
-func TestClient_GetAncestors(t *testing.T) {
-	expectedDidsburyEast := Ancestors{Ancestors: []Ancestor{Ancestor{Name: "Manchester", Level: "", Id: "E08000003", Ancestors: []Ancestor{}, Siblings: []Ancestor{}, Children: []Ancestor{}}, Ancestor{Name: "North West", Level: "", Id: "E12000002", Ancestors: []Ancestor{}, Siblings: []Ancestor{}, Children: []Ancestor{}}, Ancestor{Name: "England", Level: "", Id: "E92000001", Ancestors: []Ancestor{}, Siblings: []Ancestor{}, Children: []Ancestor{}}}}
-	expectedManchester := Ancestors{Ancestors: []Ancestor{Ancestor{Name: "North West", Level: "", Id: "E12000002", Ancestors: []Ancestor{}, Siblings: []Ancestor{}, Children: []Ancestor{}}, Ancestor{Name: "England", Level: "", Id: "E92000001", Ancestors: []Ancestor{}, Siblings: []Ancestor{}, Children: []Ancestor{}}}}
-	expectedNorthWest := Ancestors{Ancestors: []Ancestor{Ancestor{Name: "England", Level: "", Id: "E92000001", Ancestors: []Ancestor{}, Siblings: []Ancestor{}, Children: []Ancestor{}}}}
-	expectedEngland := Ancestors{Ancestors: []Ancestor{}}
-	acceptedLang := "en-GB,en-US;q=0.9,en;q=0.8"
-
-	testData := []string{
-		`{ "name": "Didsbury East", "level": "", "id": "E05011362", "ancestors": [], "siblings": [], "children": [] }`,
-		`{ "name": "Manchester", "level": "", "id": "E08000003", "ancestors": [], "siblings": [], "children": [] }`,
-		`{ "name": "North West", "level": "", "id": "E12000002", "ancestors": [], "siblings": [], "children": [] }`,
-		`{ "name": "England", "level": "", "id": "E92000001", "ancestors": [], "siblings": [], "children": [] }`,
-	}
-
-	Convey("Didsbury East code returns correct response body", t, func() {
-		mockedApi := getMockAreaAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: http.StatusOK, Body: getAncestry(testData[1], testData[2], testData[3])})
-		ancestors, err := mockedApi.GetAncestors(ctx, userAuthToken, serviceAuthToken, collectionID, "E05011362", acceptedLang)
-		So(err, ShouldBeNil)
-		So(ancestors, ShouldResemble, expectedDidsburyEast)
-	})
-	Convey("Manchester code returns correct response body", t, func() {
-		mockedApi := getMockAreaAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: http.StatusOK, Body: getAncestry(testData[2], testData[3])})
-		ancestors, err := mockedApi.GetAncestors(ctx, userAuthToken, serviceAuthToken, collectionID, "E92000001", acceptedLang)
-		So(err, ShouldBeNil)
-		So(ancestors, ShouldResemble, expectedManchester)
-	})
-	Convey("NorthWest code returns correct response body", t, func() {
-		mockedApi := getMockAreaAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: http.StatusOK, Body: getAncestry(testData[3])})
-		ancestors, err := mockedApi.GetAncestors(ctx, userAuthToken, serviceAuthToken, collectionID, "E92000001", acceptedLang)
-		So(err, ShouldBeNil)
-		So(ancestors, ShouldResemble, expectedNorthWest)
-	})
-	Convey("England code returns correct response body", t, func() {
-		mockedApi := getMockAreaAPI(http.Request{Method: "GET"}, MockedHTTPResponse{StatusCode: http.StatusOK, Body: getAncestry("")})
-		ancestors, err := mockedApi.GetAncestors(ctx, userAuthToken, serviceAuthToken, collectionID, "E92000001", acceptedLang)
-		So(err, ShouldBeNil)
-		So(ancestors, ShouldResemble, expectedEngland)
-	})
-	Convey("given a 200 status with valid empty body is returned", t, func() {
-		mockedApi := getMockAreaAPI(http.Request{Method: http.MethodGet}, MockedHTTPResponse{StatusCode: http.StatusOK, Body: getAncestry("")})
-		Convey("when GetRelations is called", func() {
-			instance, err := mockedApi.GetAncestors(ctx, userAuthToken, serviceAuthToken, collectionID, "<RANDOM>", acceptedLang)
-			Convey("a positive response is returned with empty instance", func() {
-				So(err, ShouldBeNil)
-				So(instance, ShouldResemble, Ancestors{Ancestors: []Ancestor{}})
-			})
-		})
-	})
-}
-
 func getMockAreaAPI(expectRequest http.Request, mockedHTTPResponse MockedHTTPResponse) *Client {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != expectRequest.Method {

--- a/areas/data.go
+++ b/areas/data.go
@@ -2,14 +2,15 @@ package areas
 
 // AreaDetails represents a response area model from the areas api
 type AreaDetails struct {
-	Code          string `json:"code,omitempty"`
-	Name          string `json:"name,omitempty"`
-	DateStarted   string `json:"date_start,omitempty"`
-	DateEnd       string `json:"date_end,omitempty"`
-	WelshName     string `json:"name_welsh,omitempty"`
-	GeometricData string `json:"geometry"`
-	Visible       bool   `json:"visible,omitempty"`
-	AreaType      string `json:"area_type,omitempty"`
+	Code          string     `json:"code,omitempty"`
+	Name          string     `json:"name,omitempty"`
+	DateStarted   string     `json:"date_start,omitempty"`
+	DateEnd       string     `json:"date_end,omitempty"`
+	WelshName     string     `json:"name_welsh,omitempty"`
+	GeometricData string     `json:"geometry"`
+	Visible       bool       `json:"visible,omitempty"`
+	AreaType      string     `json:"area_type,omitempty"`
+	Ancestors     []Ancestor `json:"ancestors,omitempty"`
 }
 
 // Relation represents a response relation model from area api
@@ -26,8 +27,4 @@ type Ancestor struct {
 	Ancestors []Ancestor `json:"ancestors"`
 	Siblings  []Ancestor `json:"siblings"`
 	Children  []Ancestor `json:"children"`
-}
-
-type Ancestors struct {
-	Ancestors []Ancestor `json:"ancestors"`
 }


### PR DESCRIPTION
### What

Remove Ancestor struct & GetAncestors

Describe what you have changed and why.

We don't have a requirement for a GetAncestors func anymore as this data is returned in the `/areas` response under the `ancestors` key.

We also don't require the Ancestors struct as we can use `[]Ancestor` instead without the double nested `Ancestor.Ancestor` struct member access notation. 


### How to review
Run the tests
Describe the steps required to test the changes.

Run: `make test`

### Who can review
anyone
Describe who worked on the changes, so that other people can review.
myself
