### PR TITLE
Add 'SubmitFilter' function

### DIFF
--- a/cantabular/filter.go
+++ b/cantabular/filter.go
@@ -1,0 +1,128 @@
+package cantabular
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/clientlog"
+	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
+	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
+	"github.com/ONSdigital/log.go/v2/log"
+)
+
+const (
+	service     = "dp-cantabular-filter-flex-api"
+	POST_METHOD = "POST"
+)
+
+type SubmitFilterRequest struct {
+	FilterID       string                    `json:"filter_id"`
+	Dimensions     []filter.DimensionOptions `json:"dimension_options,omitempty"`
+	PopulationType string                    `json:"population_type"`
+}
+
+type Event struct {
+	Timestamp time.Time `bson:"timestamp" json:"timestamp"`
+	Name      string    `bson:"name"      json:"name"`
+}
+
+type SFDataset struct {
+	ID      string `bson:"id"      json:"id"`
+	Edition string `bson:"edition" json:"edition"`
+	Version int    `bson:"version" json:"version"`
+}
+
+type Link struct {
+	HREF string `bson:"href"           json:"href"`
+	ID   string `bson:"id,omitempty"   json:"id,omitempty"`
+}
+
+type Links struct {
+	Version Link `bson:"version" json:"version"`
+	Self    Link `bson:"self"    json:"self"`
+}
+
+type SFDimension struct {
+	Name         string   `bson:"name"          json:"name"`
+	Options      []string `bson:"options"       json:"options"`
+	DimensionURL string   `bson:"dimension_url" json:"dimension_url,omitempty"`
+	IsAreaType   bool     `bson:"is_area_type"  json:"is_area_type"`
+}
+
+type SubmitFilterResponse struct {
+	InstanceID       string        `json:"instance_id"`
+	DimensionListUrl string        `json:"dimension_list_url"`
+	FilterID         string        `json:"filter_id"`
+	Events           []Event       `json:"events"`
+	Dataset          SFDataset     `json:"dataset"`
+	Links            Links         `json:"links"`
+	PopulationType   string        `json:"population_type"`
+	Dimensions       []SFDimension `json:"dimensions"`
+}
+
+// SubmitFilter function to submit the request to submit a filter for a cantabular dataset.
+// Should POST to /filters/{filterid}/submit in dp-cantabular-filter-flex-api microservice.
+func (c *Client) SubmitFilter(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, ifMatch string, sfr SubmitFilterRequest) (*SubmitFilterResponse, string, error) {
+	b, err := json.Marshal(sfr)
+	if err != nil {
+		return nil, "", err
+	}
+
+	uri := fmt.Sprintf("%s/filters/%s/submit", c.extApiHost, sfr.FilterID)
+
+	clientlog.Do(ctx, "updating filter job", service, uri, log.Data{
+		"method": POST_METHOD,
+		"body":   string(b),
+	})
+
+	req, err := http.NewRequest(POST_METHOD, uri, bytes.NewBuffer(b))
+	if err != nil {
+		return nil, "", err
+	}
+
+	if err = headers.SetAuthToken(req, userAuthToken); err != nil {
+		return nil, "", fmt.Errorf("failed to set auth token: %w", err)
+	}
+	if err = headers.SetServiceAuthToken(req, serviceAuthToken); err != nil {
+		return nil, "", fmt.Errorf("failed to set service auth token: %w", err)
+	}
+	if err = headers.SetDownloadServiceToken(req, downloadServiceToken); err != nil {
+		return nil, "", fmt.Errorf("failed to set download service token: %w", err)
+	}
+	if err = headers.SetIfMatch(req, ifMatch); err != nil {
+		return nil, "", fmt.Errorf("failed to set if match: %w", err)
+	}
+
+	buf := &bytes.Buffer{}
+	resp, err := c.httpPost(ctx, uri, "application/json", buf)
+	if err != nil {
+		return nil, "", err
+	}
+	defer closeResponseBody(ctx, resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", filter.ErrInvalidFilterAPIResponse{ExpectedCode: http.StatusOK, ActualCode: resp.StatusCode, URI: uri}
+	}
+
+	eTag, err := headers.GetResponseETag(resp)
+	if err != nil && err != headers.ErrHeaderNotFound {
+		return nil, "", err
+	}
+
+	b, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var r *SubmitFilterResponse
+	if err = json.Unmarshal(b, &r); err != nil {
+		return nil, "", err
+	}
+
+	return r, eTag, nil
+}

--- a/cantabular/filter_test.go
+++ b/cantabular/filter_test.go
@@ -1,0 +1,172 @@
+package cantabular_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
+	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
+	dphttp "github.com/ONSdigital/dp-net/http"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	testDownloadServiceToken   = "Download"
+	testServiceAuthTokenHeader = "X-Florence-Token"
+	testAuthTokenHeader        = "Authorization"
+	ifMatch                    = "ea1e031b-3064-427d-8fed-4b35123213"
+	newETag                    = "eb31e352f140b8a965d008f5505153bc6c4f5b48"
+)
+
+var req = cantabular.SubmitFilterRequest{
+	FilterID: "ea1e031b-3064-427d-8fed-4b35c99bf1a3",
+	Dimensions: []filter.DimensionOptions{{
+		Items: []filter.DimensionOption{{
+			DimensionOptionsURL: "http://some.url/city",
+			Option:              "City",
+		}},
+		Count:      3,
+		Offset:     0,
+		Limit:      0,
+		TotalCount: 3,
+	}},
+	PopulationType: "population-type",
+}
+
+var successfulResponse = cantabular.SubmitFilterResponse{
+	InstanceID:       "instance-id",
+	DimensionListUrl: "http://some.url/filter/filder-id/dimensions",
+	FilterID:         "filter-id",
+	Events:           nil,
+	Dataset: cantabular.SFDataset{
+		ID:      "dataset-id",
+		Edition: "2022",
+		Version: 1,
+	},
+	Links: cantabular.Links{
+		Version: cantabular.Link{
+			HREF: "http://some.url",
+			ID:   "version-id",
+		},
+		Self: cantabular.Link{
+			HREF: "http://some.url",
+			ID:   "self-id",
+		},
+	},
+	PopulationType: "population-type",
+	Dimensions:     nil,
+}
+
+func Test_SubmitFilter(t *testing.T) {
+	ctx := context.Background()
+	Convey("Given a valid Submit Filter Request ", t, func() {
+		Convey("when 'SubmitFilter' is called with the expected ifMatch value", func() {
+
+			mockHttpClient, cantabularClient := mockedClient(newExpectedResponse(successfulResponse, http.StatusOK, newETag), nil)
+			res, ETag, err := cantabularClient.SubmitFilter(ctx, testAuthTokenHeader, testServiceAuthTokenHeader, testDownloadServiceToken, ifMatch, req)
+
+			Convey("Then no error should be returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("And the expected query is posted to cantabular filter-flex-api", func() {
+				So(mockHttpClient.PostCalls(), ShouldHaveLength, 1)
+				So(mockHttpClient.PostCalls()[0].URL, ShouldEqual, fmt.Sprintf("cantabular.ext.host/filters/%s/submit", req.FilterID))
+			})
+
+			Convey("And the expected response is returned", func() {
+				So(*res, ShouldResemble, successfulResponse)
+			})
+
+			Convey("And the expected ETag is empty", func() {
+				So(ETag, ShouldEqual, newETag)
+			})
+		})
+
+		Convey("when 'SubmitFilter' is called with an outdated ifMatch value", func() {
+			var mockRespETagConflict = `{"message": "conflict: invalid ETag provided or filter has been updated"}`
+			mockHttpClient, cantabularClient := mockedClient(newExpectedResponse(mockRespETagConflict, http.StatusConflict, ""), nil)
+			res, ETag, err := cantabularClient.SubmitFilter(ctx, testAuthTokenHeader, testServiceAuthTokenHeader, testDownloadServiceToken, ifMatch, req)
+
+			Convey("Then an error should be returned", func() {
+				So(err.(filter.ErrInvalidFilterAPIResponse).ExpectedCode, ShouldEqual, http.StatusOK)
+				So(err.(filter.ErrInvalidFilterAPIResponse).ActualCode, ShouldEqual, http.StatusConflict)
+			})
+
+			Convey("And the expected query is posted to cantabular filter-flex-api", func() {
+				So(mockHttpClient.PostCalls(), ShouldHaveLength, 1)
+				So(mockHttpClient.PostCalls()[0].URL, ShouldEqual, fmt.Sprintf("cantabular.ext.host/filters/%s/submit", req.FilterID))
+			})
+
+			Convey("And the expected response is returned", func() {
+				So(res, ShouldBeNil)
+			})
+
+			Convey("And the expected ETag is empty", func() {
+				So(ETag, ShouldEqual, "")
+			})
+		})
+
+		Convey("when 'SubmitFilter' is called and the POST method returns an error", func() {
+			mockHttpClient, cantabularClient := mockedClient(nil, errors.New("Something went wrong"))
+			res, ETag, err := cantabularClient.SubmitFilter(ctx, testAuthTokenHeader, testServiceAuthTokenHeader, testDownloadServiceToken, ifMatch, req)
+
+			Convey("Then an error should be returned", func() {
+				So(err.Error(), ShouldEqual, "failed to make request: Something went wrong")
+			})
+
+			Convey("And the expected query is posted to cantabular filter-flex-api", func() {
+				So(mockHttpClient.PostCalls(), ShouldHaveLength, 1)
+				So(mockHttpClient.PostCalls()[0].URL, ShouldEqual, fmt.Sprintf("cantabular.ext.host/filters/%s/submit", req.FilterID))
+			})
+
+			Convey("And the expected response is returned", func() {
+				So(res, ShouldBeNil)
+			})
+
+			Convey("And the expected ETag is empty", func() {
+				So(ETag, ShouldEqual, "")
+			})
+		})
+	})
+}
+
+func newExpectedResponse(body interface{}, sc int, eTag string) *http.Response {
+	b, _ := json.Marshal(body)
+
+	expectedResponse := &http.Response{
+		StatusCode: sc,
+		Body:       ioutil.NopCloser(bytes.NewReader(b)),
+		Header:     http.Header{},
+	}
+	expectedResponse.Header.Set("ETag", eTag)
+	return expectedResponse
+}
+
+// newMockedClient creates a new cantabular client with a mocked response for post requests,
+// according to the provided response string and status code.
+func mockedClient(response *http.Response, err error) (*dphttp.ClienterMock, *cantabular.Client) {
+	mockHttpClient := &dphttp.ClienterMock{
+		PostFunc: func(ctx context.Context, url string, contentType string, body io.Reader) (*http.Response, error) {
+			return response, err
+		},
+	}
+
+	cantabularClient := cantabular.NewClient(
+		cantabular.Config{
+			Host:       "cantabular.host",
+			ExtApiHost: "cantabular.ext.host",
+		},
+		mockHttpClient,
+		nil,
+	)
+
+	return mockHttpClient, cantabularClient
+}


### PR DESCRIPTION
### What

A new endpoint is required in dp-cantabular-filter-flex-api to submit
the user choices to generate the cantabular downloads, so we need to
create an associated function in dp-api-clients-go.

A new function should be created to handle the request to submit a
filter for a cantabular dataset which should POST to
`/filters/{filterid}/submit` in `dp-cantabular-filter-flex-api`.

Resolves: [5614](https://trello.com/c/JnvjQOa6/5614-create-function-in-dp-api-clients-go-for-filter-submit)

### How to review

* Check the Trello story 
* Inspect the code
* Run the unit tests

### Who can review

Any **Team B - Get Data** developer
