### PR TITLE
Use io.ReadFull to read full content for zip file

### DIFF
--- a/upload/client.go
+++ b/upload/client.go
@@ -144,8 +144,7 @@ func (c *Client) validateMetadata(metadata Metadata) error {
 
 func (c *Client) chunkReader(ctx context.Context, fileContent io.ReadCloser) (io.Reader, int, error) {
 	readBuff := make([]byte, chunkSize)
-	bytesRead, err := fileContent.Read(readBuff)
-
+	bytesRead, err := io.ReadFull(fileContent, readBuff)
 	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
 		log.Error(ctx, "file content read error", err)
 		return nil, 0, err


### PR DESCRIPTION
### What

Upload client currently only reads partial content when reader is for a file within a zip archive.

### How to review

Check test scenario covers issue.

### Who can review

Another
