### PR TITLE
Add new client function for filter-api GET /filters

### DIFF
--- a/filter/contract.go
+++ b/filter/contract.go
@@ -1,0 +1,42 @@
+package filter
+// Find in this file up to date request/responses to some of the dp-filter-api
+// endpoints. For some reason the existing functions are largely out of date
+// with how the API actually behaves, but are going to create fresh functions
+// for interacting rather than update old ones in case something somewhere breaks.
+// Perhaps the old ones can be removed at a later date once we're sure they're
+// not needed.
+
+// AuthHeaders represents the common set of headers required for making
+// authorized requests
+type AuthHeaders struct{
+	UserAuthToken    string
+	ServiceAuthToken string
+	CollectionID     string
+}
+
+// getFilterInput holds the required fields for making the GET /filters
+// API call
+type GetFilterInput struct{
+	FilterID string
+	AuthHeaders
+}
+
+// getFilterResponse is the response body for GET /filters
+type GetFilterResponse struct{
+	ID             string              `json:"id"`
+	FilterID       string              `json:"filter_id"`
+	InstanceID     string              `json:"instance_id"`
+	Links          FilterLinks         `json:"links"`
+	Dataset        Dataset             `json:"dataset,omitempty"`
+	State          string              `json:"state"`
+	Published      bool                `json:"published"`
+	PopulationType string              `json:"population_type,omitempty"`
+	ETag           string              `json:"-"`
+}
+
+// FilterLinks represents the links object for /filters related endpoints
+type FilterLinks struct{
+	Dimensions Link `json:"dimensions,omitempty"`
+	Self       Link `json:"self,omitempty"`
+	Version    Link `json:"version,omitempty"`
+}

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -110,6 +111,55 @@ func closeResponseBody(ctx context.Context, resp *http.Response) {
 	}
 }
 
+// GetFilter makes an authorised request to GET /filters
+func (c *Client) GetFilter(ctx context.Context, input GetFilterInput) (*GetFilterResponse, error){
+	uri := fmt.Sprintf("%s/filters/%s", c.hcCli.URL, input.FilterID)
+	clientlog.Do(ctx, "retrieving filter", service, uri)
+
+	res, err := c.doGetWithAuthHeaders(
+		ctx,
+		input.UserAuthToken,
+		input.ServiceAuthToken,
+		input.CollectionID,
+		uri,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to do request")
+	}
+
+	defer closeResponseBody(ctx, res)
+
+	eTag, err := headers.GetResponseETag(res)
+	if err != nil && err != headers.ErrHeaderNotFound {
+		return nil, errors.Wrap(err, "failed to get ETag header")
+	}
+
+	b, err := io.ReadAll(res.Body)
+	if err != nil{
+		return nil, errors.Wrap(err, "failed to decode response body")
+	}
+
+	resp := GetFilterResponse{
+		ETag: eTag,
+	}
+
+	if err := json.Unmarshal(b, &resp); err != nil{
+		return nil, errors.Wrap(err, "failed to unmarshal response")
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, dperrors.New(
+			errors.Errorf("error(s) returned by %s", uri),
+			res.StatusCode,
+			log.Data{
+				"response_body": string(b),
+			},
+		)
+	}
+
+	return &resp, nil
+}
+
 // GetOutput returns a filter output job for a given filter output id, unmarshalled as a Model struct
 func (c *Client) GetOutput(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID string) (m Model, err error) {
 	b, err := c.GetOutputBytes(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID)
@@ -142,7 +192,6 @@ func (c *Client) GetOutputBytes(ctx context.Context, userAuthToken, serviceAuthT
 
 // UpdateFilterOutput performs a PUT operation to update the filter with the provided filterOutput model
 func (c *Client) UpdateFilterOutput(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, filterJobID string, model *Model) error {
-
 	b, err := json.Marshal(model)
 	if err != nil {
 		return err
@@ -395,7 +444,6 @@ func (c *Client) GetDimensionOptionsInBatches(ctx context.Context, userAuthToken
 // If checkETag is true, then the ETag will be validated for each batch call. If it changes from one batch to another, an ErrBatchETagMismatch error will be returned.
 // Unless your processBatch function performs some call to modify the same filter, it is recommended to set checkETag to true, and you may retry this call if it fails with ErrBatchETagMismatch
 func (c *Client) GetDimensionOptionsBatchProcess(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, processBatch DimensionOptionsBatchProcessor, batchSize, maxWorkers int, checkETag bool) (eTag string, err error) {
-
 	isFirstGet := true
 	eTag = ""
 
@@ -494,8 +542,8 @@ func (c *Client) CreateBlueprint(ctx context.Context, userAuthToken, serviceAuth
 }
 
 func (c *Client) postBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version string, reqBody []byte) ([]byte, string, error) {
-
 	uri := c.hcCli.URL + "/filters"
+
 	clientlog.Do(ctx, "attempting to create filter blueprint", service, uri, log.Data{
 		"method":    "POST",
 		"datasetID": datasetID,


### PR DESCRIPTION
### What

Added `GetFilter` client function.

This deprecates GetJobState as the models/contract used no longer resemble the behaviour of dp-filter-api.

### How to review

Check code makes sense, tests pass

### Who can review

Anyone
