### PR TITLE
Add ID/Label to filter dimensions (#5664)

### DIFF
--- a/filter/data.go
+++ b/filter/data.go
@@ -25,6 +25,8 @@ type Dimensions struct {
 // Dimension represents a dimension response from the filter api
 type Dimension struct {
 	Name       string   `json:"name"`
+	ID         string   `json:"id,omitempty"`
+	Label      string   `json:"label,omitempty"`
 	URI        string   `json:"dimension_url"`
 	IsAreaType *bool    `json:"is_area_type,omitempty"`
 	Options    []string `json:"options,omitempty"`

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -353,6 +353,8 @@ func TestClient_GetDimension(t *testing.T) {
 	name := "corge"
 	dimensionBody := `{
 		"dimension_url": "www.ons.gov.uk",
+		"id": "quuz_id",
+		"label": "Dimension",
 		"name": "quuz",
 		"is_area_type": false,
 		"options": ["corge"]}`
@@ -381,6 +383,8 @@ func TestClient_GetDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(dim, ShouldResemble, Dimension{
 			Name:       "quuz",
+			ID:         "quuz_id",
+			Label:      "Dimension",
 			URI:        "www.ons.gov.uk",
 			Options:    []string{"corge"},
 			IsAreaType: boolToPtr(false),
@@ -394,6 +398,8 @@ func TestClient_GetDimension(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(dim, ShouldResemble, Dimension{
 			Name:       "quuz",
+			ID:         "quuz_id",
+			Label:      "Dimension",
 			URI:        "www.ons.gov.uk",
 			Options:    []string{"corge"},
 			IsAreaType: boolToPtr(false),


### PR DESCRIPTION
### What

Adds the ID/Label fields to returned filter dimensions. The client component of [this PR](https://github.com/ONSdigital/dp-cantabular-filter-flex-api/pull/60).

Required as part of the census pages and the select area-type journey. 

Resolves: [5664](https://trello.com/c/3TbBPTvY)

### How to review

Sense check.

### Who can review

Anyone.