### PR TITLE
add pagination to GetGeographyDimensions

### DIFF
--- a/cantabular/contract.go
+++ b/cantabular/contract.go
@@ -100,6 +100,14 @@ type GetDimensionOptionsRequest struct {
 	Filters        []Filter
 }
 
+// GetAreaTypeAreasRequest holds the request variables required for the
+// POST [cantabular-ext]/graphql QueryAreaTypeAreas query.
+type GetAreaTypeAreasRequest struct {
+	Dataset  string
+	Variable string
+	Category string
+}
+
 // GetDimensionOptionsResponse holds the response body for
 // POST [cantabular-ext]/graphql
 // with a query to obtain static dataset variables and categories, without values.

--- a/cantabular/contract.go
+++ b/cantabular/contract.go
@@ -7,6 +7,17 @@ type ErrorResponse struct {
 	Message string `json:"message"`
 }
 
+type PaginationParams struct {
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
+}
+
+type PaginationResponse struct {
+	PaginationParams
+	Count      int `json:"count"`
+	TotalCount int `json:"total_count"`
+}
+
 // GetCodebookRequest holds the query parameters for
 // GET [cantabular-srv]/codebook/{dataset}?cats=xxx&v=xxx
 type GetCodebookRequest struct {
@@ -62,10 +73,19 @@ type GetDimensionsResponse struct {
 	Dataset gql.DatasetVariables `json:"dataset"`
 }
 
+// GetGeographyDimensionsRequest holds the request parameters for
+// POST [cantabular-ext]/graphql
+// with a query to obtain geography variables
+type GetGeographyDimensionsRequest struct {
+	PaginationParams
+	Dataset string `json:"dataset"`
+}
+
 // GetGeographyDimensionsResponse holds the response body for
 // POST [cantabular-ext]/graphql
 // with a query to obtain geography variables
 type GetGeographyDimensionsResponse struct {
+	PaginationResponse
 	Dataset gql.DatasetRuleBase `json:"dataset"`
 }
 

--- a/cantabular/contract.go
+++ b/cantabular/contract.go
@@ -100,9 +100,9 @@ type GetDimensionOptionsRequest struct {
 	Filters        []Filter
 }
 
-// GetAreaTypeAreasRequest holds the request variables required for the
-// POST [cantabular-ext]/graphql QueryAreaTypeAreas query.
-type GetAreaTypeAreasRequest struct {
+// GetAreasRequest holds the request variables required for the
+// POST [cantabular-ext]/graphql QueryAreas query.
+type GetAreasRequest struct {
 	Dataset  string
 	Variable string
 	Category string
@@ -113,11 +113,6 @@ type GetAreaTypeAreasRequest struct {
 // with a query to obtain static dataset variables and categories, without values.
 type GetDimensionOptionsResponse struct {
 	Dataset StaticDatasetDimensionOptions `json:"dataset"`
-}
-
-type GetAreasRequest struct {
-	Dataset  string `schema:"dataset" validate:"required"`
-	AreaType string `schema:"area-type"`
 }
 
 // GetAreasResponse holds the response body for

--- a/cantabular/dimensions.go
+++ b/cantabular/dimensions.go
@@ -157,9 +157,9 @@ func (c *Client) GetDimensionOptions(ctx context.Context, req GetDimensionOption
 	return &resp.Data, nil
 }
 
-// GetAreaTypeAreas performs a graphQL query to retrieve the areas (categories) for a given area type. If the category
+// GetAreas performs a graphQL query to retrieve the areas (categories) for a given area type. If the category
 // is left empty, then all categories are returned. Results can also be filtered by area by passing a variable name.
-func (c *Client) GetAreaTypeAreas(ctx context.Context, req GetAreaTypeAreasRequest) (*GetAreasResponse, error) {
+func (c *Client) GetAreas(ctx context.Context, req GetAreasRequest) (*GetAreasResponse, error) {
 	resp := &struct {
 		Data   GetAreasResponse `json:"data"`
 		Errors []gql.Error      `json:"errors,omitempty"`
@@ -171,28 +171,7 @@ func (c *Client) GetAreaTypeAreas(ctx context.Context, req GetAreaTypeAreasReque
 		Category: req.Category,
 	}
 
-	if err := c.queryUnmarshal(ctx, QueryAreaTypeAreas, data, resp); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal query")
-	}
-
-	if resp != nil && len(resp.Errors) != 0 {
-		return nil, dperrors.New(
-			errors.New("error(s) returned by graphQL query"),
-			resp.Errors[0].StatusCode(),
-			log.Data{"errors": resp.Errors},
-		)
-	}
-
-	return &resp.Data, nil
-}
-
-func (c *Client) GetAreas(ctx context.Context, req QueryData) (*GetAreasResponse, error) {
-	resp := &struct {
-		Data   GetAreasResponse `json:"data"`
-		Errors []gql.Error      `json:"errors,omitempty"`
-	}{}
-
-	if err := c.queryUnmarshal(ctx, QueryAreasByArea, req, resp); err != nil {
+	if err := c.queryUnmarshal(ctx, QueryAreas, data, resp); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal query")
 	}
 

--- a/cantabular/dimensions.go
+++ b/cantabular/dimensions.go
@@ -157,6 +157,35 @@ func (c *Client) GetDimensionOptions(ctx context.Context, req GetDimensionOption
 	return &resp.Data, nil
 }
 
+// GetAreaTypeAreas performs a graphQL query to retrieve the areas (categories) for a given area type. If the category
+// is left empty, then all categories are returned. Results can also be filtered by area by passing a variable name.
+func (c *Client) GetAreaTypeAreas(ctx context.Context, req GetAreaTypeAreasRequest) (*GetAreasResponse, error) {
+	resp := &struct {
+		Data   GetAreasResponse `json:"data"`
+		Errors []gql.Error      `json:"errors,omitempty"`
+	}{}
+
+	data := QueryData{
+		Dataset:  req.Dataset,
+		Text:     req.Variable,
+		Category: req.Category,
+	}
+
+	if err := c.queryUnmarshal(ctx, QueryAreaTypeAreas, data, resp); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal query")
+	}
+
+	if resp != nil && len(resp.Errors) != 0 {
+		return nil, dperrors.New(
+			errors.New("error(s) returned by graphQL query"),
+			resp.Errors[0].StatusCode(),
+			log.Data{"errors": resp.Errors},
+		)
+	}
+
+	return &resp.Data, nil
+}
+
 func (c *Client) GetAreas(ctx context.Context, req QueryData) (*GetAreasResponse, error) {
 	resp := &struct {
 		Data   GetAreasResponse `json:"data"`

--- a/cantabular/dimensions_test.go
+++ b/cantabular/dimensions_test.go
@@ -481,15 +481,20 @@ func TestGetDimensionOptionsUnhappy(t *testing.T) {
 	})
 }
 
-func TestGetAreasHappy(t *testing.T) {
-	Convey("Given a correct getAreas response from the /graphql endpoint", t, func() {
+func TestGetAreas(t *testing.T) {
+	Convey("Given a valid response from the /graphql endpoint", t, func() {
+		const dataset = "Example"
+		const variable = "city"
+		const category = "london"
+
 		testCtx := context.Background()
 		mockHttpClient, cantabularClient := newMockedClient(mockRespBodyGetAreas, http.StatusOK)
 
 		Convey("When GetAreas is called", func() {
-			req := cantabular.QueryData{
-				Dataset: "Example",
-				Text:    "London",
+			req := cantabular.GetAreasRequest{
+				Dataset:  dataset,
+				Variable: variable,
+				Category: category,
 			}
 
 			resp, err := cantabularClient.GetAreas(testCtx, req)
@@ -503,10 +508,11 @@ func TestGetAreasHappy(t *testing.T) {
 				So(mockHttpClient.PostCalls()[0].URL, ShouldEqual, "cantabular.ext.host/graphql")
 				validateQuery(
 					mockHttpClient.PostCalls()[0].Body,
-					cantabular.QueryAreasByArea,
+					cantabular.QueryAreas,
 					cantabular.QueryData{
-						Dataset: "Example",
-						Text:    "London",
+						Dataset:  dataset,
+						Text:     variable,
+						Category: category,
 					},
 				)
 			})
@@ -519,139 +525,7 @@ func TestGetAreasHappy(t *testing.T) {
 }
 
 func TestGetAreasUnhappy(t *testing.T) {
-	Convey("Given a no-dataset graphql error response from the /graphql endpoint", t, func() {
-		testCtx := context.Background()
-		_, cantabularClient := newMockedClient(mockRespBodyNoDataset, http.StatusOK)
-
-		Convey("When GetAreas is called", func() {
-			req := cantabular.QueryData{
-				Dataset: "Test",
-				Text:    "London",
-			}
-
-			resp, err := cantabularClient.GetAreas(testCtx, req)
-
-			Convey("Then the expected error is returned", func() {
-				So(cantabularClient.StatusCode(err), ShouldResemble, http.StatusNotFound)
-			})
-
-			Convey("And no response is returned", func() {
-				So(resp, ShouldBeNil)
-			})
-		})
-	})
-
-	Convey("Given a no-dataset graphql error response from the /graphql endpoint", t, func() {
-		testCtx := context.Background()
-		_, cantabularClient := newMockedClient(mockRespBodyNoDataset, http.StatusOK)
-
-		Convey("When GetAreas is called", func() {
-			req := cantabular.QueryData{
-				Dataset: "Test",
-				Text:    "London",
-			}
-
-			resp, err := cantabularClient.GetAreas(testCtx, req)
-
-			Convey("Then the expected error is returned", func() {
-				So(cantabularClient.StatusCode(err), ShouldResemble, http.StatusNotFound)
-			})
-
-			Convey("And no response is returned", func() {
-				So(resp, ShouldBeNil)
-			})
-		})
-	})
-
-	Convey("Given no areas are returned from the /graphql endpoint", t, func() {
-		testCtx := context.Background()
-		_, cantabularClient := newMockedClient(mockRespBodyNoAreasFound, http.StatusOK)
-
-		Convey("When GetAreas is called", func() {
-			req := cantabular.QueryData{
-				Dataset: "Example",
-				Text:    "Rio",
-			}
-
-			resp, err := cantabularClient.GetAreas(testCtx, req)
-
-			Convey("Then the expected error is returned", func() {
-				So(err, ShouldBeNil)
-			})
-
-			Convey("And no response is returned", func() {
-				So(*resp, ShouldResemble, expectedAreasNotFound)
-			})
-		})
-	})
-
-	Convey("Given a 500 HTTP Status response from the /graphql endpoint", t, func() {
-		testCtx := context.Background()
-		_, cantabularClient := newMockedClient(mockRespInternalServerErr, http.StatusInternalServerError)
-
-		Convey("When GetAreas is called", func() {
-			req := cantabular.QueryData{
-				Dataset: "Teaching-Dataset",
-				Text:    "London",
-			}
-			resp, err := cantabularClient.GetAreas(testCtx, req)
-
-			Convey("Then the expected error is returned", func() {
-				So(cantabularClient.StatusCode(err), ShouldResemble, http.StatusInternalServerError)
-			})
-
-			Convey("And no response is returned", func() {
-				So(resp, ShouldBeNil)
-			})
-		})
-	})
-}
-
-func TestGetAreaTypeAreasHappy(t *testing.T) {
-	Convey("Given a valid response from the /graphql endpoint", t, func() {
-		const dataset = "Example"
-		const variable = "city"
-		const category = "london"
-
-		testCtx := context.Background()
-		mockHttpClient, cantabularClient := newMockedClient(mockRespBodyGetAreaTypeAreas, http.StatusOK)
-
-		Convey("When GetAreaTypesAreas is called", func() {
-			req := cantabular.GetAreaTypeAreasRequest{
-				Dataset:  dataset,
-				Variable: variable,
-				Category: category,
-			}
-
-			resp, err := cantabularClient.GetAreaTypeAreas(testCtx, req)
-
-			Convey("Then no error should be returned", func() {
-				So(err, ShouldBeNil)
-			})
-
-			Convey("And the expected query is posted to cantabular api-ext", func() {
-				So(mockHttpClient.PostCalls(), ShouldHaveLength, 1)
-				So(mockHttpClient.PostCalls()[0].URL, ShouldEqual, "cantabular.ext.host/graphql")
-				validateQuery(
-					mockHttpClient.PostCalls()[0].Body,
-					cantabular.QueryAreaTypeAreas,
-					cantabular.QueryData{
-						Dataset:  dataset,
-						Text:     variable,
-						Category: category,
-					},
-				)
-			})
-
-			Convey("And the expected response is returned", func() {
-				So(*resp, ShouldResemble, expectedAreaTypeAreas)
-			})
-		})
-	})
-}
-
-func TestGetAreaTypeAreasUnhappy(t *testing.T) {
-	stubReq := cantabular.GetAreaTypeAreasRequest{
+	stubReq := cantabular.GetAreasRequest{
 		Dataset:  "Example",
 		Variable: "city",
 		Category: "london",
@@ -661,9 +535,9 @@ func TestGetAreaTypeAreasUnhappy(t *testing.T) {
 		testCtx := context.Background()
 		_, cantabularClient := newMockedClient(mockRespBodyNoDataset, http.StatusOK)
 
-		Convey("When GetAreaTypeAreas is called", func() {
+		Convey("When GetAreas is called", func() {
 
-			resp, err := cantabularClient.GetAreaTypeAreas(testCtx, stubReq)
+			resp, err := cantabularClient.GetAreas(testCtx, stubReq)
 
 			Convey("Then the expected error is returned", func() {
 				So(cantabularClient.StatusCode(err), ShouldResemble, http.StatusNotFound)
@@ -679,8 +553,8 @@ func TestGetAreaTypeAreasUnhappy(t *testing.T) {
 		testCtx := context.Background()
 		_, cantabularClient := newMockedClient(mockRespInternalServerErr, http.StatusInternalServerError)
 
-		Convey("When GetAreaTypeAreas is called", func() {
-			resp, err := cantabularClient.GetAreaTypeAreas(testCtx, stubReq)
+		Convey("When GetAreas is called", func() {
+			resp, err := cantabularClient.GetAreas(testCtx, stubReq)
 
 			Convey("Then the expected error is returned", func() {
 				So(cantabularClient.StatusCode(err), ShouldResemble, http.StatusInternalServerError)
@@ -1282,7 +1156,7 @@ var expectedDimensionOptions = cantabular.GetDimensionOptionsResponse{
 	},
 }
 
-var mockRespBodyGetAreaTypeAreas = `
+var mockRespBodyGetAreas = `
 {
   "data": {
     "dataset": {
@@ -1317,7 +1191,7 @@ var mockRespBodyGetAreaTypeAreas = `
 }
 `
 
-var expectedAreaTypeAreas = cantabular.GetAreasResponse{
+var expectedAreas = cantabular.GetAreasResponse{
 	Dataset: gql.DatasetRuleBase{
 		RuleBase: gql.RuleBase{
 			IsSourceOf: gql.Variables{
@@ -1342,89 +1216,6 @@ var expectedAreaTypeAreas = cantabular.GetAreasResponse{
 							},
 						},
 					},
-				},
-			},
-		},
-	},
-}
-
-// mockRespBodyGetAreas is a successful 'get areas' query respose that is returned from a mocked client for testing
-var mockRespBodyGetAreas = `
-{
-	"data": {
-	  "dataset": {
-		"ruleBase": {
-		  "isSourceOf": {
-			"categorySearch": {
-			  "edges": [
-				{
-				  "node": {
-					"code": "0",
-					"label": "london",
-					"variable": {
-					  "mapFrom": [],
-					  "name": "city"
-					}
-				  }
-				}
-			  ]
-			}
-		  }
-		}
-	  }
-	}
-  }
-`
-
-// mockRespBodyGetAreasNotFound is a 'get areas' query respose that is returned from a mocked client for testing
-var mockRespBodyNoAreasFound = `
-{
-	"data": {
-	  "dataset": {
-		"ruleBase": {
-		  "isSourceOf": {
-			"categorySearch": {
-			  "edges": []
-			}
-		  }
-		}
-	  }
-	}
-  }
-`
-
-var expectedAreas = cantabular.GetAreasResponse{
-	Dataset: gql.DatasetRuleBase{
-		RuleBase: gql.RuleBase{
-			IsSourceOf: gql.Variables{
-				CategorySearch: gql.Search{
-					Edges: []gql.Edge{
-						{
-
-							Node: gql.Node{
-								Code:  "0",
-								Name:  "",
-								Label: "london",
-								Variable: gql.Variable{
-									Name: "city",
-								},
-							},
-						},
-					},
-				},
-			},
-			Name: "",
-		},
-	},
-}
-
-var expectedAreasNotFound = cantabular.GetAreasResponse{
-	Dataset: gql.DatasetRuleBase{
-		RuleBase: gql.RuleBase{
-			IsSourceOf: gql.Variables{
-				Search: gql.Search{},
-				CategorySearch: gql.Search{
-					Edges: []gql.Edge{},
 				},
 			},
 		},

--- a/cantabular/dimensions_test.go
+++ b/cantabular/dimensions_test.go
@@ -607,6 +607,92 @@ func TestGetAreasUnhappy(t *testing.T) {
 	})
 }
 
+func TestGetAreaTypeAreasHappy(t *testing.T) {
+	Convey("Given a valid response from the /graphql endpoint", t, func() {
+		const dataset = "Example"
+		const variable = "city"
+		const category = "london"
+
+		testCtx := context.Background()
+		mockHttpClient, cantabularClient := newMockedClient(mockRespBodyGetAreaTypeAreas, http.StatusOK)
+
+		Convey("When GetAreaTypesAreas is called", func() {
+			req := cantabular.GetAreaTypeAreasRequest{
+				Dataset:  dataset,
+				Variable: variable,
+				Category: category,
+			}
+
+			resp, err := cantabularClient.GetAreaTypeAreas(testCtx, req)
+
+			Convey("Then no error should be returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("And the expected query is posted to cantabular api-ext", func() {
+				So(mockHttpClient.PostCalls(), ShouldHaveLength, 1)
+				So(mockHttpClient.PostCalls()[0].URL, ShouldEqual, "cantabular.ext.host/graphql")
+				validateQuery(
+					mockHttpClient.PostCalls()[0].Body,
+					cantabular.QueryAreaTypeAreas,
+					cantabular.QueryData{
+						Dataset:  dataset,
+						Text:     variable,
+						Category: category,
+					},
+				)
+			})
+
+			Convey("And the expected response is returned", func() {
+				So(*resp, ShouldResemble, expectedAreaTypeAreas)
+			})
+		})
+	})
+}
+
+func TestGetAreaTypeAreasUnhappy(t *testing.T) {
+	stubReq := cantabular.GetAreaTypeAreasRequest{
+		Dataset:  "Example",
+		Variable: "city",
+		Category: "london",
+	}
+
+	Convey("Given a no-dataset graphql error response from the /graphql endpoint", t, func() {
+		testCtx := context.Background()
+		_, cantabularClient := newMockedClient(mockRespBodyNoDataset, http.StatusOK)
+
+		Convey("When GetAreaTypeAreas is called", func() {
+
+			resp, err := cantabularClient.GetAreaTypeAreas(testCtx, stubReq)
+
+			Convey("Then the expected error is returned", func() {
+				So(cantabularClient.StatusCode(err), ShouldResemble, http.StatusNotFound)
+			})
+
+			Convey("And no response is returned", func() {
+				So(resp, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("Given a 500 HTTP Status response from the /graphql endpoint", t, func() {
+		testCtx := context.Background()
+		_, cantabularClient := newMockedClient(mockRespInternalServerErr, http.StatusInternalServerError)
+
+		Convey("When GetAreaTypeAreas is called", func() {
+			resp, err := cantabularClient.GetAreaTypeAreas(testCtx, stubReq)
+
+			Convey("Then the expected error is returned", func() {
+				So(cantabularClient.StatusCode(err), ShouldResemble, http.StatusInternalServerError)
+			})
+
+			Convey("And no response is returned", func() {
+				So(resp, ShouldBeNil)
+			})
+		})
+	})
+}
+
 // newMockedClient creates a new cantabular client with a mocked response for post requests,
 // according to the provided response string and status code.
 func newMockedClient(response string, statusCode int) (*dphttp.ClienterMock, *cantabular.Client) {
@@ -1189,6 +1275,72 @@ var expectedDimensionOptions = cantabular.GetDimensionOptionsResponse{
 						{Code: "8", Label: "Process, Plant and Machine Operatives"},
 						{Code: "9", Label: "Elementary Occupations"},
 						{Code: "-9", Label: "N/A"},
+					},
+				},
+			},
+		},
+	},
+}
+
+var mockRespBodyGetAreaTypeAreas = `
+{
+  "data": {
+    "dataset": {
+      "ruleBase": {
+        "isSourceOf": {
+          "search": {
+            "edges": [
+              {
+                "node": {
+                  "label": "City",
+                  "name": "city",
+                  "categories": {
+                    "search": {
+                      "edges": [
+                        {
+                          "node": {
+                            "code": "0",
+                            "label": "London"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+`
+
+var expectedAreaTypeAreas = cantabular.GetAreasResponse{
+	Dataset: gql.DatasetRuleBase{
+		RuleBase: gql.RuleBase{
+			IsSourceOf: gql.Variables{
+				Search: gql.Search{
+					Edges: []gql.Edge{
+						{
+							Node: gql.Node{
+								Name:  "city",
+								Label: "City",
+								Categories: gql.Categories{
+									Search: gql.Search{
+										Edges: []gql.Edge{
+											{
+												Node: gql.Node{
+													Code:  "0",
+													Label: "London",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/cantabular/dimensions_test.go
+++ b/cantabular/dimensions_test.go
@@ -85,7 +85,13 @@ func TestGetGeographyDimensionsHappy(t *testing.T) {
 		mockHttpClient, cantabularClient := newMockedClient(mockRespBodyGetGeographyDimensions, http.StatusOK)
 
 		Convey("When GetGeographyDimensions is called", func() {
-			resp, err := cantabularClient.GetGeographyDimensions(testCtx, "Teaching-Dataset")
+			resp, err := cantabularClient.GetGeographyDimensions(testCtx, cantabular.GetGeographyDimensionsRequest{
+				Dataset: "Teaching-Dataset",
+				PaginationParams: cantabular.PaginationParams{
+					Limit:  10,
+					Offset: 0,
+				},
+			})
 
 			Convey("Then no error should be returned", func() {
 				So(err, ShouldBeNil)
@@ -99,6 +105,10 @@ func TestGetGeographyDimensionsHappy(t *testing.T) {
 					cantabular.QueryGeographyDimensions,
 					cantabular.QueryData{
 						Dataset: "Teaching-Dataset",
+						PaginationParams: cantabular.PaginationParams{
+							Limit:  10,
+							Offset: 0,
+						},
 					},
 				)
 			})
@@ -116,7 +126,13 @@ func TestGetGeographyDimensionsUnhappy(t *testing.T) {
 		_, cantabularClient := newMockedClient(mockRespBodyNoDataset, http.StatusOK)
 
 		Convey("When GetGeographyDimensions is called", func() {
-			resp, err := cantabularClient.GetGeographyDimensions(testCtx, "InexistentDataset")
+			resp, err := cantabularClient.GetGeographyDimensions(testCtx, cantabular.GetGeographyDimensionsRequest{
+				Dataset: "InexistentDataset",
+				PaginationParams: cantabular.PaginationParams{
+					Limit:  10,
+					Offset: 0,
+				},
+			})
 
 			Convey("Then the expected error is returned", func() {
 				So(cantabularClient.StatusCode(err), ShouldResemble, http.StatusNotFound)
@@ -133,7 +149,13 @@ func TestGetGeographyDimensionsUnhappy(t *testing.T) {
 		_, cantabularClient := newMockedClient(mockRespInternalServerErr, http.StatusInternalServerError)
 
 		Convey("When GetGeographyDimensions is called", func() {
-			resp, err := cantabularClient.GetGeographyDimensions(testCtx, "Teaching-Dataset")
+			resp, err := cantabularClient.GetGeographyDimensions(testCtx, cantabular.GetGeographyDimensionsRequest{
+				Dataset: "Teaching-Dataset",
+				PaginationParams: cantabular.PaginationParams{
+					Limit:  10,
+					Offset: 0,
+				},
+			})
 
 			Convey("Then the expected error is returned", func() {
 				So(err, ShouldResemble, expectedInternalServeError)
@@ -771,6 +793,7 @@ var mockRespBodyGetGeographyDimensions = `
 		"dataset": {
 			"ruleBase": {
 				"isSourceOf": {
+					"totalCount": 2,
 					"edges": [
 						{
 							"node": {
@@ -817,6 +840,7 @@ var expectedGeographyDimensions = cantabular.GetGeographyDimensionsResponse{
 	Dataset: gql.DatasetRuleBase{
 		RuleBase: gql.RuleBase{
 			IsSourceOf: gql.Variables{
+				TotalCount: 2,
 				Edges: []gql.Edge{
 					{
 						Node: gql.Node{
@@ -853,6 +877,14 @@ var expectedGeographyDimensions = cantabular.GetGeographyDimensionsResponse{
 				},
 			},
 			Name: "Region",
+		},
+	},
+	PaginationResponse: cantabular.PaginationResponse{
+		Count:      2,
+		TotalCount: 2,
+		PaginationParams: cantabular.PaginationParams{
+			Limit:  10,
+			Offset: 0,
 		},
 	},
 }

--- a/cantabular/dimensions_test.go
+++ b/cantabular/dimensions_test.go
@@ -960,6 +960,7 @@ var expectedSearchDimensionsResponse = cantabular.GetDimensionsResponse{
 							Label: "Country",
 							MapFrom: []gql.Variables{
 								{
+									TotalCount: 1,
 									Edges: []gql.Edge{
 										{
 											Node: gql.Node{

--- a/cantabular/gql/data.go
+++ b/cantabular/gql/data.go
@@ -17,6 +17,7 @@ type Variables struct {
 	Edges          []Edge `json:"edges"`
 	Search         Search `json:"search,omitempty"`
 	CategorySearch Search `json:"categorySearch,omitempty"`
+	TotalCount     int    `json:"totalCount"`
 }
 
 type Search struct {

--- a/cantabular/gql/data.go
+++ b/cantabular/gql/data.go
@@ -41,6 +41,7 @@ type Node struct {
 type Categories struct {
 	TotalCount int    `json:"totalCount"`
 	Edges      []Edge `json:"edges"`
+	Search     Search `json:"search,omitempty"`
 }
 
 type Variable struct {

--- a/cantabular/queries.go
+++ b/cantabular/queries.go
@@ -157,42 +157,10 @@ query($dataset: String!, $text: String!) {
 	}
 }`
 
-// QueryDimensionsByName is the graphQL query to obtain dimensions by name (subset of variables, without categories)
-const QueryAreasByArea = `
-query($dataset: String!, $text: String!) {
-	dataset(name: $dataset) {
-		ruleBase 
-		{
-		  isSourceOf {
-			categorySearch(text: $text){
-		   		edges {
-			  		node { 
-						code
-						label
-						variable {
-				  			mapFrom{
-								edges{
-					  				node{
-										name
-										label
-										 }
-									}
-				 				 }
-							 name 
-						}
-					  } 
-	  				}
-				}
-	  		}
-	  	}
-	  }
-  }
-`
-
-// QueryAreaTypeAreas is the graphQL query to search for areas and area types which match a specific string.
+// QueryAreas is the graphQL query to search for areas and area types which match a specific string.
 // This can be used to retrieve a list of all the areas for a given area type, or to search for specific
 // area within all area types.
-const QueryAreaTypeAreas = `
+const QueryAreas = `
 query ($dataset: String!, $text: String!, $category: String!) {
   dataset(name: $dataset) {
     ruleBase {

--- a/cantabular/queries.go
+++ b/cantabular/queries.go
@@ -189,13 +189,46 @@ query($dataset: String!, $text: String!) {
   }
 `
 
+// QueryAreaTypeAreas is the graphQL query to search for areas and area types which match a specific string.
+// This can be used to retrieve a list of all the areas for a given area type, or to search for specific
+// area within all area types.
+const QueryAreaTypeAreas = `
+query ($dataset: String!, $text: String!, $category: String!) {
+  dataset(name: $dataset) {
+    ruleBase {
+      isSourceOf {
+        search(text: $text) {
+          edges {
+            node {
+              label
+              name
+              categories {
+                search(text: $category) {
+                  edges {
+                    node {
+                      code
+                      label
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`
+
 // QueryData holds all the possible required variables to encode any of the graphql queries defined in this file.
 type QueryData struct {
+	PaginationParams
 	Dataset   string
 	Text      string
 	Variables []string
 	Filters   []Filter
-	PaginationParams
+	Category  string
 }
 
 // Filter holds the fields for the Cantabular GraphQL 'Filter' object used for specifying categories
@@ -220,6 +253,7 @@ func (data *QueryData) Encode(query string) (bytes.Buffer, error) {
 		"text":      data.Text,
 		"limit":     data.Limit,
 		"offset":    data.Offset,
+		"category":  data.Category,
 	}
 	if len(data.Filters) > 0 {
 		vars["filters"] = data.Filters


### PR DESCRIPTION
### What

Added pagination to GetGeographyDimensions function, to be used by GET /area-types in dp-cantabular-dimension-api

Enables passing of limit and offset and responds with limit, offset, count and total count

Related to https://github.com/ONSdigital/dp-cantabular-dimension-api/pull/13

### How to review

Check changes make sense and tests pass

### Who can review

Anyone
