### PR TITLE
Add dp-download-service client

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -1,0 +1,127 @@
+package download
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/clientlog"
+	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
+	healthcheck "github.com/ONSdigital/dp-api-clients-go/v2/health"
+	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
+	dprequest "github.com/ONSdigital/dp-net/request"
+	"github.com/ONSdigital/log.go/v2/log"
+)
+
+const service = "download-service"
+
+type Response struct {
+	Content io.ReadCloser `json:"content"`
+}
+
+// Client is an download service client which can be used to make requests to the server.
+// It extends the generic healthcheck Client structure.
+type Client struct {
+	hcCli            *healthcheck.Client
+	serviceAuthToken string
+}
+
+// NewAPIClient creates a new instance of DownloadServiceAPI Client with a given download service url
+func NewAPIClient(downloadServiceAPIURL, serviceAuthToken string) *Client {
+	return &Client{
+		healthcheck.NewClient(service, downloadServiceAPIURL),
+		serviceAuthToken,
+	}
+}
+
+// NewWithHealthClient creates a new instance of DownloadServiceAPI Client,
+// reusing the URL and Clienter from the provided healthcheck client.
+func NewWithHealthClient(hcCli *healthcheck.Client, serviceAuthToken string) *Client {
+	return &Client{
+		healthcheck.NewClientWithClienter(service, hcCli.URL, hcCli.Client),
+		serviceAuthToken,
+	}
+}
+
+// URL returns the URL used by this client
+func (c *Client) URL() string {
+	return c.hcCli.URL
+}
+
+// HealthClient returns the underlying Healthcheck Client for this download service client
+func (c *Client) HealthClient() *healthcheck.Client {
+	return c.hcCli
+}
+
+// Checker calls download service health endpoint and returns a check object to the caller.
+func (c *Client) Checker(ctx context.Context, check *health.CheckState) error {
+	return c.hcCli.Checker(ctx, check)
+}
+
+// Download returns the requested path
+func (c *Client) Download(ctx context.Context, path string) (*Response, error) {
+	uri := fmt.Sprintf("%s/downloads-new/%s", c.hcCli.URL, path)
+
+	clientlog.Do(ctx, "retrieving resource", service, uri)
+
+	resp, err := c.doGetWithAuthHeaders(ctx, uri)
+	if err != nil {
+		return nil, dperrors.New(
+			fmt.Errorf("failed to create request to DownloadService API: %w", err),
+			http.StatusInternalServerError,
+			nil,
+		)
+	}
+
+	//resp.StatusCode == http.StatusMovedPermanently - redirects followed by default with httpclient: https://github.com/golang/go/issues/42832
+
+	if resp.StatusCode != http.StatusOK {
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, dperrors.New(
+				fmt.Errorf("failed to read error response body: %s", err),
+				resp.StatusCode,
+				nil,
+			)
+		}
+		closeResponseBody(ctx, resp)
+		return nil, dperrors.New(
+			errors.New(string(b)), resp.StatusCode, nil,
+		)
+	}
+
+	return &Response{Content: resp.Body}, nil
+}
+
+func (c *Client) doGetWithAuthHeaders(ctx context.Context, uri string) (*http.Response, error) {
+	clientlog.Do(ctx, "retrieving resource", service, uri)
+
+	req, err := http.NewRequest(http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	dprequest.AddServiceTokenHeader(req, c.serviceAuthToken)
+
+	resp, err := c.hcCli.Client.Do(ctx, req)
+	if err != nil {
+		return nil, dperrors.New(
+			fmt.Errorf("failed to create request to DownloadService API: %s", err),
+			http.StatusInternalServerError,
+			nil,
+		)
+	}
+	return resp, nil
+}
+
+// closeResponseBody closes the response body and logs an error if unsuccessful
+func closeResponseBody(ctx context.Context, resp *http.Response) {
+	if resp.Body != nil {
+		if err := resp.Body.Close(); err != nil {
+			log.Error(ctx, "error closing http response body", err)
+		}
+	}
+}

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -1,0 +1,263 @@
+package download_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/download"
+	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
+	"github.com/ONSdigital/dp-api-clients-go/v2/health"
+	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+	dprequest "github.com/ONSdigital/dp-net/request"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	rootpath        = "downloads-new"
+	filepath        = "testing/test.txt"
+	authHeaderValue = "a-service-client-auth-token"
+	actualContent   = "some-content"
+)
+
+var (
+	actualMethod, actualURL, actualAuthHeaderValue string
+)
+
+func TestHealthCheck(t *testing.T) {
+	timePriorHealthCheck := time.Now()
+
+	Convey("Given the download service is healthy", t, func() {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }))
+		defer s.Close()
+
+		c := download.NewAPIClient(s.URL, "")
+
+		Convey("When we check that state of the service", func() {
+			state := health.CreateCheckState("testing")
+			c.Checker(context.Background(), &state)
+
+			Convey("Then the health check should be successful", func() {
+				So(state.Status(), ShouldEqual, healthcheck.StatusOK)
+				So(state.StatusCode(), ShouldEqual, 200)
+				So(state.Message(), ShouldContainSubstring, "is ok")
+			})
+
+			Convey("And the timestamps are logged appropriately", func() {
+				So(*state.LastChecked(), ShouldHappenAfter, timePriorHealthCheck)
+				So(*state.LastSuccess(), ShouldHappenAfter, timePriorHealthCheck)
+				So(state.LastFailure(), ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("Given the download service is failing", t, func() {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusInternalServerError) }))
+		defer s.Close()
+
+		c := download.NewAPIClient(s.URL, "")
+
+		Convey("When we check the state of the service", func() {
+			state := health.CreateCheckState("testing")
+			c.Checker(context.Background(), &state)
+
+			Convey("Then the health check should be successful", func() {
+				So(state.Status(), ShouldEqual, healthcheck.StatusCritical)
+				So(state.StatusCode(), ShouldEqual, 500)
+				So(state.Message(), ShouldContainSubstring, "unavailable or non-functioning")
+			})
+
+			Convey("And the timestamps are logged appropriately", func() {
+				So(*state.LastChecked(), ShouldHappenAfter, timePriorHealthCheck)
+				So(state.LastSuccess(), ShouldBeNil)
+				So(*state.LastFailure(), ShouldHappenAfter, timePriorHealthCheck)
+			})
+		})
+	})
+}
+
+func TestDownload(t *testing.T) {
+
+	Convey("Given a file is available for download", t, func() {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			actualMethod = r.Method
+			actualURL = r.URL.Path
+			actualAuthHeaderValue = r.Header.Get(dprequest.AuthHeaderKey)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(actualContent))
+		}))
+		defer s.Close()
+
+		c := download.NewAPIClient(s.URL, authHeaderValue)
+
+		Convey("When I download", func() {
+			resp, err := c.Download(context.Background(), filepath)
+			content := readAndClose(resp)
+
+			Convey("Then the response is as expected", func() {
+				So(err, ShouldBeNil)
+				So(actualMethod, ShouldEqual, http.MethodGet)
+				So(actualAuthHeaderValue, ShouldEqual, fmt.Sprintf("Bearer %s", authHeaderValue))
+				So(actualURL, ShouldEqual, fmt.Sprintf("/%s/%s", rootpath, filepath))
+				So(actualContent, ShouldEqual, content)
+			})
+		})
+	})
+
+	Convey("Given a file responds as expected from a redirect", t, func() {
+		redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			actualMethod = r.Method
+			actualURL = r.URL.Path
+			actualAuthHeaderValue = r.Header.Get(dprequest.AuthHeaderKey)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(actualContent))
+		}))
+		defer redirect.Close()
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, redirect.URL, http.StatusMovedPermanently)
+		}))
+		defer s.Close()
+
+		c := download.NewAPIClient(s.URL, authHeaderValue)
+
+		Convey("When I download", func() {
+			resp, err := c.Download(context.Background(), filepath)
+			content := readAndClose(resp)
+
+			Convey("Then the response is as expected", func() {
+				So(err, ShouldBeNil)
+				So(actualMethod, ShouldEqual, http.MethodGet)
+				So(actualURL, ShouldEqual, "/")
+				So(actualContent, ShouldEqual, content)
+				So(actualAuthHeaderValue, ShouldBeEmpty) //not passed through
+			})
+		})
+	})
+
+	Convey("Given there no file available", t, func() {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer s.Close()
+
+		c := download.NewAPIClient(s.URL, authHeaderValue)
+
+		Convey("When I download", func() {
+			resp, err := c.Download(context.Background(), filepath)
+			content := readAndClose(resp)
+
+			Convey("Then a well formatted error should be returned", func() {
+				So(err, ShouldHaveSameTypeAs, &dperrors.Error{})
+			})
+
+			Convey("And the expected error is returned", func() {
+				dperr := err.(*dperrors.Error)
+				So(dperr.Error(), ShouldBeEmpty)
+				So(dperr.Code(), ShouldEqual, http.StatusNotFound)
+			})
+
+			Convey("And the content should be empty", func() {
+				So(content, ShouldBeEmpty)
+			})
+		})
+	})
+
+	Convey("Given the service auth token is not valid", t, func() {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer s.Close()
+
+		c := download.NewAPIClient(s.URL, "not-valid-token")
+
+		Convey("When I download", func() {
+			resp, err := c.Download(context.Background(), filepath)
+			content := readAndClose(resp)
+
+			Convey("Then a well formatted error should be returned", func() {
+				So(err, ShouldHaveSameTypeAs, &dperrors.Error{})
+			})
+
+			Convey("And the expected error is returned", func() {
+				dperr := err.(*dperrors.Error)
+				So(dperr.Error(), ShouldBeEmpty)
+				So(dperr.Code(), ShouldEqual, http.StatusForbidden)
+			})
+
+			Convey("And the content should be empty", func() {
+				So(content, ShouldBeEmpty)
+			})
+		})
+	})
+
+	Convey("Given download service has downstream errors", t, func() {
+		errorCode := "CriticalError"
+		errorDescription := "it is broken"
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			errorBody := fmt.Sprintf(`{"errors": [{"errorCode": "%s", "description": "%s"}]}`, errorCode, errorDescription)
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(errorBody))
+		}))
+		defer s.Close()
+
+		c := download.NewAPIClient(s.URL, authHeaderValue)
+
+		Convey("When I download", func() {
+			resp, err := c.Download(context.Background(), filepath)
+			content := readAndClose(resp)
+
+			Convey("Then a well formatted error should be returned", func() {
+				So(err, ShouldHaveSameTypeAs, &dperrors.Error{})
+			})
+
+			Convey("And the expected error is returned", func() {
+				dperr := err.(*dperrors.Error)
+				So(dperr.Error(), ShouldContainSubstring, errorCode)
+				So(dperr.Error(), ShouldContainSubstring, errorDescription)
+				So(dperr.Code(), ShouldEqual, http.StatusInternalServerError)
+			})
+
+			Convey("And the content should be empty", func() {
+				So(content, ShouldBeEmpty)
+			})
+		})
+	})
+
+	Convey("Given download service is configured incorrectly", t, func() {
+		c := download.NewAPIClient("broken", authHeaderValue)
+
+		Convey("When I download", func() {
+			resp, err := c.Download(context.Background(), filepath)
+			content := readAndClose(resp)
+
+			Convey("Then a well formatted error should be returned", func() {
+				So(err, ShouldHaveSameTypeAs, &dperrors.Error{})
+			})
+
+			Convey("And the expected error is returned", func() {
+				dperr := err.(*dperrors.Error)
+				So(dperr.Error(), ShouldContainSubstring, "broken")
+				So(dperr.Code(), ShouldEqual, http.StatusInternalServerError)
+			})
+
+			Convey("And the content should be empty", func() {
+				So(content, ShouldBeEmpty)
+			})
+		})
+	})
+}
+
+func readAndClose(response *download.Response) string {
+	if response == nil {
+		return ""
+	}
+	content, _ := io.ReadAll(response.Content)
+	response.Content.Close()
+	return string(content)
+}


### PR DESCRIPTION
### What

Add dp-download-service client:
- follow pattern of other clients (lift n shift'ish 🤠)
- only one endpoint covered - as expected for this piece of work: https://github.com/ONSdigital/dp-download-service/blob/500edf0ca0b286f8542f4f7b831bd9168749ff86/swagger.yml#L72
- have tested locally

### How to review

Sanity check and check test scenarios.

### Who can review

Anyone
