### PR TITLE
Extend interactives client with PATCH endpoint

### DIFF
--- a/interactives/data.go
+++ b/interactives/data.go
@@ -1,8 +1,16 @@
 package interactives
 
 const (
-	UpdateFormFieldKey = "update"
+	UpdateFormFieldKey = "interactive"
+	PatchImportArchive = "ImportArchive"
 )
+
+type PatchRequest struct {
+	Action      string      `json:"action,omitempty"`
+	Successful  bool        `json:"successful,omitempty"`
+	Message     string      `json:"message,omitempty"`
+	Interactive Interactive `json:"interactive,omitempty"`
+}
 
 type InteractiveFilter struct {
 	AssociateCollection bool                 `json:"associate_collection,omitempty"`
@@ -35,12 +43,6 @@ type InteractiveFile struct {
 	Name     string `json:"name,omitempty"`
 	Mimetype string `json:"mimetype,omitempty"`
 	Size     int64  `json:"size_in_bytes,omitempty"`
-}
-
-type InteractiveUpdate struct {
-	ImportSuccessful *bool       `json:"import_successful,omitempty"`
-	ImportMessage    string      `json:"import_message,omitempty"`
-	Interactive      Interactive `json:"interactive,omitempty"`
 }
 
 type List struct {


### PR DESCRIPTION
### What

Extended the interactives client with a PATCH endpoint for partial updates only - in this case: just updating the interactive with files uploaded from importer async task.

*NOTE:* upload/update endpoints updated to reflect better model - i.e. json payload should be just an interactive now and called interactive. Swagger change coming in API PR.

### How to review

Sanity check - code & tests

### Who can review

Anyone
