### PR TITLE
Expect HTTP Accepted code from  filters/{id}/submit

### DIFF
--- a/filter/data.go
+++ b/filter/data.go
@@ -149,12 +149,9 @@ type SubmitFilterRequest struct {
 }
 
 type SubmitFilterResponse struct {
-	InstanceID       string      `json:"instance_id"`
-	DimensionListUrl string      `json:"dimension_list_url"`
-	FilterID         string      `json:"filter_id"`
-	Events           []Event     `json:"events"`
-	Dataset          Dataset     `json:"dataset"`
-	Links            Links       `json:"links"`
-	PopulationType   string      `json:"population_type"`
-	Dimensions       []Dimension `json:"dimensions"`
+	InstanceID     string      `json:"instance_id"`
+	FilterOutputID string      `json:"filter_output_id"`
+	Dataset        Dataset     `json:"dataset"`
+	Links          FilterLinks `json:"links"`
+	PopulationType string      `json:"population_type"`
 }

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 
@@ -112,7 +112,7 @@ func closeResponseBody(ctx context.Context, resp *http.Response) {
 }
 
 // GetFilter makes an authorised request to GET /filters
-func (c *Client) GetFilter(ctx context.Context, input GetFilterInput) (*GetFilterResponse, error){
+func (c *Client) GetFilter(ctx context.Context, input GetFilterInput) (*GetFilterResponse, error) {
 	uri := fmt.Sprintf("%s/filters/%s", c.hcCli.URL, input.FilterID)
 	clientlog.Do(ctx, "retrieving filter", service, uri)
 
@@ -135,7 +135,7 @@ func (c *Client) GetFilter(ctx context.Context, input GetFilterInput) (*GetFilte
 	}
 
 	b, err := io.ReadAll(res.Body)
-	if err != nil{
+	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}
 
@@ -148,7 +148,7 @@ func (c *Client) GetFilter(ctx context.Context, input GetFilterInput) (*GetFilte
 		ETag: eTag,
 	}
 
-	if err := json.Unmarshal(b, &resp); err != nil{
+	if err := json.Unmarshal(b, &resp); err != nil {
 		return nil, dperrors.New(
 			errors.Wrap(err, "failed to unmarshal response"),
 			res.StatusCode,
@@ -706,7 +706,7 @@ func (c *Client) SubmitFilter(ctx context.Context, userAuthToken, serviceAuthTok
 		return nil, "", errors.Wrap(err, "failed to read the response body")
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusAccepted {
 		return nil, "", dperrors.New(
 			errors.Errorf("error(s) returned by %s", uri),
 			resp.StatusCode,

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -1096,23 +1096,28 @@ func Test_SubmitFilter(t *testing.T) {
 	}
 
 	var successfulResponse = SubmitFilterResponse{
-		InstanceID:       "instance-id",
-		DimensionListUrl: "http://some.url/filter/filder-id/dimensions",
-		FilterID:         "filter-id",
-		Events:           nil,
+		InstanceID:     "instance-id",
+		FilterOutputID: "filter-output-id",
 		Dataset: Dataset{
 			DatasetID: "dataset-id",
 			Edition:   "2022",
 			Version:   1,
 		},
-		Links: Links{
+		Links: FilterLinks{
 			Version: Link{
 				HRef: "http://some.url",
 				ID:   "version-id",
 			},
+			Self: Link{
+				ID:   "http://some.url",
+				HRef: "self-id",
+			},
+			Dimensions: Link{
+				ID:   "http://some.url",
+				HRef: "dimensions",
+			},
 		},
 		PopulationType: "population-type",
-		Dimensions:     nil,
 	}
 
 	var newExpectedResponse = func(body interface{}, sc int, eTag string) *http.Response {

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -1129,7 +1129,7 @@ func Test_SubmitFilter(t *testing.T) {
 
 	Convey("Given a valid Submit Filter Request ", t, func() {
 		Convey("when 'SubmitFilter' is called with the expected ifMatch value", func() {
-			httpClient := newMockHTTPClient(newExpectedResponse(successfulResponse, http.StatusOK, newETag), nil)
+			httpClient := newMockHTTPClient(newExpectedResponse(successfulResponse, http.StatusAccepted, newETag), nil)
 			filterClient := newFilterClient(httpClient)
 			res, ETag, err := filterClient.SubmitFilter(ctx, testAuthTokenHeader, testServiceAuthTokenHeader, testDownloadServiceToken, ifMatch, req)
 


### PR DESCRIPTION
### What

The **dp-cantabular-filter-flex-api** `/filter/{id}/submit` [endpoint](https://github.com/ONSdigital/dp-cantabular-filter-flex-api/blob/develop/api/filters.go#L221) is returning a `202 Accepted` HTTP response code.

### How to review

Ensure tests run and check the **dp-cantabular-filter-flex-api** project.

### Who can review

Any developer
