### PR TITLE
feat: is_based_on parameter added to GET list_datasets

### DIFF
--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -103,9 +103,10 @@ type Client struct {
 
 // QueryParams represents the possible query parameters that a caller can provide
 type QueryParams struct {
-	Offset int
-	Limit  int
-	IDs    []string
+	Offset    int
+	Limit     int
+	IsBasedOn string
+	IDs       []string
 }
 
 // Validate validates tht no negative values are provided for limit or offset, and that the length of IDs is lower than the maximum
@@ -274,6 +275,10 @@ func (c *Client) GetDatasets(ctx context.Context, userAuthToken, serviceAuthToke
 			return List{}, err
 		}
 		uri = fmt.Sprintf("%s?offset=%d&limit=%d", uri, q.Offset, q.Limit)
+
+		if q.IsBasedOn != "" {
+			uri += fmt.Sprintf(`?is_based_on="%s"`, q.IsBasedOn)
+		}
 	}
 
 	clientlog.Do(ctx, "retrieving datasets", service, uri)

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -416,6 +416,17 @@ func TestClient_GetDatasets(t *testing.T) {
 			})
 		})
 
+		Convey("when GetDatasets is called with valid values for is_based_on", func() {
+			isBasedOn := "test"
+			q := QueryParams{IsBasedOn: isBasedOn, Offset: offset, Limit: limit, IDs: []string{}}
+			datasetClient.GetDatasets(ctx, userAuthToken, serviceAuthToken, collectionID, &q)
+
+			Convey("and dphttpclient.Do is called 1 time with the expected URI", func() {
+				expectedURI := fmt.Sprintf(`/datasets?offset=%d&limit=%d?is_based_on="%s"`, offset, limit, isBasedOn)
+				checkRequestBase(httpClient, http.MethodGet, expectedURI, "")
+			})
+		})
+
 		Convey("when GetDatasets is called with negative offset", func() {
 			q := QueryParams{Offset: -1, Limit: limit, IDs: []string{}}
 			options, err := datasetClient.GetDatasets(ctx, userAuthToken, serviceAuthToken, collectionID, &q)


### PR DESCRIPTION
Work in reference to https://trello.com/c/o7gox9jw/5701-add-check-to-area-types-endpoint-to-ensure-population-type-is-published-for-public-users 
as now the client must be updated to use the new parameter in the `dp-population-types-api`

### What

The is_based_on parameter is now part of the dataset-api
Added parameter to dataset function

### How to review

run unit tests 

### Who can review

Anyone from Team-b
