### PR TITLE
remove filter v2 dependency on filter v1; make go version consistent

### DIFF
--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.15.7
+    tag: 1.18.3
 
 inputs:
   - name: dp-api-clients-go

--- a/filter/data.go
+++ b/filter/data.go
@@ -2,8 +2,6 @@ package filter
 
 import (
 	"time"
-
-	"github.com/ONSdigital/dp-api-clients-go/filter"
 )
 
 const (
@@ -143,9 +141,9 @@ type Preview struct {
 }
 
 type SubmitFilterRequest struct {
-	FilterID       string                    `json:"filter_id"`
-	Dimensions     []filter.DimensionOptions `json:"dimension_options,omitempty"`
-	PopulationType string                    `json:"population_type"`
+	FilterID       string             `json:"filter_id"`
+	Dimensions     []DimensionOptions `json:"dimension_options,omitempty"`
+	PopulationType string             `json:"population_type"`
 }
 
 type SubmitFilterResponse struct {

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ONSdigital/dp-api-clients-go/filter"
 	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
 	"github.com/pkg/errors"
 
@@ -1082,8 +1081,8 @@ func Test_SubmitFilter(t *testing.T) {
 
 	var req = SubmitFilterRequest{
 		FilterID: "ea1e031b-3064-427d-8fed-4b35c99bf1a3",
-		Dimensions: []filter.DimensionOptions{{
-			Items: []filter.DimensionOption{{
+		Dimensions: []DimensionOptions{{
+			Items: []DimensionOption{{
 				DimensionOptionsURL: "http://some.url/city",
 				Option:              "City",
 			}},

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/ONSdigital/dp-api-clients-go/v2
 go 1.18
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.43.0
 	github.com/ONSdigital/dp-healthcheck v1.2.3
 	github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9
 	github.com/ONSdigital/dp-net v1.2.0
@@ -17,6 +16,7 @@ require (
 )
 
 require (
+	github.com/ONSdigital/dp-api-clients-go v1.43.0 // indirect
 	github.com/ONSdigital/log.go v1.1.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20220104163920-15ed2e8cf2bd // indirect


### PR DESCRIPTION
### What

the whole v2 lib was importing v1 of itself for the `filter` client
when it seemingly need not do so
so, tidied that up

### How to review

does it still work

### Who can review

!me

