### PR TITLE
5728 Pass through the Filter options to the GraphQL query

### DIFF
--- a/cantabular/contract.go
+++ b/cantabular/contract.go
@@ -39,6 +39,7 @@ type GetCodebookResponse struct {
 type StaticDatasetQueryRequest struct {
 	Dataset   string   `json:"dataset"`
 	Variables []string `json:"variables"`
+	Filters   []Filter `json:"filters"`
 }
 
 // StaticDatasetQuery holds the query for a static dataset landing page from

--- a/cantabular/static_dataset.go
+++ b/cantabular/static_dataset.go
@@ -7,10 +7,11 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/shurcooL/graphql"
+
 	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
 	"github.com/ONSdigital/dp-api-clients-go/v2/stream"
 	"github.com/ONSdigital/log.go/v2/log"
-	"github.com/shurcooL/graphql"
 )
 
 // Consumer is a stream func to read from a reader
@@ -94,6 +95,7 @@ func (c *Client) StaticDatasetQueryStreamCSV(ctx context.Context, req StaticData
 	data := QueryData{
 		Dataset:   req.Dataset,
 		Variables: req.Variables,
+		Filters:   req.Filters,
 	}
 
 	res, err := c.postQuery(ctx, QueryStaticDataset, data)

--- a/cantabular/static_dataset_test.go
+++ b/cantabular/static_dataset_test.go
@@ -9,13 +9,14 @@ import (
 	"net/http"
 	"testing"
 
+	. "github.com/smartystreets/goconvey/convey"
+
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular/gql"
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular/mock"
 	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
 	dphttp "github.com/ONSdigital/dp-net/http"
 	"github.com/ONSdigital/log.go/v2/log"
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 var testCtx = context.Background()
@@ -55,6 +56,7 @@ func TestStream(t *testing.T) {
 				req := cantabular.StaticDatasetQueryRequest{
 					Dataset:   "Example",
 					Variables: []string{"city", "siblings"},
+					Filters:   []cantabular.Filter{{Variable: "city", Codes: []string{"0", "1"}}},
 				}
 				rowCount, err := cantabularClient.StaticDatasetQueryStreamCSV(testCtx, req, consume)
 				So(err, ShouldBeNil)
@@ -69,6 +71,7 @@ func TestStream(t *testing.T) {
 				req := cantabular.StaticDatasetQueryRequest{
 					Dataset:   "Example",
 					Variables: []string{"city", "siblings"},
+					Filters:   []cantabular.Filter{{Variable: "city", Codes: []string{"0", "1"}}},
 				}
 				_, err := cantabularClient.StaticDatasetQueryStreamCSV(testCtxWithCancel, req, consume)
 				So(err, ShouldResemble,


### PR DESCRIPTION
### What

Pass through the Filter options to the GraphQL query, that is useful for the CSV exporter service.
Resolves: [5728](https://trello.com/c/BMgVL3wg/5728-pass-through-options-from-filter-collection-to-the-call-to-querystaticdataset-in-dp-cantabular-csv-exporter) 

### How to review

Sense check it, review the Trello story and ensure the tests pass

### Who can review

Any ONS developer