### PR TITLE
search client model to handle es710 response

### DIFF
--- a/site-search/data.go
+++ b/site-search/data.go
@@ -2,6 +2,7 @@ package search
 
 // Response represents the fields for the search results as returned by dp-search-api
 type Response struct {
+	ES_710                bool          `json:"es_710"`
 	Count                 int           `json:"count"`
 	ContentTypes          []FilterCount `json:"content_types"`
 	Items                 []ContentItem `json:"items"`
@@ -18,14 +19,15 @@ type FilterCount struct {
 
 // ContentItem represents each search result
 type ContentItem struct {
-	Description Description `json:"description"`
-	Type        string      `json:"type"`
-	URI         string      `json:"uri"`
-	Matches     *Matches    `json:"matches,omitempty"`
+	Description
+	LegacyDescription LegacyDescription `json:"description"`
+	Type              string            `json:"type"`
+	URI               string            `json:"uri"`
+	Matches           *Matches          `json:"matches,omitempty"`
 }
 
-// Description represents each search result description
-type Description struct {
+// LegacyDescription represents each search result description which is given from data in ES 2.2
+type LegacyDescription struct {
 	CanonicalTopic    string    `json:"canonical_topic,omitempty"`
 	Contact           *Contact  `json:"contact,omitempty"`
 	DatasetID         string    `json:"dataset_id,omitempty"`
@@ -47,6 +49,26 @@ type Description struct {
 	Topics            []string  `json:"topics,omitempty"`
 	Unit              string    `json:"unit,omitempty"`
 	Highlight         Highlight `json:"highlight,omitempty"`
+}
+
+// Description represents each search result which is given from data in ES 7.10
+type Description struct {
+	CDID            string              `json:"cdid"`
+	DatasetID       string              `json:"dataset_id"`
+	Keywords        []string            `json:"keywords"`
+	MetaDescription string              `json:"meta_description"`
+	ReleaseDate     string              `json:"release_date,omitempty"`
+	Summary         string              `json:"summary"`
+	Title           string              `json:"title"`
+	Topics          []string            `json:"topics"`
+	Highlight       *Highlight          `json:"highlight,omitempty"`
+	DateChanges     []ReleaseDateChange `json:"date_changes,omitempty"`
+	Cancelled       bool                `json:"cancelled,omitempty"`
+	Finalised       bool                `json:"finalised,omitempty"`
+	ProvisionalDate string              `json:"provisional_date,omitempty"`
+	Published       bool                `json:"published,omitempty"`
+	Language        string              `json:"language,omitempty"`
+	Survey          string              `json:"survey,omitempty"`
 }
 
 // Highlight contains specific metadata with search keyword(s) highlighted


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- The search item data returned from dp-search-api when using ES 2.2 and ES 7.10 is different
- The client data model has been updated to handle both versions
- The `ES_710` bool helps the controller to identify what type of data is coming to then map the data accordingly for rendering

### How to review
**Describe the steps required to test the changes.**
- Check if the changes make sense

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone