### PR TITLE
5732 - Add delete dimension options function

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/pkg/errors"
+
 	"github.com/ONSdigital/dp-api-clients-go/v2/batch"
 	"github.com/ONSdigital/dp-api-clients-go/v2/clientlog"
 	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
@@ -18,7 +20,6 @@ import (
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dprequest "github.com/ONSdigital/dp-net/request"
 	"github.com/ONSdigital/log.go/v2/log"
-	"github.com/pkg/errors"
 )
 
 const service = "filter-api"
@@ -476,6 +477,42 @@ func (c *Client) GetDimensionOptionsBatchProcess(ctx context.Context, userAuthTo
 	}
 
 	return eTag, batch.ProcessInConcurrentBatches(batchGetter, batchProcessor, batchSize, maxWorkers)
+}
+
+// DeleteDimensionOptions completely removes the options array from a given dimension
+func (c *Client) DeleteDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string) (string, error) {
+	logData := log.Data{
+		"filter_id":      filterID,
+		"dimension_name": name,
+	}
+
+	uri := fmt.Sprintf("%s/filters/%s/dimensions/%s/options", c.hcCli.URL, filterID, name)
+	clientlog.Do(ctx, "deleting selected dimension options", service, uri)
+
+	res, err := c.doDeleteWithAuthHeadersAndWithDownloadToken(ctx, userAuthToken, serviceAuthToken, collectionID, uri)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to delete dimension options")
+	}
+
+	defer closeResponseBody(ctx, res)
+
+	if res.StatusCode != http.StatusNoContent {
+		return "", dperrors.New(
+			errors.Wrap(&ErrInvalidFilterAPIResponse{http.StatusNoContent, res.StatusCode, uri}, "unexpected response"),
+			res.StatusCode,
+			logData,
+		)
+	}
+
+	eTag, err := headers.GetResponseETag(res)
+	if err != nil && err != headers.ErrHeaderNotFound {
+		dperrors.New(
+			errors.Wrap(err, "no ETag header found"),
+			res.StatusCode,
+			logData,
+		)
+	}
+	return eTag, err
 }
 
 // CreateFlexibleBlueprint creates a flexible filter blueprint and returns the associated filterID and eTag
@@ -1397,6 +1434,26 @@ func (c *Client) doGetWithAuthHeadersAndWithDownloadToken(ctx context.Context, u
 	}
 	if err = headers.SetDownloadServiceToken(req, downloadServiceAuthToken); err != nil {
 		return nil, fmt.Errorf("failed to set download service token: %w", err)
+	}
+	return c.hcCli.Client.Do(ctx, req)
+
+} // doDeleteWithAuthHeadersAndWithDownloadToken executes clienter.Do setting the user and service authentication and download token as a request header.
+// Returns the http.Response and any error.
+// It is the caller's responsibility to ensure response.Body is closed on completion.
+func (c *Client) doDeleteWithAuthHeadersAndWithDownloadToken(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, uri string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodDelete, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = headers.SetCollectionID(req, collectionID); err != nil {
+		return nil, fmt.Errorf("failed to set collection id: %w", err)
+	}
+	if err = headers.SetAuthToken(req, userAuthToken); err != nil {
+		return nil, fmt.Errorf("failed to set auth token: %w", err)
+	}
+	if err = headers.SetServiceAuthToken(req, serviceAuthToken); err != nil {
+		return nil, fmt.Errorf("failed to set service auth token: %w", err)
 	}
 	return c.hcCli.Client.Do(ctx, req)
 }

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -13,10 +13,11 @@ import (
 	"testing"
 	"time"
 
-	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
 	"github.com/pkg/errors"
 
 	. "github.com/smartystreets/goconvey/convey"
+
+	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/health"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
@@ -859,6 +860,122 @@ func TestClient_GetDimensionOptionsInBatches(t *testing.T) {
 			})
 		})
 	})
+}
+
+func TestClient_DeleteDimensionOptions(t *testing.T) {
+
+	filterID := "foo"
+	name := "corge"
+
+	Convey("Given a Filter ID and Dimension name exist", t, func() {
+		newETag := "84798def3a75c8783b09e946d2fbf85e8a1dcce5"
+
+		r := &http.Response{
+			StatusCode: http.StatusNoContent,
+			Header:     http.Header{},
+		}
+		httpClient := newMockHTTPClient(r, nil)
+		httpClient.DoFunc = func(ctx context.Context, req *http.Request) (*http.Response, error) {
+			r.Header.Set("ETag", newETag)
+			return r, nil
+		}
+		filterClient := newFilterClient(httpClient)
+
+		Convey("When DeleteDimensionOptions is called", func() {
+			eTag, err := filterClient.DeleteDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterID, name)
+
+			Convey("Then the new eTag is returned without error", func() {
+				So(err, ShouldBeNil)
+				So(eTag, ShouldResemble, newETag)
+			})
+		})
+	})
+
+	Convey("Given a Filter ID exists but the Dimension name is incorrect", t, func() {
+		r := &http.Response{
+			StatusCode: http.StatusNotFound,
+			Header:     http.Header{},
+		}
+		httpClient := newMockHTTPClient(r, nil)
+		httpClient.DoFunc = func(ctx context.Context, req *http.Request) (*http.Response, error) {
+			r.Header.Set("ETag", "")
+			return r, nil
+		}
+		filterClient := newFilterClient(httpClient)
+
+		Convey("When DeleteDimensionOptions is called", func() {
+			eTag, err := filterClient.DeleteDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterID, name)
+
+			Convey("Then an error is returned with no ETag", func() {
+				expectedErr := errors.Wrap(&ErrInvalidFilterAPIResponse{http.StatusNoContent, http.StatusNotFound, "http://localhost:8080/filters/foo/dimensions/corge/options"}, "unexpected response")
+				So(err.Error(), ShouldResemble, expectedErr.Error())
+				So(eTag, ShouldResemble, "")
+			})
+		})
+	})
+
+	Convey("Given a Filter ID is incorrect", t, func() {
+		r := &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Header:     http.Header{},
+		}
+		httpClient := newMockHTTPClient(r, nil)
+		httpClient.DoFunc = func(ctx context.Context, req *http.Request) (*http.Response, error) {
+			r.Header.Set("ETag", "")
+			return r, nil
+		}
+		filterClient := newFilterClient(httpClient)
+
+		Convey("When DeleteDimensionOptions is called", func() {
+			eTag, err := filterClient.DeleteDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterID, name)
+
+			Convey("Then an error is returned with no ETag", func() {
+				expectedErr := errors.Wrap(&ErrInvalidFilterAPIResponse{http.StatusNoContent, http.StatusBadRequest, "http://localhost:8080/filters/foo/dimensions/corge/options"}, "unexpected response")
+				So(err.Error(), ShouldResemble, expectedErr.Error())
+				So(eTag, ShouldResemble, "")
+			})
+		})
+	})
+
+	Convey("Given the filter-api returns a resource conflict", t, func() {
+		r := &http.Response{
+			StatusCode: http.StatusConflict,
+			Header:     http.Header{},
+		}
+		httpClient := newMockHTTPClient(r, nil)
+		httpClient.DoFunc = func(ctx context.Context, req *http.Request) (*http.Response, error) {
+			r.Header.Set("ETag", "")
+			return r, nil
+		}
+		filterClient := newFilterClient(httpClient)
+
+		Convey("When DeleteDimensionOptions is called", func() {
+			eTag, err := filterClient.DeleteDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterID, name)
+
+			Convey("Then an error is returned with no ETag", func() {
+				expectedErr := errors.Wrap(&ErrInvalidFilterAPIResponse{http.StatusNoContent, http.StatusConflict, "http://localhost:8080/filters/foo/dimensions/corge/options"}, "unexpected response")
+				So(err.Error(), ShouldResemble, expectedErr.Error())
+				So(eTag, ShouldResemble, "")
+			})
+		})
+	})
+
+	Convey("Given dphttpclient.do returns an error", t, func() {
+		mockErr := errors.New("dphttpclient.do is not available")
+		expectedError := errors.Wrap(mockErr, "failed to delete dimension options")
+
+		httpClient := newMockHTTPClient(nil, mockErr)
+		filterClient := newFilterClient(httpClient)
+
+		Convey("when DeleteDimensionOptions is called", func() {
+			_, err := filterClient.DeleteDimensionOptions(ctx, testUserAuthToken, testServiceToken, testCollectionID, filterID, name)
+
+			Convey("then the expected error is returned", func() {
+				So(err.Error(), ShouldResemble, expectedError.Error())
+			})
+		})
+	})
+
 }
 
 func TestClient_CreateFlexBlueprint(t *testing.T) {


### PR DESCRIPTION
### What

`DeleteDimensionOptions` completely removes the options array from a
given dimension and filterID

Resolves: [5732 - dp-api-clients-go function for DELETE filters/{filterid}/dimensions/{dimension}/options](https://trello.com/c/XBSVWDXW/5732-dp-api-clients-go-function-for-delete-filter-filterid-dimension-dimension-options)

### How to review

Sense check it.

### Who can review

Any ONS developer.