### PR TITLE
feat: log graphql query to logData

### DIFF
--- a/cantabular/queries.go
+++ b/cantabular/queries.go
@@ -312,6 +312,7 @@ func (c *Client) postQuery(ctx context.Context, graphQLQuery string, data QueryD
 	}
 
 	b, err := data.Encode(graphQLQuery)
+	logData["query"] = b.String()
 	if err != nil {
 		return nil, dperrors.New(err, http.StatusInternalServerError, logData)
 	}


### PR DESCRIPTION
trello #5769

Add query logging to logData, so we can see query very quickly
in case of failed requests. When wrong assumptions about queries
are used in tests often queries fail in production, incorrect queries are hard to debug without seeing the actual query.

### What

Add query to logdata. simple change. 

### How to review

see commit

### Who can review

anyone
