### PR TITLE
Refactor handling archive files for interactives

### DIFF
--- a/interactives/data.go
+++ b/interactives/data.go
@@ -2,20 +2,27 @@ package interactives
 
 const (
 	UpdateFormFieldKey = "interactive"
-	PatchArchive       = "Archive"
+
+	PatchArchive     PatchAttribute = "Archive"
+	Publish          PatchAttribute = "Publish"
+	LinkToCollection PatchAttribute = "LinkToCollection"
+	PatchArchiveFile PatchAttribute = "ArchiveFile"
 )
 
+type PatchAttribute string
+
 type PatchRequest struct {
-	Attribute   string      `json:"attribute,omitempty"`
-	Interactive Interactive `json:"interactive,omitempty"`
+	Attribute    PatchAttribute `json:"attribute,omitempty"`
+	Interactive  Interactive    `json:"interactive,omitempty"`
+	ArchiveFiles []*ArchiveFile `json:"archive_files,omitempty"`
 }
 
-type InteractiveFilter struct {
-	AssociateCollection bool                 `json:"associate_collection,omitempty"`
-	Metadata            *InteractiveMetadata `json:"metadata,omitempty"`
+type Filter struct {
+	AssociateCollection bool      `json:"associate_collection,omitempty"`
+	Metadata            *Metadata `json:"metadata,omitempty"`
 }
 
-type InteractiveMetadata struct {
+type Metadata struct {
 	Title             string `json:"title,omitempty"`
 	Label             string `json:"label,omitempty"`
 	InternalID        string `json:"internal_id,omitempty"`
@@ -25,23 +32,29 @@ type InteractiveMetadata struct {
 }
 
 type Interactive struct {
-	ID        string               `json:"id,omitempty"`
-	Published *bool                `json:"published,omitempty"`
-	Metadata  *InteractiveMetadata `json:"metadata,omitempty"`
-	Archive   *InteractiveArchive  `json:"archive,omitempty"`
+	ID        string      `json:"id,omitempty"`
+	Published *bool       `json:"published,omitempty"`
+	Metadata  *Metadata   `json:"metadata,omitempty"`
+	Archive   *Archive    `json:"archive,omitempty"`
+	HTMLFiles []*HTMLFile `json:"html_files,omitempty"`
 }
 
-type InteractiveArchive struct {
-	Name             string             `json:"name,omitempty"`
-	Size             int64              `json:"size_in_bytes,omitempty"`
-	Files            []*InteractiveFile `json:"files,omitempty"`
-	ImportMessage    string             `json:"import_message,omitempty"`
-	ImportSuccessful bool               `json:"import_successful,omitempty"`
+type Archive struct {
+	Name                string `json:"name,omitempty"`
+	Size                int64  `json:"size_in_bytes,omitempty"`
+	UploadRootDirectory string `json:"upload_root_directory,omitempty"`
+	ImportMessage       string `json:"import_message,omitempty"`
+	ImportSuccessful    bool   `json:"import_successful,omitempty"`
 }
 
-type InteractiveFile struct {
+type ArchiveFile struct {
 	Name     string `json:"name,omitempty"`
 	Mimetype string `json:"mimetype,omitempty"`
 	Size     int64  `json:"size_in_bytes,omitempty"`
 	URI      string `json:"uri,omitempty"`
+}
+
+type HTMLFile struct {
+	Name string `json:"name,omitempty"`
+	URI  string `json:"uri,omitempty"`
 }

--- a/interactives/interactives.go
+++ b/interactives/interactives.go
@@ -126,7 +126,7 @@ func (c *Client) GetInteractive(ctx context.Context, userAuthToken, serviceAuthT
 }
 
 // ListInteractives returns the list of interactives
-func (c *Client) ListInteractives(ctx context.Context, userAuthToken, serviceAuthToken string, filter *InteractiveFilter) (m []Interactive, err error) {
+func (c *Client) ListInteractives(ctx context.Context, userAuthToken, serviceAuthToken string, filter *Filter) (m []Interactive, err error) {
 	uri := fmt.Sprintf("%s/%s/%s", c.hcCli.URL, c.version, rootPath)
 	var qVals url.Values
 	if filter != nil {

--- a/interactives/interactives_test.go
+++ b/interactives/interactives_test.go
@@ -52,7 +52,7 @@ func TestClient_GetInteractives(t *testing.T) {
 		interactivesClient := newInteractivesClient(httpClient)
 
 		Convey("when GetInteractives is called with valid values for limit, offset and filter", func() {
-			q := &InteractiveFilter{Metadata: &InteractiveMetadata{ResourceID: "resid123"}}
+			q := &Filter{Metadata: &Metadata{ResourceID: "resid123"}}
 			i, err := interactivesClient.ListInteractives(ctx, userAuthToken, serviceAuthToken, q)
 
 			Convey("a positive response is returned, with the expected interactives", func() {


### PR DESCRIPTION
### What

- main motivation was to refactor the InteractiveArchive.ArchiveFiles attribute - this is nonsense with a huge zip file of 000s k files
- added `UploadRootDirectory` - this will be used to render the file via dp-frontend-interactives-controller
- some housekeeping - renamed dropping `Interactives` as already namespaced by package

Tested locally - when merged I can create other PRs with this version bumped

### How to review

Sanity check

### Who can review

Anyone
