### PR TITLE
#5778 - remove FilterOnly field

### DIFF
--- a/cantabular/dimensions_test.go
+++ b/cantabular/dimensions_test.go
@@ -716,7 +716,6 @@ var mockRespBodyGetDimensions = `
 									"edges": [
 										{
 											"node": {
-												"filterOnly": "false",
 												"label": "Region",
 												"name": "Region"
 											}
@@ -796,9 +795,8 @@ var expectedDimensions = cantabular.GetDimensionsResponse{
 								Edges: []gql.Edge{
 									{
 										Node: gql.Node{
-											FilterOnly: "false",
-											Label:      "Region",
-											Name:       "Region",
+											Label: "Region",
+											Name:  "Region",
 										},
 									},
 								},
@@ -863,7 +861,6 @@ var mockRespBodyGetGeographyDimensions = `
 										"edges": [
 											{
 												"node": {
-													"filterOnly": "false",
 													"label": "Region",
 													"name": "Region"
 												}
@@ -913,13 +910,11 @@ var expectedGeographyDimensions = cantabular.GetGeographyDimensionsResponse{
 												Label:      "Region",
 												Categories: gql.Categories{TotalCount: 0},
 												MapFrom:    []gql.Variables(nil),
-												FilterOnly: "false",
 											},
 										},
 									},
 								},
 							},
-							FilterOnly: "",
 						},
 					},
 					{
@@ -928,7 +923,6 @@ var expectedGeographyDimensions = cantabular.GetGeographyDimensionsResponse{
 							Label:      "Region",
 							Categories: gql.Categories{TotalCount: 10},
 							MapFrom:    []gql.Variables{},
-							FilterOnly: "",
 						},
 					},
 				},

--- a/cantabular/gql/data.go
+++ b/cantabular/gql/data.go
@@ -31,7 +31,6 @@ type Node struct {
 	Label            string      `json:"label"`
 	Categories       Categories  `json:"categories"`
 	MapFrom          []Variables `json:"mapFrom"`
-	FilterOnly       string      `json:"filterOnly,omitempty"`
 	Variable         Variable    `json:"variable"`
 	IsDirectSourceOf Variables   `json:"isDirectSourceOf"`
 	IsSourceOf       Variables   `json:"isSourceOf"`

--- a/cantabular/queries.go
+++ b/cantabular/queries.go
@@ -58,7 +58,6 @@ query($dataset: String!) {
 					mapFrom {
 						edges {
 							node {
-								filterOnly
 								label
 								name
 							}
@@ -85,7 +84,6 @@ query($dataset: String!, $variables: [String!]!) {
 					mapFrom {
 						edges {
 							node {
-								filterOnly
 								label
 								name
 							}
@@ -115,7 +113,6 @@ query($dataset: String!, $limit: Int!, $offset: Int) {
 						mapFrom {
 							edges {
 								node {
-									filterOnly
 									label
 									name
 								}


### PR DESCRIPTION
### What

In Cantabular version 10.1 the FilterOnly field has been changed to be a boolean value from a string type so is causing issues when running imports locally.

We do not need to use this in our queries so it can be removed completely

Trello - https://trello.com/c/YkgpIV1l/5778-remove-filteronly-from-cantabular-queries

### How to review

Confirm changes match Trello ticket request

### Who can review

Anyone
