### PR TITLE
remove base and rule from query data

### DIFF
--- a/cantabular/queries.go
+++ b/cantabular/queries.go
@@ -213,8 +213,6 @@ type QueryData struct {
 	Variables []string
 	Filters   []Filter
 	Category  string
-	Rule      bool
-	Base      bool
 }
 
 // Filter holds the fields for the Cantabular GraphQL 'Filter' object used for specifying categories
@@ -240,8 +238,6 @@ func (data *QueryData) Encode(query string) (bytes.Buffer, error) {
 		"limit":     data.Limit,
 		"offset":    data.Offset,
 		"category":  data.Category,
-		"rule":      data.Rule,
-		"base":      data.Base,
 	}
 	if len(data.Filters) > 0 {
 		vars["filters"] = data.Filters


### PR DESCRIPTION
### What

Removed 'rule' and 'base' from QueryData as they're not used and will force asserting to false in case of omission, which isn't the intended behaviour

### How to review

Check change makes sense

### Who can review

Anyone