### PR TITLE
5785 - Do not request 'values' when querying Dimension Options

### DIFF
--- a/cantabular/queries.go
+++ b/cantabular/queries.go
@@ -41,7 +41,6 @@ query($dataset: String!, $variables: [String!]!, $filters: [Filter!]) {
 				variable { name label }
 				categories { code label }
 			}
-			values
 			error
 		}
 	}


### PR DESCRIPTION
### What

When we send a query to `dp-cantabular-api-ext` to retrieve a list of
categories for a variable, we are also requesting the values
(i.e. the observation numbers) which is not needed here.

It was triggering the SDC rules applied on the population-type.

Subsequent PRs will have to be raised.

Resolves: [5785](https://trello.com/c/BgynyRgB/5785-update-cantabular-query-that-retrieves-dimension-options)

### How to review

Sense check it and ensure tests are :green_circle: 

### Who can review
Any ONS developer