### PR TITLE
Add json unmarshaller for the Metadata struct

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -2,6 +2,7 @@ package dataset
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"unicode"
 )
@@ -194,6 +195,34 @@ type Metadata struct {
 	Version
 	DatasetDetails
 	DatasetLinks Links `json:"dataset_links,omitempty"`
+}
+
+// UnmarshalJSON is used to disambiguate the 'links' attribute of the incoming Metadata struct. As currently structured
+// both the embedded Version and DatasetDetails objects have a 'links' attribute, and the default json marshaller will
+// not populate either field as it doesn't know which to populate.
+// In order not to introduce a breaking change to the api, the bespoke Unmarshaller below will do the disambiguation
+func (m *Metadata) UnmarshalJSON(js []byte) error {
+	e := json.Unmarshal(js, &m.Version)
+	if e != nil {
+		return e
+	}
+
+	e = json.Unmarshal(js, &m.DatasetDetails)
+	if e != nil {
+		return e
+	}
+	m.DatasetDetails.Links = Links{}
+
+	var dl struct {
+		Links `json:"dataset_links,omitempty"`
+	}
+	e = json.Unmarshal(js, &dl)
+	if e != nil {
+		return e
+	}
+	m.DatasetLinks = dl.Links
+
+	return nil
 }
 
 // DownloadList represents a list of objects of containing information on the downloadable files

--- a/dataset/metadata_test.go
+++ b/dataset/metadata_test.go
@@ -1,0 +1,127 @@
+package dataset
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMetadata(t *testing.T) {
+	Convey("Given a json encoded Metadata struct as returned from the dp-dataset-api", t, func() {
+		mj, ex := setDatasetAPIMetadata()
+
+		Convey("When the json is unmarshalled into a dp-clients-so Metadata struct", func() {
+			var mu Metadata
+			err := json.Unmarshal(mj, &mu)
+			So(err, ShouldBeNil)
+
+			Convey("the dp-clients-go Metadata's Version Links is populated with the dp-dataset-api Metadata's Links section (and dp-clients-go Metadata's DatasetDetails Links is not populated)", func() {
+				So(mu, ShouldResemble, ex)
+			})
+		})
+	})
+}
+
+func setDatasetAPIMetadata() (json.RawMessage, Metadata) {
+	incoming := []byte(`
+{
+  "contacts":[
+    {
+      "email":"bob@test.com",
+      "name":"Bob",
+      "telephone":"01657923723"
+    }
+  ],
+  "description":"description",
+  "keywords":[
+    "keyword_1",
+    "keyword_2"
+  ],
+  "latest_changes":[
+    {
+      "description":"change description",
+      "name":"change name",
+      "type":"change type"
+    }
+  ],
+  "links":{
+    "self":{
+      "href":"/dataset/metadata"
+    },
+    "version":{
+      "href":"/dataset/D1/editions/E1/versions/V1",
+      "id":"V1"
+    },
+    "website_version":{
+      "href":"/website-version"
+    }
+  },
+  "national_statistic":true,
+  "release_date":"release date",
+  "title":"title",
+  "headers":[
+    "csv header 1",
+    "csv header 2"
+  ],
+  "dataset_links":{
+    "latest_version":{
+      "href":"/dataset/D1/editions/E1/versions/V1",
+      "id":"V1"
+    },
+    "self":{
+      "href":"/dataset/UUID",
+      "id":"UUID"
+    }
+  }
+}
+`)
+
+	expected := Metadata{
+		Version: Version{
+			ReleaseDate: "release date",
+			CSVHeader:   []string{"csv header 1", "csv header 2"},
+			LatestChanges: []Change{
+				{
+					Description: "change description",
+					Name:        "change name",
+					Type:        "change type",
+				},
+			},
+			Links: Links{
+				Self: Link{
+					URL: "/dataset/metadata",
+				},
+				Version: Link{
+					URL: "/dataset/D1/editions/E1/versions/V1",
+					ID:  "V1",
+				},
+			},
+		},
+		DatasetDetails: DatasetDetails{
+			Title:             "title",
+			Description:       "description",
+			Keywords:          &[]string{"keyword_1", "keyword_2"},
+			NationalStatistic: true,
+			Contacts: &[]Contact{
+				{
+					Name:      "Bob",
+					Email:     "bob@test.com",
+					Telephone: "01657923723",
+				},
+			},
+		},
+		DatasetLinks: Links{
+			Self: Link{
+				URL: "/dataset/UUID",
+				ID:  "UUID",
+			},
+			LatestVersion: Link{
+				URL: "/dataset/D1/editions/E1/versions/V1",
+				ID:  "V1",
+			},
+		},
+	}
+
+	return incoming, expected
+}


### PR DESCRIPTION
### What

As currently structured the Metadata struct has both an embedded Version and DatasetDetails object. Each of these has a Links ('json: links') attribute, and the default json marshaller fails to populate either field. In order not to introduce a breaking change to the api, a bespoke json Unmarshaller is used to do the disambiguation

### How to review

Review code and ensure all tests are passing

### Who can review

Anyone
