### PR TITLE
Add GetAggregatedDimensionOptions func

### DIFF
--- a/cantabular/contract.go
+++ b/cantabular/contract.go
@@ -115,6 +115,19 @@ type GetDimensionOptionsResponse struct {
 	Dataset StaticDatasetDimensionOptions `json:"dataset"`
 }
 
+// GetAggregatedDimensionOptionsRequest holds the required inputs for the
+// GetAggregatedDimensionOptions query
+type GetAggregatedDimensionOptionsRequest struct {
+	Dataset        string
+	DimensionNames []string
+}
+
+// GetAggregatedDimensionOptionsResponse holds the response body for
+// the GetAggregatedDimensionOptions query
+type GetAggregatedDimensionOptionsResponse struct {
+	Dataset gql.Dataset `json:"dataset"`
+}
+
 // GetAreasRequest holds the request variables required for the
 // POST [cantabular-ext]/graphql QueryAreas query.
 type GetAreasRequest struct {

--- a/cantabular/dimensions.go
+++ b/cantabular/dimensions.go
@@ -196,6 +196,34 @@ func (c *Client) GetDimensionOptions(ctx context.Context, req GetDimensionOption
 	return &resp.Data, nil
 }
 
+// GetAggregatedDimensionOptions performs an alternative graphQL query to obtain the requested dimension options,
+// specifically for aggregated population type static datasets
+func (c *Client) GetAggregatedDimensionOptions(ctx context.Context, req GetAggregatedDimensionOptionsRequest) (*GetAggregatedDimensionOptionsResponse, error) {
+	resp := &struct {
+		Data   GetAggregatedDimensionOptionsResponse `json:"data"`
+		Errors []gql.Error                           `json:"errors,omitempty"`
+	}{}
+
+	data := QueryData{
+		Dataset:   req.Dataset,
+		Variables: req.DimensionNames,
+	}
+
+	if err := c.queryUnmarshal(ctx, QueryAggregatedDimensionOptions, data, resp); err != nil {
+		return nil, err
+	}
+
+	if resp != nil && len(resp.Errors) != 0 {
+		return nil, dperrors.New(
+			errors.New("error(s) returned by graphQL query"),
+			resp.Errors[0].StatusCode(),
+			log.Data{"errors": resp.Errors},
+		)
+	}
+
+	return &resp.Data, nil
+}
+
 // GetAreas performs a graphQL query to retrieve the areas (categories) for a given area type. If the category
 // is left empty, then all categories are returned. Results can also be filtered by area by passing a variable name.
 func (c *Client) GetAreas(ctx context.Context, req GetAreasRequest) (*GetAreasResponse, error) {

--- a/cantabular/queries.go
+++ b/cantabular/queries.go
@@ -46,6 +46,30 @@ query($dataset: String!, $variables: [String!]!, $filters: [Filter!]) {
 	}
 }`
 
+// QueryAggregatedDimensionOptions is the graphQL query to obtain static dataset dimension options
+// for aggregated population types
+const QueryAggregatedDimensionOptions = `
+query($dataset: String!, $variables: [String!]!) {
+	dataset(name: $dataset) {
+		variables(names: $variables){
+			edges{
+		  		node{
+					name
+					label
+					categories{
+						edges{
+							node{
+								label
+								code
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}`
+
 // QueryAllDimensions is the graphQL query to obtain all dimensions (variables without categories)
 const QueryAllDimensions = `
 query($dataset: String!) {


### PR DESCRIPTION
### What

Add new GetAggregatedDimensionOptions, an alternative to GetDimensionOptions specifically for importing static datasets for aggregated population types.

### How to review

Check changes make sense

### Who can review

Anyone