### PR TITLE
Remove the 'omitempty' json tag on the NationalStatistic attribute in dataset.DatasetDetails

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -17,7 +17,7 @@ type DatasetDetails struct {
 	License           string            `json:"license,omitempty"`
 	Links             Links             `json:"links,omitempty"`
 	Methodologies     *[]Methodology    `json:"methodologies,omitempty"`
-	NationalStatistic bool              `json:"national_statistic,omitempty"`
+	NationalStatistic bool              `json:"national_statistic"`
 	NextRelease       string            `json:"next_release,omitempty"`
 	NomisReferenceURL string            `json:"nomis_reference_url,omitempty"`
 	Publications      *[]Publication    `json:"publications,omitempty"`


### PR DESCRIPTION
### What

As currently structured there is a mismatch between the dp-clients DatasetDetails and the dp-dataset-api DatasetDetails in that one has the NationalStatistic bool attribute as a straight bool and one has a *bool. Both use the json 'omitempty' tag. This means that a client using the dp-clients DatasetDetails will never send the NationalStatistic field in its JSON rendering when the field has a value of false, and consequently the receiving dp-dataset-api DatasetDetails will always have its value set to nil. In at least one situation (PutDataset()), this means the value of NationalStatistic can never be set to false. Changing the dp-clients DatasetDetails to have a *bool would be a breaking change, so removing the 'omitempty' flag is the solution chosen, as this is not strictly a breaking change.

### How to review

Review code and ensure all tests are passing

### Who can review

Anyone
