### PR TITLE
5849 Create a 'GetArea' function to perform an exact match

### DIFF
--- a/cantabular/contract.go
+++ b/cantabular/contract.go
@@ -137,11 +137,23 @@ type GetAreasRequest struct {
 	Category string
 }
 
+// GetAreaRequest holds the request required for the POST [cantabular-ext]/graphql QueryArea query
+type GetAreaRequest struct {
+	Dataset  string
+	Variable string
+	Category string
+}
+
 // GetAreasResponse holds the response body for
 // POST [cantabular-ext]/graphql
 // with a query to obtain static dataset variables and categories, without values.
 type GetAreasResponse struct {
 	PaginationResponse
+	Dataset gql.Dataset `json:"dataset"`
+}
+
+// GetAreaResponse holds the response body for POST [cantabular-ext]/graphql
+type GetAreaResponse struct {
 	Dataset gql.Dataset `json:"dataset"`
 }
 

--- a/cantabular/dimensions.go
+++ b/cantabular/dimensions.go
@@ -266,6 +266,34 @@ func (c *Client) GetAreas(ctx context.Context, req GetAreasRequest) (*GetAreasRe
 	return &resp.Data, nil
 }
 
+// GetArea performs a graphQL query to retrieve the exact area (category) for a given area type
+func (c *Client) GetArea(ctx context.Context, req GetAreaRequest) (*GetAreaResponse, error) {
+	resp := &struct {
+		Data   GetAreaResponse `json:"data"`
+		Errors []gql.Error     `json:"errors,omitempty"`
+	}{}
+
+	data := QueryData{
+		Dataset:  req.Dataset,
+		Text:     req.Variable,
+		Category: req.Category,
+	}
+
+	if err := c.queryUnmarshal(ctx, QueryArea, data, resp); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal query")
+	}
+
+	if resp != nil && len(resp.Errors) != 0 {
+		return nil, dperrors.New(
+			errors.New("error(s) returned by graphQL query"),
+			resp.Errors[0].StatusCode(),
+			log.Data{"errors": resp.Errors},
+		)
+	}
+
+	return &resp.Data, nil
+}
+
 // GetParents returns a list of variables that map to the provided variable
 func (c *Client) GetParents(ctx context.Context, req GetParentsRequest) (*GetParentsResponse, error) {
 	resp := &struct {

--- a/cantabular/queries.go
+++ b/cantabular/queries.go
@@ -208,7 +208,7 @@ query ($dataset: String!, $text: String!, $category: String!, $limit: Int!, $off
 			name
 			label
 			categories {
-                          totalCount
+			  totalCount
 			  search(text: $category, first: $limit, skip: $offset ) {
 				edges {
 				  node {
@@ -223,6 +223,30 @@ query ($dataset: String!, $text: String!, $category: String!, $limit: Int!, $off
 	  }
 	}
   }
+`
+
+// QueryArea is the graphQL query to search for an area which exactly match a specific string.
+const QueryArea = `
+query ($dataset: String!, $text: String!, $category: String!) {
+  dataset(name: $dataset) {
+    variables(rule: true, names: [ $text ]) {
+      edges {
+        node {
+          name
+          label
+          categories(codes: [ $category ]) {
+            edges {
+              node {
+                code
+                label
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
 `
 
 const QueryParents = `


### PR DESCRIPTION
### What

Previously the endpoint
```
GET /population-types/{dataset}/area-types/{area-type}/areas/{area-id}
```

was performing a fuzzy search and limiting the results to 1.
Since cantabular api extension  v10.2.1 we can now match exactly an area id.

This is the change to perform an exact match.

Resolves: [5849](https://trello.com/c/epE8FvNN/5849-getarea-endpoint-returning-error-results)

### How to review

Sense check it and ensure tests are :green_circle: 

### Who can review

ONS developers
