### PR TITLE
5851 Update client's models to include the PaginationResponse

### DIFF
--- a/population/area_types.go
+++ b/population/area_types.go
@@ -1,5 +1,7 @@
 package population
 
+import "github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
+
 // AreaType is an area type model with ID and Label
 type AreaType struct {
 	ID         string `json:"id"`
@@ -9,5 +11,6 @@ type AreaType struct {
 
 // GetAreaTypesResponse is the response object for GET /area-types
 type GetAreaTypesResponse struct {
+	cantabular.PaginationResponse
 	AreaTypes []AreaType `json:"area_types"`
 }

--- a/population/areas.go
+++ b/population/areas.go
@@ -11,6 +11,7 @@ type Area struct {
 
 // GetAreasResponse is the response object for GET /areas
 type GetAreasResponse struct {
+	cantabular.PaginationResponse
 	Areas []Area `json:"areas"`
 }
 
@@ -28,6 +29,7 @@ type AreaTypes struct {
 
 // GetAreaTypeParentsResponse is the response object for GET /areas
 type GetAreaTypeParentsResponse struct {
+	cantabular.PaginationResponse
 	AreaTypes []AreaTypes `json:"area_types"`
 }
 

--- a/population/client_test.go
+++ b/population/client_test.go
@@ -237,6 +237,14 @@ func TestGetAreas(t *testing.T) {
 
 	Convey("Given a valid areas response payload", t, func() {
 		areas := GetAreasResponse{
+			PaginationResponse: cantabular.PaginationResponse{
+				PaginationParams: cantabular.PaginationParams{
+					Limit:  2,
+					Offset: 0,
+				},
+				Count:      2,
+				TotalCount: 6,
+			},
 			Areas: []Area{{ID: "test", Label: "Test", AreaType: "city"}},
 		}
 
@@ -510,6 +518,14 @@ func TestGetPopulationTypes(t *testing.T) {
 
 	Convey("Given a valid areas response payload", t, func() {
 		areas := GetAreasResponse{
+			PaginationResponse: cantabular.PaginationResponse{
+				PaginationParams: cantabular.PaginationParams{
+					Limit:  2,
+					Offset: 0,
+				},
+				Count:      2,
+				TotalCount: 6,
+			},
 			Areas: []Area{{ID: "test", Label: "Test", AreaType: "city"}},
 		}
 
@@ -673,6 +689,14 @@ func TestGetAreaTypesParent(t *testing.T) {
 
 	Convey("Given a valid areaTypes parents response payload", t, func() {
 		parents := GetAreaTypeParentsResponse{
+			PaginationResponse: cantabular.PaginationResponse{
+				PaginationParams: cantabular.PaginationParams{
+					Limit:  2,
+					Offset: 0,
+				},
+				Count:      2,
+				TotalCount: 6,
+			},
 			AreaTypes: []AreaTypes{{ID: "test", Label: "Test", TotalCount: 2}},
 		}
 
@@ -1001,8 +1025,9 @@ func newStubClient(response *http.Response, err error) *dphttp.ClienterMock {
 // shouldBeDPError is a GoConvey matcher that asserts the passed in error
 // includes a dperrors.Error within the chain, and optionally that the status
 // code matches the expected value.
-// Usage:`So(err, shouldBeDPError)`
-//       `So(err, shouldBeDPError, 404)`
+// Usage:
+// `So(err, shouldBeDPError)`
+// `So(err, shouldBeDPError, 404)`
 func shouldBeDPError(actual interface{}, expected ...interface{}) string {
 	err, ok := actual.(error)
 	if !ok {


### PR DESCRIPTION
### What

@mr-nick17 has raised this as an issue, after updating the `dp-population-types-api` REST endpoints I forgot to update the response models of the it's go api client.

Resolves: [5851](https://trello.com/c/7yZXgUEJ/5851-bug-fix-count-on-review-page-update-api-clients-go)

### How to review

Sense check it and ensure tests are :green_circle: 

### Who can review

Any ONS developer.
