### PR TITLE
fix: get categorisations

### DIFF
--- a/cantabular/dimensions.go
+++ b/cantabular/dimensions.go
@@ -462,7 +462,7 @@ func (c *Client) GetCategorisations(ctx context.Context, req GetCategorisationsR
 	data := QueryData{
 		PaginationParams: req.PaginationParams,
 		Dataset:          req.Dataset,
-		Variables:        []string{req.Variable},
+		Text:             req.Variable,
 	}
 
 	if err := c.queryUnmarshal(ctx, QueryCategorisations, data, resp); err != nil {

--- a/cantabular/dimensions_test.go
+++ b/cantabular/dimensions_test.go
@@ -1140,8 +1140,8 @@ func TestGetCategorisationsHappy(t *testing.T) {
 					mockHttpClient.PostCalls()[0].Body,
 					cantabular.QueryCategorisations,
 					cantabular.QueryData{
-						Dataset:   dataset,
-						Variables: []string{variable},
+						Dataset: dataset,
+						Text:    variable,
 					},
 				)
 			})
@@ -1861,7 +1861,7 @@ var mockRespBodyGetAggregatedDimensionOptions = `
 											"label": "16 to 24"
 										}
 									},
-									{	
+									{
 										"node": {
 											"code": "3",
 											"label": "25+"
@@ -1978,24 +1978,24 @@ var mockRespBodyGetArea = `
   "data": {
     "dataset": {
       "variables": {
-        "edges": [
-          {
-            "node": {
-              "categories": {
-                "edges": [
-                  {
-                    "node": {
-                      "code": "E",
-                      "label": "England"
-                    }
-                  }
-                ]
-              },
-              "label": "Country",
-              "name": "country"
-            }
-          }
-        ]
+	"edges": [
+	  {
+	    "node": {
+	      "categories": {
+		"edges": [
+		  {
+		    "node": {
+		      "code": "E",
+		      "label": "England"
+		    }
+		  }
+		]
+	      },
+	      "label": "Country",
+	      "name": "country"
+	    }
+	  }
+	]
       }
     }
   }
@@ -2161,7 +2161,7 @@ const mockRespBodyGetCategorisations = `
 								"label": "label 2"
 							}
 						}
-						
+
 					]
 				}
 			}


### PR DESCRIPTION
### What

Ammended categorisations method not to use variable but to use text as defined in the query. Previously It was using an empty string, resulting in the same response for every dimension in the cantabular dataset.

### How to review


### Who can review

TeamB
