### PR TITLE
5858 Create 'GET' parent areas count function

### DIFF
--- a/population/client_test.go
+++ b/population/client_test.go
@@ -814,6 +814,218 @@ func TestGetAreaTypesParent(t *testing.T) {
 	})
 }
 
+func TestGetParentAreaCount(t *testing.T) {
+	const userAuthToken = "user"
+	const serviceAuthToken = "service"
+	const datasetId = "datasetId"
+	const areaTypeId = "areaId"
+	const parentAreaTypeId = "parentAreaTypeId"
+	areas := []string{"area1", "area2"}
+	Convey("Given a valid request", t, func() {
+		stubClient := newStubClient(&http.Response{Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil)
+		client, err := NewWithHealthClient(health.NewClientWithClienter("", "http://test.test:2000/v1", stubClient))
+		So(err, ShouldBeNil)
+
+		input := GetParentAreaCountInput{
+			UserAuthToken:    userAuthToken,
+			ServiceAuthToken: serviceAuthToken,
+			DatasetID:        datasetId,
+			AreaTypeID:       areaTypeId,
+			ParentAreaTypeID: parentAreaTypeId,
+			Areas:            areas,
+		}
+		_, _ = client.GetParentAreaCount(context.Background(), input)
+
+		Convey("it should call the parent areas count endpoint", func() {
+			calls := stubClient.DoCalls()
+			So(calls, ShouldNotBeEmpty)
+			So(calls[0].Req.URL.String(), ShouldEqual, "http://test.test:2000/v1/population-types/datasetId/area-types/areaId/parents/parentAreaTypeId/areas-count?areas=area1&areas=area2")
+		})
+	})
+
+	Convey("Given authentication tokens", t, func() {
+		stubClient := newStubClient(&http.Response{Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil)
+		client := newHealthClient(stubClient)
+
+		input := GetParentAreaCountInput{
+			UserAuthToken:    userAuthToken,
+			ServiceAuthToken: serviceAuthToken,
+		}
+
+		_, _ = client.GetParentAreaCount(context.Background(), input)
+
+		Convey("it should set the auth headers on the request", func() {
+			calls := stubClient.DoCalls()
+			So(calls, ShouldNotBeEmpty)
+
+			So(calls[0].Req, shouldHaveAuthHeaders, userAuthToken, serviceAuthToken)
+		})
+	})
+
+	Convey("Given a valid parents areas count response payload", t, func() {
+		resp, err := json.Marshal("1")
+		So(err, ShouldBeNil)
+
+		stubClient := newStubClient(&http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewReader(resp)),
+		}, nil)
+		client := newHealthClient(stubClient)
+
+		input := GetParentAreaCountInput{
+			UserAuthToken:    userAuthToken,
+			ServiceAuthToken: serviceAuthToken,
+			DatasetID:        datasetId,
+			AreaTypeID:       areaTypeId,
+			ParentAreaTypeID: parentAreaTypeId,
+			Areas:            areas,
+		}
+		res, err := client.GetParentAreaCount(context.Background(), input)
+
+		Convey("it should return a list of population types", func() {
+			So(err, ShouldBeNil)
+			So(res, ShouldResemble, 1)
+		})
+	})
+
+	Convey("Given the population API returns an error", t, func() {
+		stubClient := newStubClient(nil, errors.New("oh no"))
+
+		client := newHealthClient(stubClient)
+
+		input := GetParentAreaCountInput{
+			UserAuthToken:    userAuthToken,
+			ServiceAuthToken: serviceAuthToken,
+			DatasetID:        datasetId,
+			AreaTypeID:       areaTypeId,
+			ParentAreaTypeID: parentAreaTypeId,
+			Areas:            areas,
+		}
+		_, err := client.GetParentAreaCount(context.Background(), input)
+
+		Convey("it should return an internal error", func() {
+			So(err, shouldBeDPError, http.StatusInternalServerError)
+		})
+	})
+
+	Convey("Given the parents area count endpoint returns a status code of 404", t, func() {
+		stubClient := newStubClient(&http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{ "errors": ["not found"] }`))),
+		}, nil)
+
+		client := newHealthClient(stubClient)
+
+		input := GetParentAreaCountInput{
+			UserAuthToken:    userAuthToken,
+			ServiceAuthToken: serviceAuthToken,
+			DatasetID:        datasetId,
+			AreaTypeID:       areaTypeId,
+			ParentAreaTypeID: parentAreaTypeId,
+			Areas:            areas,
+		}
+		_, err := client.GetParentAreaCount(context.Background(), input)
+
+		Convey("the error chain should contain the original Errors type", func() {
+			So(err, shouldBeDPError, http.StatusInternalServerError)
+
+			var respErr ErrorResp
+			ok := errors.As(err, &respErr)
+			So(ok, ShouldBeTrue)
+			So(respErr, ShouldResemble, ErrorResp{Errors: []string{"not found"}})
+		})
+	})
+
+	Convey("Given the parent areas count API returns a status code other than 200/400", t, func() {
+		stubClient := newStubClient(&http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{ "areas": [] }`))),
+		}, nil)
+
+		client := newHealthClient(stubClient)
+
+		input := GetParentAreaCountInput{
+			UserAuthToken:    userAuthToken,
+			ServiceAuthToken: serviceAuthToken,
+			DatasetID:        datasetId,
+			AreaTypeID:       areaTypeId,
+			ParentAreaTypeID: parentAreaTypeId,
+			Areas:            areas,
+		}
+		_, err := client.GetParentAreaCount(context.Background(), input)
+
+		Convey("it should return an internal error", func() {
+			So(err, shouldBeDPError, http.StatusInternalServerError)
+		})
+	})
+
+	Convey("Given the response cannot be deserialized", t, func() {
+		stubClient := newStubClient(&http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{ "areas" `))),
+		}, nil)
+
+		client := newHealthClient(stubClient)
+
+		input := GetParentAreaCountInput{
+			UserAuthToken:    userAuthToken,
+			ServiceAuthToken: serviceAuthToken,
+			DatasetID:        datasetId,
+			AreaTypeID:       areaTypeId,
+			ParentAreaTypeID: parentAreaTypeId,
+			Areas:            areas,
+		}
+		_, err := client.GetParentAreaCount(context.Background(), input)
+
+		Convey("it should return an internal error", func() {
+			So(err, shouldBeDPError, http.StatusInternalServerError)
+		})
+	})
+
+	Convey("Given the request cannot be processed", t, func() {
+		client := newHealthClient(newStubClient(nil, nil))
+
+		input := GetParentAreaCountInput{
+			UserAuthToken:    userAuthToken,
+			ServiceAuthToken: serviceAuthToken,
+			DatasetID:        datasetId,
+			AreaTypeID:       areaTypeId,
+			ParentAreaTypeID: parentAreaTypeId,
+			Areas:            areas,
+		}
+		_, err := client.GetParentAreaCount(nil, input)
+
+		Convey("it should return a client error", func() {
+			So(err, shouldBeDPError, http.StatusBadRequest)
+		})
+	})
+
+	Convey("Given the parent areas count request response cannot be converted to int", t, func() {
+		resp, err := json.Marshal("some incorrect value")
+		So(err, ShouldBeNil)
+
+		stubClient := newStubClient(&http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewReader(resp)),
+		}, nil)
+		client := newHealthClient(stubClient)
+
+		input := GetParentAreaCountInput{
+			UserAuthToken:    userAuthToken,
+			ServiceAuthToken: serviceAuthToken,
+			DatasetID:        datasetId,
+			AreaTypeID:       areaTypeId,
+			ParentAreaTypeID: parentAreaTypeId,
+			Areas:            areas,
+		}
+		_, err = client.GetParentAreaCount(context.Background(), input)
+
+		Convey("it should return a list of population types", func() {
+			So(err, shouldBeDPError, http.StatusInternalServerError)
+		})
+	})
+}
+
 func TestGetDimensions(t *testing.T) {
 	const userAuthToken = "user"
 	const serviceAuthToken = "service"


### PR DESCRIPTION
### What

A new GET endpoint is needed to retrieve the count of areas within the larger area-type.

URI would be
```
  /population-types/{population-type}/area-type/{area-type}/parents/{parent-area-type}/areas-count?areas=put,your,list,of,areas,here.
```

This should just return an integer of the count of the number of areas within the original area type within the larger area.

Resolves: [5858](https://trello.com/c/oDyIu8hU/5858-create-endpoint-to-get-the-count-of-areas-within-the-larger-area-type)
Depends on:  https://github.com/ONSdigital/dp-population-types-api/pull/75

### How to review

* Sense check it
* Ensure tests are :green_circle:

### Who can review

Any ONS developer
