### PR TITLE
5858 - Amend the parent areas count type

### DIFF
--- a/population/client.go
+++ b/population/client.go
@@ -429,7 +429,7 @@ func (c *Client) GetParentAreaCount(ctx context.Context, input GetParentAreaCoun
 		input.ParentAreaTypeID,
 	)
 
-	urlValues := map[string][]string{"areas": input.Areas}
+	urlValues := map[string][]string{"areas": {strings.Join(input.Areas, ",")}}
 
 	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, urlValues)
 	if err != nil {

--- a/population/client.go
+++ b/population/client.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -462,8 +461,8 @@ func (c *Client) GetParentAreaCount(ctx context.Context, input GetParentAreaCoun
 		return 0, err
 	}
 
-	var countStr string
-	if err := json.NewDecoder(resp.Body).Decode(&countStr); err != nil {
+	var count int
+	if err := json.NewDecoder(resp.Body).Decode(&count); err != nil {
 		return 0, dperrors.New(
 			errors.Wrap(err, "unable to deserialize parent areas count response"),
 			http.StatusInternalServerError,
@@ -471,7 +470,6 @@ func (c *Client) GetParentAreaCount(ctx context.Context, input GetParentAreaCoun
 		)
 	}
 
-	count, err := strconv.Atoi(countStr)
 	if err != nil {
 		return 0, dperrors.New(
 			errors.Wrap(err, "unable to convert parent areas count API response"),

--- a/population/client_test.go
+++ b/population/client_test.go
@@ -863,7 +863,7 @@ func TestGetParentAreaCount(t *testing.T) {
 	})
 
 	Convey("Given a valid parents areas count response payload", t, func() {
-		resp, err := json.Marshal("1")
+		resp, err := json.Marshal(1)
 		So(err, ShouldBeNil)
 
 		stubClient := newStubClient(&http.Response{

--- a/population/client_test.go
+++ b/population/client_test.go
@@ -839,7 +839,7 @@ func TestGetParentAreaCount(t *testing.T) {
 		Convey("it should call the parent areas count endpoint", func() {
 			calls := stubClient.DoCalls()
 			So(calls, ShouldNotBeEmpty)
-			So(calls[0].Req.URL.String(), ShouldEqual, "http://test.test:2000/v1/population-types/datasetId/area-types/areaId/parents/parentAreaTypeId/areas-count?areas=area1&areas=area2")
+			So(calls[0].Req.URL.String(), ShouldEqual, "http://test.test:2000/v1/population-types/datasetId/area-types/areaId/parents/parentAreaTypeId/areas-count?areas=area1%2Carea2")
 		})
 	})
 


### PR DESCRIPTION
### What

* The value returned by the Populations API is an `int` and not a `string`.
* Amend the parent areas count query param structure  
    It should be `?areas=area1,area2`
    And not `?areas=area1&areas=area2`

**Resolves**: [5843](https://trello.com/c/cKGTgs1o/5843-fix-count-on-pages-that-getareas) [5858](https://trello.com/c/oDyIu8hU/5858-create-endpoint-to-get-the-count-of-areas-within-the-larger-area-type)

### How to review

* Sense check it
* Ensure test are :green_circle: 
* Check with @mr-nick17 

### Who can review

Any ONS developer
