### PR TITLE
5862 Update Cantabular API Ext healthcheck GraphQL query

### DIFF
--- a/cantabular/client.go
+++ b/cantabular/client.go
@@ -124,7 +124,7 @@ func (c *Client) Checker(ctx context.Context, state *healthcheck.CheckState) err
 
 // CheckerAPIExt contacts the /graphql endpoint with an empty query and updates the healthcheck state accordingly.
 func (c *Client) CheckerAPIExt(ctx context.Context, state *healthcheck.CheckState) error {
-	reqURL := fmt.Sprintf("%s/graphql?query={}", c.extApiHost)
+	reqURL := fmt.Sprintf("%s/graphql?query={datasets{name}}", c.extApiHost)
 	return c.checkHealth(ctx, state, ServiceAPIExt, reqURL)
 }
 

--- a/cantabular/client_test.go
+++ b/cantabular/client_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/smartystreets/goconvey/convey"
+
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dphttp "github.com/ONSdigital/dp-net/http"
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 type testError struct {
@@ -74,7 +75,7 @@ func TestChecker(t *testing.T) {
 
 			Convey("Then the expected endpoint is called", func() {
 				So(mockHttpClient.GetCalls(), ShouldHaveLength, 1)
-				So(mockHttpClient.GetCalls()[0].URL, ShouldEqual, "/graphql?query={}")
+				So(mockHttpClient.GetCalls()[0].URL, ShouldEqual, "/graphql?query={datasets{name}}")
 			})
 
 			Convey("Then the CheckState is updated to the expected OK state", func() {
@@ -126,7 +127,7 @@ func TestChecker(t *testing.T) {
 
 			Convey("Then the expected endpoint is called", func() {
 				So(mockHttpClient.GetCalls(), ShouldHaveLength, 1)
-				So(mockHttpClient.GetCalls()[0].URL, ShouldEqual, "/graphql?query={}")
+				So(mockHttpClient.GetCalls()[0].URL, ShouldEqual, "/graphql?query={datasets{name}}")
 			})
 
 			Convey("Then the CheckState is updated to the expected CRITICAL state", func() {
@@ -182,7 +183,7 @@ func TestChecker(t *testing.T) {
 
 			Convey("Then the expected endpoint is called", func() {
 				So(mockHttpClient.GetCalls(), ShouldHaveLength, 1)
-				So(mockHttpClient.GetCalls()[0].URL, ShouldEqual, "/graphql?query={}")
+				So(mockHttpClient.GetCalls()[0].URL, ShouldEqual, "/graphql?query={datasets{name}}")
 			})
 
 			Convey("Then the CheckState is updated to the expected CRITICAL state", func() {


### PR DESCRIPTION
### What

Currently when our services do a healthcheck against `cantabular-api-ext` an empty query is sent to check the connectivity which is throwing errors in the logs and making it difficult to debug the extended api.

The error that appears on the logs is the following:
```
t=2022-09-21T16:27:56Z ns=api-ext lvl=info ev=graphql query={} op= vars=
t=2022-09-21T16:27:56Z ns=api-ext lvl=info ev=message msg="GraphQL error: Syntax Error GraphQL request (1:1) Unexpected empty IN {}\n\n1: {}\n   ^\n"
t=2022-09-21T16:27:56Z ns=api-ext lvl=info ev=http port=8492 url="/graphql?query={}" method=GET httpStatus=200 contentType=application/json remoteAddr=172.20.0.34 authUser= nBytes=150
```

Going forward the response on the logs should be:
```
t=2022-09-21T17:06:33Z ns=api-ext lvl=info ev=graphql query={datasets{name}} op= vars=
t=2022-09-21T17:06:33Z ns=api-ext lvl=info ev=http port=8492 url="/graphql?query={datasets{name}}" method=GET httpStatus=200 contentType=application/json remoteAddr=172.20.0.1 authUser= nBytes=128
```

https://user-images.githubusercontent.com/102318/191567566-49a29562-b3d0-446e-8c7a-44b240beefcd.mp4


Resolves: [5862](https://trello.com/c/3dsfjvv9/5862-update-cantabular-api-ext-health-check-to-send-the-correct-query)

### How to review

Sense check it and ensure tests are :green_circle: 

### Who can review
Any ONS Developer

