### PR TITLE
Feature/cantabular/5836 get categorisations

### DIFF
--- a/population/area_types.go
+++ b/population/area_types.go
@@ -1,6 +1,18 @@
 package population
 
-import "github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/clientlog"
+	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
+	"github.com/ONSdigital/log.go/v2/log"
+	"github.com/pkg/errors"
+)
 
 // AreaType is an area type model with ID and Label
 type AreaType struct {
@@ -9,8 +21,137 @@ type AreaType struct {
 	TotalCount int    `json:"total_count"`
 }
 
+type GetAreaTypesInput struct {
+	AuthTokens
+	PaginationParams
+	PopulationType string
+}
+
+type GetAreaTypeParentsInput struct {
+	AuthTokens
+	PaginationParams
+	PopulationType string
+	AreaTypeID     string
+}
+
 // GetAreaTypesResponse is the response object for GET /area-types
 type GetAreaTypesResponse struct {
-	cantabular.PaginationResponse
+	PaginationResponse
 	AreaTypes []AreaType `json:"area_types"`
+}
+
+// GetAreaTypeParentsResponse is the response object for GET /areas
+type GetAreaTypeParentsResponse struct {
+	PaginationResponse
+	AreaTypes []AreaType `json:"area_types"`
+}
+
+// GetPopulationAreaTypes retrieves the Cantabular area-types associated with a dataset
+func (c *Client) GetAreaTypes(ctx context.Context, input GetAreaTypesInput) (GetAreaTypesResponse, error) {
+	logData := log.Data{
+		"method":     http.MethodGet,
+		"dataset_id": input.PopulationType,
+	}
+
+	urlPath := fmt.Sprintf("population-types/%s/area-types", input.PopulationType)
+	urlValues := url.Values{
+		"limit":  []string{strconv.Itoa(input.Limit)},
+		"offset": []string{strconv.Itoa(input.Offset)},
+	}
+
+	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, urlValues)
+	if err != nil {
+		return GetAreaTypesResponse{}, dperrors.New(
+			err,
+			dperrors.StatusCode(err),
+			logData,
+		)
+	}
+
+	clientlog.Do(ctx, "getting area types", service, req.URL.String(), logData)
+
+	resp, err := c.hcCli.Client.Do(ctx, req)
+	if err != nil {
+		return GetAreaTypesResponse{}, dperrors.New(
+			errors.Wrap(err, "failed to get response from Population Type API"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Error(ctx, "error closing http response body", err)
+		}
+	}()
+
+	if err := checkGetResponse(resp); err != nil {
+		return GetAreaTypesResponse{}, err
+	}
+
+	var areaTypes GetAreaTypesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&areaTypes); err != nil {
+		return GetAreaTypesResponse{}, dperrors.New(
+			errors.Wrap(err, "unable to deserialize area types response"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	return areaTypes, nil
+}
+
+func (c *Client) GetAreaTypeParents(ctx context.Context, input GetAreaTypeParentsInput) (GetAreaTypeParentsResponse, error) {
+	logData := log.Data{
+		"method":       http.MethodGet,
+		"dataset_id":   input.PopulationType,
+		"area_type_id": input.AreaTypeID,
+	}
+
+	urlPath := fmt.Sprintf("population-types/%s/area-types/%s/parents", input.PopulationType, input.AreaTypeID)
+	urlValues := url.Values{
+		"limit":  []string{strconv.Itoa(input.Limit)},
+		"offset": []string{strconv.Itoa(input.Offset)},
+	}
+
+	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, urlValues)
+	if err != nil {
+		return GetAreaTypeParentsResponse{}, dperrors.New(
+			err,
+			dperrors.StatusCode(err),
+			logData,
+		)
+	}
+
+	clientlog.Do(ctx, "getting area-types parents", service, req.URL.String(), logData)
+
+	resp, err := c.hcCli.Client.Do(ctx, req)
+	if err != nil {
+		return GetAreaTypeParentsResponse{}, dperrors.New(
+			errors.Wrap(err, "failed to get response from Population types API"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Error(ctx, "error closing http response body", err)
+		}
+	}()
+
+	if err := checkGetResponse(resp); err != nil {
+		return GetAreaTypeParentsResponse{}, err
+	}
+
+	var atp GetAreaTypeParentsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&atp); err != nil {
+		return GetAreaTypeParentsResponse{}, dperrors.New(
+			errors.Wrap(err, "unable to deserialize areas response"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	return atp, nil
 }

--- a/population/areas.go
+++ b/population/areas.go
@@ -1,6 +1,20 @@
 package population
 
-import "github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/clientlog"
+	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
+	"github.com/ONSdigital/log.go/v2/log"
+	"github.com/pkg/errors"
+)
 
 // Area is an area model with ID and Label
 type Area struct {
@@ -9,9 +23,32 @@ type Area struct {
 	AreaType string `json:"area_type"`
 }
 
+type GetAreaInput struct {
+	AuthTokens
+	PopulationType string
+	AreaType       string
+	Area           string
+}
+
+type GetAreasInput struct {
+	AuthTokens
+	PaginationParams
+	PopulationType string
+	AreaTypeID     string
+	Text           string
+}
+
+type GetParentAreaCountInput struct {
+	AuthTokens
+	PopulationType   string
+	AreaTypeID       string
+	ParentAreaTypeID string
+	Areas            []string
+}
+
 // GetAreasResponse is the response object for GET /areas
 type GetAreasResponse struct {
-	cantabular.PaginationResponse
+	PaginationResponse
 	Areas []Area `json:"areas"`
 }
 
@@ -20,28 +57,194 @@ type GetAreaResponse struct {
 	Area Area `json:"area"`
 }
 
-// Area is an area model with ID and Label
-type AreaTypes struct {
-	ID         string `json:"id"`
-	Label      string `json:"label"`
-	TotalCount int    `json:"total_count"`
+func (c *Client) GetArea(ctx context.Context, input GetAreaInput) (GetAreaResponse, error) {
+	logData := log.Data{
+		"method":          http.MethodGet,
+		"population_type": input.PopulationType,
+		"area_type":       input.AreaType,
+		"area":            input.Area,
+	}
+	urlPath := fmt.Sprintf("population-types/%s/area-types/%s/areas/%s", input.PopulationType, input.AreaType, input.Area)
+
+	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, nil)
+	if err != nil {
+		return GetAreaResponse{}, dperrors.New(
+			err,
+			dperrors.StatusCode(err),
+			logData,
+		)
+	}
+
+	clientlog.Do(ctx, "getting area", service, req.URL.String(), logData)
+
+	res, err := c.hcCli.Client.Do(ctx, req)
+	if err != nil {
+		return GetAreaResponse{}, dperrors.New(
+			errors.Wrap(err, "failed to get response from Population types API"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			log.Error(ctx, "error closing http response body", err)
+		}
+	}()
+
+	if err := checkGetResponse(res); err != nil {
+		return GetAreaResponse{}, err
+	}
+
+	var resp GetAreaResponse
+
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		return GetAreaResponse{}, err
+	}
+
+	logData["resp"] = string(b)
+
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return GetAreaResponse{}, dperrors.New(
+			errors.Wrap(err, "unable to deserialize area response"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	return resp, nil
 }
 
-// GetAreaTypeParentsResponse is the response object for GET /areas
-type GetAreaTypeParentsResponse struct {
-	cantabular.PaginationResponse
-	AreaTypes []AreaTypes `json:"area_types"`
+func (c *Client) GetAreas(ctx context.Context, input GetAreasInput) (GetAreasResponse, error) {
+	logData := log.Data{
+		"method":          http.MethodGet,
+		"population_type": input.PopulationType,
+		"area_type_id":    input.AreaTypeID,
+		"text":            input.Text,
+		"limit":           input.Limit,
+		"offset":          input.Offset,
+	}
+
+	urlPath := fmt.Sprintf("population-types/%s/area-types/%s/areas", input.PopulationType, input.AreaTypeID)
+	urlValues := url.Values{
+		"limit":  []string{strconv.Itoa(input.Limit)},
+		"offset": []string{strconv.Itoa(input.Offset)},
+	}
+	if input.Text != "" {
+		urlValues["q"] = []string{input.Text}
+	}
+
+	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, urlValues)
+	if err != nil {
+		return GetAreasResponse{}, dperrors.New(
+			err,
+			dperrors.StatusCode(err),
+			logData,
+		)
+	}
+
+	clientlog.Do(ctx, "getting areas", service, req.URL.String(), logData)
+
+	resp, err := c.hcCli.Client.Do(ctx, req)
+	if err != nil {
+		return GetAreasResponse{}, dperrors.New(
+			errors.Wrap(err, "failed to get response from Population types API"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Error(ctx, "error closing http response body", err)
+		}
+	}()
+
+	if err := checkGetResponse(resp); err != nil {
+		return GetAreasResponse{}, err
+	}
+
+	var areas GetAreasResponse
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return GetAreasResponse{}, err
+	}
+
+	if err := json.Unmarshal(b, &areas); err != nil {
+		return GetAreasResponse{}, dperrors.New(
+			errors.Wrap(err, "unable to deserialize areas response"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	return areas, nil
 }
 
-// Dimension is an area-type model with ID and Label
-type Dimension struct {
-	Name       string `json:"name"`
-	Label      string `json:"label"`
-	TotalCount int    `json:"total_count"`
-}
+func (c *Client) GetParentAreaCount(ctx context.Context, input GetParentAreaCountInput) (int, error) {
+	logData := log.Data{
+		"method":              http.MethodGet,
+		"dataset_id":          input.PopulationType,
+		"area_type_id":        input.AreaTypeID,
+		"parent_area_type_id": input.ParentAreaTypeID,
+		"areas":               input.Areas,
+	}
 
-// GetDimensionsResponse is the response object for GetDimensions
-type GetDimensionsResponse struct {
-	cantabular.PaginationResponse
-	Dimensions []Dimension `json:"items"`
+	urlPath := fmt.Sprintf("population-types/%s/area-types/%s/parents/%s/areas-count",
+		input.PopulationType,
+		input.AreaTypeID,
+		input.ParentAreaTypeID,
+	)
+
+	urlValues := map[string][]string{"areas": {strings.Join(input.Areas, ",")}}
+
+	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, urlValues)
+	if err != nil {
+		return 0, dperrors.New(
+			err,
+			dperrors.StatusCode(err),
+			logData,
+		)
+	}
+
+	clientlog.Do(ctx, "getting area-types parents", service, req.URL.String(), logData)
+
+	resp, err := c.hcCli.Client.Do(ctx, req)
+	if err != nil {
+		return 0, dperrors.New(
+			errors.Wrap(err, "failed to get response from Population types API"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Error(ctx, "error closing http response body", err)
+		}
+	}()
+
+	if err := checkGetResponse(resp); err != nil {
+		return 0, err
+	}
+
+	var count int
+	if err := json.NewDecoder(resp.Body).Decode(&count); err != nil {
+		return 0, dperrors.New(
+			errors.Wrap(err, "unable to deserialize parent areas count response"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	if err != nil {
+		return 0, dperrors.New(
+			errors.Wrap(err, "unable to convert parent areas count API response"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+	return count, nil
 }

--- a/population/client.go
+++ b/population/client.go
@@ -7,10 +7,12 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
 	"github.com/ONSdigital/dp-api-clients-go/v2/clientlog"
 	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
 	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
@@ -36,6 +38,7 @@ type GetAreaInput struct {
 }
 
 type GetAreasInput struct {
+	cantabular.PaginationParams
 	UserAuthToken    string
 	ServiceAuthToken string
 	DatasetID        string
@@ -247,12 +250,19 @@ func (c *Client) GetAreas(ctx context.Context, input GetAreasInput) (GetAreasRes
 		"dataset_id":   input.DatasetID,
 		"area_type_id": input.AreaTypeID,
 		"text":         input.Text,
+		"limit":        input.Limit,
+		"offset":       input.Offset,
 	}
 
 	urlPath := fmt.Sprintf("population-types/%s/area-types/%s/areas", input.DatasetID, input.AreaTypeID)
-	var urlValues map[string][]string
+
+	urlValues := map[string][]string{
+		"offset": {strconv.Itoa(input.Offset)},
+		"limit":  {strconv.Itoa(input.Limit)},
+	}
+
 	if input.Text != "" {
-		urlValues = url.Values{"q": []string{input.Text}}
+		urlValues["q"] = []string{input.Text}
 	}
 
 	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, urlValues)

--- a/population/client.go
+++ b/population/client.go
@@ -7,13 +7,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
 
-	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
-	"github.com/ONSdigital/dp-api-clients-go/v2/clientlog"
 	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
 	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
 	"github.com/ONSdigital/dp-api-clients-go/v2/health"
@@ -27,48 +24,6 @@ const service = "population-types-api"
 type Client struct {
 	hcCli   *health.Client
 	baseURL *url.URL
-}
-
-type GetAreaInput struct {
-	UserAuthToken    string
-	ServiceAuthToken string
-	PopulationType   string
-	AreaType         string
-	Area             string
-}
-
-type GetAreasInput struct {
-	cantabular.PaginationParams
-	UserAuthToken    string
-	ServiceAuthToken string
-	DatasetID        string
-	AreaTypeID       string
-	Text             string
-}
-
-type GetAreaTypeParentsInput struct {
-	UserAuthToken    string
-	ServiceAuthToken string
-	DatasetID        string
-	AreaTypeID       string
-}
-
-type GetParentAreaCountInput struct {
-	UserAuthToken    string
-	ServiceAuthToken string
-	DatasetID        string
-	AreaTypeID       string
-	ParentAreaTypeID string
-	Areas            []string
-}
-
-type GetDimensionsInput struct {
-	UserAuthToken    string
-	ServiceAuthToken string
-	Limit            int
-	Offset           int
-	PopulationType   string
-	SearchString     string
 }
 
 // NewClient creates a new instance of Client with a given Population Type API URL
@@ -101,7 +56,7 @@ func (c *Client) Checker(ctx context.Context, check *healthcheck.CheckState) err
 }
 
 func (c *Client) createGetRequest(ctx context.Context, userAuthToken, serviceAuthToken, urlPath string, urlValues url.Values) (*http.Request, error) {
-	areasURL, err := c.baseURL.Parse(urlPath)
+	populationURL, err := c.baseURL.Parse(urlPath)
 	if err != nil {
 		return &http.Request{}, dperrors.New(
 			errors.Wrap(err, "failed to parse areas URL"),
@@ -110,8 +65,8 @@ func (c *Client) createGetRequest(ctx context.Context, userAuthToken, serviceAut
 		)
 	}
 
-	areasURL.RawQuery = urlValues.Encode()
-	reqURL := areasURL.String()
+	populationURL.RawQuery = urlValues.Encode()
+	reqURL := populationURL.String()
 
 	req, err := newRequest(ctx, http.MethodGet, reqURL, nil, userAuthToken, serviceAuthToken)
 	if err != nil {
@@ -126,429 +81,34 @@ func (c *Client) createGetRequest(ctx context.Context, userAuthToken, serviceAut
 
 func checkGetResponse(resp *http.Response) error {
 	if resp.StatusCode != http.StatusOK {
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read error response body: %w", err)
+		}
+
 		var errorResp ErrorResp
-		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err == nil {
+		if err := json.Unmarshal(b, &errorResp); err != nil {
 			return dperrors.New(
-				fmt.Errorf("error response from Population Type API (%d): %w", resp.StatusCode, errorResp),
-				http.StatusInternalServerError,
-				log.Data{},
+				fmt.Errorf("failed to unmarshal response body: %w", err),
+				resp.StatusCode,
+				log.Data{
+					"response_body": string(b),
+				},
 			)
 		}
+
+		return dperrors.New(
+			fmt.Errorf("error response from Population Type API: %w", errorResp),
+			resp.StatusCode,
+			nil,
+		)
 	}
 
 	return nil
 }
 
-func (c *Client) GetPopulationTypes(ctx context.Context, input GetAreasInput) (GetAreasResponse, error) {
-	logData := log.Data{
-		"method":       http.MethodGet,
-		"dataset_id":   input.DatasetID,
-		"area_type_id": input.AreaTypeID,
-		"text":         input.Text,
-	}
-
-	urlPath := "population-types"
-	urlValues := url.Values{}
-
-	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, urlValues)
-	if err != nil {
-		return GetAreasResponse{}, dperrors.New(
-			err,
-			dperrors.StatusCode(err),
-			logData,
-		)
-	}
-
-	clientlog.Do(ctx, "getting areas", service, req.URL.String(), logData)
-
-	resp, err := c.hcCli.Client.Do(ctx, req)
-	if err != nil {
-		return GetAreasResponse{}, dperrors.New(
-			errors.Wrap(err, "failed to get response from Population types API"),
-			http.StatusInternalServerError,
-			logData,
-		)
-	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			log.Error(ctx, "error closing http response body", err)
-		}
-	}()
-
-	if err := checkGetResponse(resp); err != nil {
-		return GetAreasResponse{}, err
-	}
-
-	var areas GetAreasResponse
-	if err := json.NewDecoder(resp.Body).Decode(&areas); err != nil {
-		return GetAreasResponse{}, dperrors.New(
-			errors.Wrap(err, "unable to deserialize areas response"),
-			http.StatusInternalServerError,
-			logData,
-		)
-	}
-
-	return areas, nil
-}
-
-// GetPopulationAreaTypes retrieves the Cantabular area-types associated with a dataset
-func (c *Client) GetPopulationAreaTypes(ctx context.Context, userAuthToken, serviceAuthToken, datasetID string) (GetAreaTypesResponse, error) {
-	logData := log.Data{
-		"method":     http.MethodGet,
-		"dataset_id": datasetID,
-	}
-
-	urlPath := fmt.Sprintf("population-types/%s/area-types", datasetID)
-	urlValues := url.Values{}
-
-	req, err := c.createGetRequest(ctx, userAuthToken, serviceAuthToken, urlPath, urlValues)
-	if err != nil {
-		return GetAreaTypesResponse{}, dperrors.New(
-			err,
-			dperrors.StatusCode(err),
-			logData,
-		)
-	}
-
-	clientlog.Do(ctx, "getting area types", service, req.URL.String(), logData)
-
-	resp, err := c.hcCli.Client.Do(ctx, req)
-	if err != nil {
-		return GetAreaTypesResponse{}, dperrors.New(
-			errors.Wrap(err, "failed to get response from Population Type API"),
-			http.StatusInternalServerError,
-			logData,
-		)
-	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			log.Error(ctx, "error closing http response body", err)
-		}
-	}()
-
-	if err := checkGetResponse(resp); err != nil {
-		return GetAreaTypesResponse{}, err
-	}
-
-	var areaTypes GetAreaTypesResponse
-	if err := json.NewDecoder(resp.Body).Decode(&areaTypes); err != nil {
-		return GetAreaTypesResponse{}, dperrors.New(
-			errors.Wrap(err, "unable to deserialize area types response"),
-			http.StatusInternalServerError,
-			logData,
-		)
-	}
-
-	return areaTypes, nil
-}
-
-func (c *Client) GetAreas(ctx context.Context, input GetAreasInput) (GetAreasResponse, error) {
-	logData := log.Data{
-		"method":       http.MethodGet,
-		"dataset_id":   input.DatasetID,
-		"area_type_id": input.AreaTypeID,
-		"text":         input.Text,
-		"limit":        input.Limit,
-		"offset":       input.Offset,
-	}
-
-	urlPath := fmt.Sprintf("population-types/%s/area-types/%s/areas", input.DatasetID, input.AreaTypeID)
-
-	urlValues := map[string][]string{
-		"offset": {strconv.Itoa(input.Offset)},
-		"limit":  {strconv.Itoa(input.Limit)},
-	}
-
-	if input.Text != "" {
-		urlValues["q"] = []string{input.Text}
-	}
-
-	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, urlValues)
-	if err != nil {
-		return GetAreasResponse{}, dperrors.New(
-			err,
-			dperrors.StatusCode(err),
-			logData,
-		)
-	}
-
-	clientlog.Do(ctx, "getting areas", service, req.URL.String(), logData)
-
-	resp, err := c.hcCli.Client.Do(ctx, req)
-	if err != nil {
-		return GetAreasResponse{}, dperrors.New(
-			errors.Wrap(err, "failed to get response from Population types API"),
-			http.StatusInternalServerError,
-			logData,
-		)
-	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			log.Error(ctx, "error closing http response body", err)
-		}
-	}()
-
-	if err := checkGetResponse(resp); err != nil {
-		return GetAreasResponse{}, err
-	}
-
-	var areas GetAreasResponse
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return GetAreasResponse{}, err
-	}
-
-	if err := json.Unmarshal(b, &areas); err != nil {
-		return GetAreasResponse{}, dperrors.New(
-			errors.Wrap(err, "unable to deserialize areas response"),
-			http.StatusInternalServerError,
-			logData,
-		)
-	}
-
-	return areas, nil
-}
-
-func (c *Client) GetArea(ctx context.Context, input GetAreaInput) (GetAreaResponse, error) {
-	logData := log.Data{
-		"method":          http.MethodGet,
-		"population_type": input.PopulationType,
-		"area_type":       input.AreaType,
-		"area":            input.Area,
-	}
-	urlPath := fmt.Sprintf("population-types/%s/area-types/%s/areas/%s", input.PopulationType, input.AreaType, input.Area)
-
-	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, nil)
-	if err != nil {
-		return GetAreaResponse{}, dperrors.New(
-			err,
-			dperrors.StatusCode(err),
-			logData,
-		)
-	}
-
-	clientlog.Do(ctx, "getting area", service, req.URL.String(), logData)
-
-	res, err := c.hcCli.Client.Do(ctx, req)
-	if err != nil {
-		return GetAreaResponse{}, dperrors.New(
-			errors.Wrap(err, "failed to get response from Population types API"),
-			http.StatusInternalServerError,
-			logData,
-		)
-	}
-
-	defer func() {
-		if err := res.Body.Close(); err != nil {
-			log.Error(ctx, "error closing http response body", err)
-		}
-	}()
-
-	if err := checkGetResponse(res); err != nil {
-		return GetAreaResponse{}, err
-	}
-
-	var resp GetAreaResponse
-
-	b, err := io.ReadAll(res.Body)
-	if err != nil {
-		return GetAreaResponse{}, err
-	}
-
-	logData["resp"] = string(b)
-
-	if err := json.Unmarshal(b, &resp); err != nil {
-		return GetAreaResponse{}, dperrors.New(
-			errors.Wrap(err, "unable to deserialize area response"),
-			http.StatusInternalServerError,
-			logData,
-		)
-	}
-
-	return resp, nil
-}
-
-func (c *Client) GetAreaTypeParents(ctx context.Context, input GetAreaTypeParentsInput) (GetAreaTypeParentsResponse, error) {
-	logData := log.Data{
-		"method":       http.MethodGet,
-		"dataset_id":   input.DatasetID,
-		"area_type_id": input.AreaTypeID,
-	}
-
-	urlPath := fmt.Sprintf("population-types/%s/area-types/%s/parents", input.DatasetID, input.AreaTypeID)
-	var urlValues map[string][]string
-
-	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, urlValues)
-	if err != nil {
-		return GetAreaTypeParentsResponse{}, dperrors.New(
-			err,
-			dperrors.StatusCode(err),
-			logData,
-		)
-	}
-
-	clientlog.Do(ctx, "getting area-types parents", service, req.URL.String(), logData)
-
-	resp, err := c.hcCli.Client.Do(ctx, req)
-	if err != nil {
-		return GetAreaTypeParentsResponse{}, dperrors.New(
-			errors.Wrap(err, "failed to get response from Population types API"),
-			http.StatusInternalServerError,
-			logData,
-		)
-	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			log.Error(ctx, "error closing http response body", err)
-		}
-	}()
-
-	if err := checkGetResponse(resp); err != nil {
-		return GetAreaTypeParentsResponse{}, err
-	}
-
-	var atp GetAreaTypeParentsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&atp); err != nil {
-		return GetAreaTypeParentsResponse{}, dperrors.New(
-			errors.Wrap(err, "unable to deserialize areas response"),
-			http.StatusInternalServerError,
-			logData,
-		)
-	}
-
-	return atp, nil
-}
-
-func (c *Client) GetParentAreaCount(ctx context.Context, input GetParentAreaCountInput) (int, error) {
-	logData := log.Data{
-		"method":              http.MethodGet,
-		"dataset_id":          input.DatasetID,
-		"area_type_id":        input.AreaTypeID,
-		"parent_area_type_id": input.ParentAreaTypeID,
-		"areas":               input.Areas,
-	}
-
-	urlPath := fmt.Sprintf("population-types/%s/area-types/%s/parents/%s/areas-count",
-		input.DatasetID,
-		input.AreaTypeID,
-		input.ParentAreaTypeID,
-	)
-
-	urlValues := map[string][]string{"areas": {strings.Join(input.Areas, ",")}}
-
-	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, urlValues)
-	if err != nil {
-		return 0, dperrors.New(
-			err,
-			dperrors.StatusCode(err),
-			logData,
-		)
-	}
-
-	clientlog.Do(ctx, "getting area-types parents", service, req.URL.String(), logData)
-
-	resp, err := c.hcCli.Client.Do(ctx, req)
-	if err != nil {
-		return 0, dperrors.New(
-			errors.Wrap(err, "failed to get response from Population types API"),
-			http.StatusInternalServerError,
-			logData,
-		)
-	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			log.Error(ctx, "error closing http response body", err)
-		}
-	}()
-
-	if err := checkGetResponse(resp); err != nil {
-		return 0, err
-	}
-
-	var count int
-	if err := json.NewDecoder(resp.Body).Decode(&count); err != nil {
-		return 0, dperrors.New(
-			errors.Wrap(err, "unable to deserialize parent areas count response"),
-			http.StatusInternalServerError,
-			logData,
-		)
-	}
-
-	if err != nil {
-		return 0, dperrors.New(
-			errors.Wrap(err, "unable to convert parent areas count API response"),
-			http.StatusInternalServerError,
-			logData,
-		)
-	}
-	return count, nil
-}
-
-func (c *Client) GetDimensions(ctx context.Context, input GetDimensionsInput) (GetDimensionsResponse, error) {
-	logData := log.Data{
-		"method":         http.MethodGet,
-		"limit":          input.Limit,
-		"offset":         input.Offset,
-		"populationType": input.PopulationType,
-		"search string":  input.SearchString,
-	}
-
-	urlPath := fmt.Sprintf("/population-types/%s/dimensions", input.PopulationType)
-	var urlValues map[string][]string
-	if input.SearchString != "" {
-		urlValues = url.Values{"q": []string{input.SearchString}}
-	}
-
-	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, urlValues)
-	if err != nil {
-		return GetDimensionsResponse{}, dperrors.New(
-			err,
-			dperrors.StatusCode(err),
-			logData,
-		)
-	}
-
-	clientlog.Do(ctx, "getting dimensions", service, req.URL.String(), logData)
-
-	resp, err := c.hcCli.Client.Do(ctx, req)
-	if err != nil {
-		return GetDimensionsResponse{}, dperrors.New(
-			errors.Wrap(err, "failed to get response from Population types API"),
-			http.StatusInternalServerError,
-			logData,
-		)
-	}
-
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			log.Error(ctx, "error closing http response body", err)
-		}
-	}()
-
-	if err := checkGetResponse(resp); err != nil {
-		return GetDimensionsResponse{}, err
-	}
-
-	var dimensions GetDimensionsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&dimensions); err != nil {
-		return GetDimensionsResponse{}, dperrors.New(
-			errors.Wrap(err, "unable to deserialize areas response"),
-			http.StatusInternalServerError,
-			logData,
-		)
-	}
-
-	return dimensions, nil
-}
-
 // newRequest creates a new http.Request with auth headers
-func newRequest(ctx context.Context, method string, url string, body io.Reader, userAuthToken, serviceAuthToken string) (*http.Request, error) {
+func newRequest(ctx context.Context, method, url string, body io.Reader, userAuthToken, serviceAuthToken string) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create request")

--- a/population/client_test.go
+++ b/population/client_test.go
@@ -184,7 +184,7 @@ func TestGetAreas(t *testing.T) {
 		Convey("it should call the areas endpoint, serializing the dataset, area type and text query params", func() {
 			calls := stubClient.DoCalls()
 			So(calls, ShouldNotBeEmpty)
-			So(calls[0].Req.URL.String(), ShouldEqual, "http://test.test:2000/v1/population-types/testDataSet/area-types/testAreaType/areas?q=testText")
+			So(calls[0].Req.URL.String(), ShouldEqual, "http://test.test:2000/v1/population-types/testDataSet/area-types/testAreaType/areas?limit=0&offset=0&q=testText")
 		})
 	})
 
@@ -206,7 +206,7 @@ func TestGetAreas(t *testing.T) {
 		Convey("it should call the areas endpoint, omitting the text query param", func() {
 			calls := stubClient.DoCalls()
 			So(calls, ShouldNotBeEmpty)
-			So(calls[0].Req.URL.String(), ShouldEqual, "http://test.test:2000/v1/population-types/testDataSet/area-types/testAreaType/areas")
+			So(calls[0].Req.URL.String(), ShouldEqual, "http://test.test:2000/v1/population-types/testDataSet/area-types/testAreaType/areas?limit=0&offset=0")
 		})
 	})
 

--- a/population/contract.go
+++ b/population/contract.go
@@ -1,0 +1,17 @@
+package population
+
+type PaginationParams struct {
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
+}
+
+type PaginationResponse struct {
+	PaginationParams
+	Count      int `json:"count"`
+	TotalCount int `json:"total_count"`
+}
+
+type AuthTokens struct {
+	UserAuthToken    string
+	ServiceAuthToken string
+}

--- a/population/dimensions.go
+++ b/population/dimensions.go
@@ -1,0 +1,164 @@
+package population
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/clientlog"
+	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
+	"github.com/ONSdigital/log.go/v2/log"
+	"github.com/pkg/errors"
+)
+
+// Dimension is an area-type model with ID and Label
+type Dimension struct {
+	Name       string `json:"name"`
+	Label      string `json:"label"`
+	TotalCount int    `json:"total_count"`
+}
+
+type GetDimensionsInput struct {
+	AuthTokens
+	PaginationParams
+	PopulationType string
+	SearchString   string
+}
+
+type GetCategorisationsInput struct {
+	AuthTokens
+	PaginationParams
+	PopulationType string
+	Dimension      string
+}
+
+// GetDimensionsResponse is the response object for GetDimensions
+type GetDimensionsResponse struct {
+	PaginationResponse
+	Dimensions []Dimension `json:"items"`
+}
+
+type GetCategorisationsResponse struct {
+	PaginationResponse
+	Items []Dimension `json:"items"`
+}
+
+func (c *Client) GetDimensions(ctx context.Context, input GetDimensionsInput) (GetDimensionsResponse, error) {
+	logData := log.Data{
+		"method":          http.MethodGet,
+		"limit":           input.Limit,
+		"offset":          input.Offset,
+		"population_type": input.PopulationType,
+		"search_string":   input.SearchString,
+	}
+
+	urlPath := fmt.Sprintf("/population-types/%s/dimensions", input.PopulationType)
+	urlValues := url.Values{
+		"limit":  []string{strconv.Itoa(input.Limit)},
+		"offset": []string{strconv.Itoa(input.Offset)},
+	}
+	if input.SearchString != "" {
+		urlValues["q"] = []string{input.SearchString}
+	}
+
+	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, urlValues)
+	if err != nil {
+		return GetDimensionsResponse{}, dperrors.New(
+			err,
+			dperrors.StatusCode(err),
+			logData,
+		)
+	}
+
+	clientlog.Do(ctx, "getting dimensions", service, req.URL.String(), logData)
+
+	resp, err := c.hcCli.Client.Do(ctx, req)
+	if err != nil {
+		return GetDimensionsResponse{}, dperrors.New(
+			errors.Wrap(err, "failed to get response from Population types API"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Error(ctx, "error closing http response body", err)
+		}
+	}()
+
+	if err := checkGetResponse(resp); err != nil {
+		return GetDimensionsResponse{}, err
+	}
+
+	var dimensions GetDimensionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dimensions); err != nil {
+		return GetDimensionsResponse{}, dperrors.New(
+			errors.Wrap(err, "unable to deserialize areas response"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	return dimensions, nil
+}
+
+func (c *Client) GetCategorisations(ctx context.Context, input GetCategorisationsInput) (GetCategorisationsResponse, error) {
+	logData := log.Data{
+		"method":          http.MethodGet,
+		"limit":           input.Limit,
+		"offset":          input.Offset,
+		"population_type": input.PopulationType,
+		"dimension":       input.Dimension,
+	}
+
+	urlPath := fmt.Sprintf("/population-types/%s/dimensions/%s/categorisations", input.PopulationType, input.Dimension)
+	urlValues := url.Values{
+		"limit":  []string{strconv.Itoa(input.Limit)},
+		"offset": []string{strconv.Itoa(input.Offset)},
+	}
+
+	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, urlValues)
+	if err != nil {
+		return GetCategorisationsResponse{}, dperrors.New(
+			err,
+			dperrors.StatusCode(err),
+			logData,
+		)
+	}
+
+	clientlog.Do(ctx, "getting dimension categorisations", service, req.URL.String(), logData)
+
+	res, err := c.hcCli.Client.Do(ctx, req)
+	if err != nil {
+		return GetCategorisationsResponse{}, dperrors.New(
+			errors.Wrap(err, "failed to get response from Population types API"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			log.Error(ctx, "error closing http response body", err)
+		}
+	}()
+
+	if err := checkGetResponse(res); err != nil {
+		return GetCategorisationsResponse{}, err
+	}
+
+	var resp GetCategorisationsResponse
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return GetCategorisationsResponse{}, dperrors.New(
+			errors.Wrap(err, "unable to deserialize categorisations response"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	return resp, nil
+}

--- a/population/population_types.go
+++ b/population/population_types.go
@@ -1,0 +1,75 @@
+package population
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/clientlog"
+	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
+	"github.com/ONSdigital/log.go/v2/log"
+	"github.com/pkg/errors"
+)
+
+type PopulationType struct {
+	Name string `json:"name"`
+}
+
+type GetPopulationTypesInput struct {
+	AuthTokens
+}
+
+type GetPopulationTypesResponse struct {
+	Items []PopulationType `json:"items"`
+}
+
+func (c *Client) GetPopulationTypes(ctx context.Context, input GetPopulationTypesInput) (GetPopulationTypesResponse, error) {
+	logData := log.Data{
+		"method": http.MethodGet,
+	}
+
+	urlPath := "population-types"
+	urlValues := url.Values{}
+
+	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, urlValues)
+	if err != nil {
+		return GetPopulationTypesResponse{}, dperrors.New(
+			err,
+			dperrors.StatusCode(err),
+			logData,
+		)
+	}
+
+	clientlog.Do(ctx, "getting population types", service, req.URL.String(), logData)
+
+	res, err := c.hcCli.Client.Do(ctx, req)
+	if err != nil {
+		return GetPopulationTypesResponse{}, dperrors.New(
+			errors.Wrap(err, "failed to get response from Population types API"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			log.Error(ctx, "error closing http response body", err)
+		}
+	}()
+
+	if err := checkGetResponse(res); err != nil {
+		return GetPopulationTypesResponse{}, err
+	}
+
+	var resp GetPopulationTypesResponse
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return GetPopulationTypesResponse{}, dperrors.New(
+			errors.Wrap(err, "unable to deserialize population types response"),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
### What

Added GetCategorisations func to `population` client including:

Significant refactor to better organise files and types:
- Moved area-type functions to area-types.go
- Created dimensions.go and population-types.go to cater for respective functionality
- Moved client functions to relative file along with contract structs, leaving client.go
- Created contract.go with global contract structs
- Renamed datasetID to population-type in all places

Fixed several mistakes including:
- GetPopulationTypes being completely miswritten
- checkGetResponse not returning an error if response body didn't unmarshal
- checkGetResponse not returning status code returned by service
- Passing on `limit` and `offset` to the url parameters

### How to review

Check changes make sense

### Who can review

Anyone