### PR TITLE
fix: use "items" key instead of struct type

### DIFF
--- a/population/area_types.go
+++ b/population/area_types.go
@@ -37,13 +37,13 @@ type GetAreaTypeParentsInput struct {
 // GetAreaTypesResponse is the response object for GET /area-types
 type GetAreaTypesResponse struct {
 	PaginationResponse
-	AreaTypes []AreaType `json:"area_types"`
+	AreaTypes []AreaType `json:"items"`
 }
 
 // GetAreaTypeParentsResponse is the response object for GET /areas
 type GetAreaTypeParentsResponse struct {
 	PaginationResponse
-	AreaTypes []AreaType `json:"area_types"`
+	AreaTypes []AreaType `json:"items"`
 }
 
 // GetPopulationAreaTypes retrieves the Cantabular area-types associated with a dataset

--- a/population/areas.go
+++ b/population/areas.go
@@ -49,7 +49,7 @@ type GetParentAreaCountInput struct {
 // GetAreasResponse is the response object for GET /areas
 type GetAreasResponse struct {
 	PaginationResponse
-	Areas []Area `json:"areas"`
+	Areas []Area `json:"items"`
 }
 
 // GetAreasResponse is the response object for GET /areas


### PR DESCRIPTION
### What

Change the return keys of the structs in population types area methods to reflect ONS standard 

### How to review

Check that unit tests work  

### Who can review

team b 
