### PR TITLE
Update Subtopics property of the dataset model to be a pointer

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -33,7 +33,7 @@ type DatasetDetails struct {
 	URI               string            `json:"uri,omitempty"`
 	IsBasedOn         *IsBasedOn        `json:"is_based_on,omitempty"`
 	CanonicalTopic    *Topic            `json:"canonical_topic,omitempty"`
-	SubTopics         []Topic           `json:"sub_topics,omitempty"`
+	SubTopics         *[]Topic           `json:"sub_topics,omitempty"`
 }
 
 // Dataset represents a dataset resource
@@ -506,8 +506,11 @@ func (m Metadata) ToString() string {
 	if m.CanonicalTopic != nil {
 		b.WriteString(fmt.Sprintf("Canonical Topic: %s\n", *m.CanonicalTopic))
 	}
-	if len(m.SubTopics) > 0 {
-		b.WriteString(fmt.Sprintf("SubTopics: %s\n", m.SubTopics))
+	if m.SubTopics != nil {
+		subTopics:=*m.SubTopics
+		if len(subTopics) > 0 {
+			b.WriteString(fmt.Sprintf("SubTopics: %s\n", subTopics))
+		}
 	}
 	return b.String()
 }

--- a/dataset/data.go
+++ b/dataset/data.go
@@ -33,7 +33,7 @@ type DatasetDetails struct {
 	URI               string            `json:"uri,omitempty"`
 	IsBasedOn         *IsBasedOn        `json:"is_based_on,omitempty"`
 	CanonicalTopic    *Topic            `json:"canonical_topic,omitempty"`
-	SubTopics         *[]Topic           `json:"sub_topics,omitempty"`
+	SubTopics         *[]Topic          `json:"sub_topics,omitempty"`
 }
 
 // Dataset represents a dataset resource
@@ -507,7 +507,7 @@ func (m Metadata) ToString() string {
 		b.WriteString(fmt.Sprintf("Canonical Topic: %s\n", *m.CanonicalTopic))
 	}
 	if m.SubTopics != nil {
-		subTopics:=*m.SubTopics
+		subTopics := *m.SubTopics
 		if len(subTopics) > 0 {
 			b.WriteString(fmt.Sprintf("SubTopics: %s\n", subTopics))
 		}

--- a/dataset/data_test.go
+++ b/dataset/data_test.go
@@ -90,7 +90,7 @@ func setupMetadata() Metadata {
 				ID:    "canonicalTopicID",
 				Title: "Canonical Topic title",
 			},
-			SubTopics: []Topic{{
+			SubTopics: &[]Topic{{
 				ID:    "secondaryTopic1ID",
 				Title: "Secondary topic 1 title",
 			}, {


### PR DESCRIPTION
### What

Since the `SubTopics` field of the `DatasetDetails` model is an optional field, the user should be able to remove the sub-topics selection once saved to the dataset model. This functionality was lost due to various changes made to the `dp-dataset-api` while fixing another [bug](https://github.com/ONSdigital/dp-dataset-api/pull/379). Wrapping the `SubTopics` update statement in a guard, in the `dp-dataset-api`, is not allowing the user to delete an existing `SubTopics` selection because when an empty slice is passed down from the [dp-publishing-dataset-controller](https://github.com/ONSdigital/dp-publishing-dataset-controller) service to `dp-api-clients-go` library due to the `omitempty` tag in the `dp-api-clients-go` the `SubTopics` key is omitted from the JSON object sent to the `dataset-api`. To fix this issue I had two solutions, either to remove the `omitempty` tag from the `dp-api-clients-go` or to update the `SubTopics` property to be a pointer and I went with the second option since this is the existent pattern in the `dp-api-clients-go` library.

### How to review

Check the code and run the tests.

### Who can review

Anyone
