### PR TITLE
Feature/1183 support census branding

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -505,14 +505,11 @@ func (m Metadata) ToString() string {
 	if m.RelatedDatasets != nil {
 		b.WriteString(fmt.Sprintf("Related Links: %s\n", *m.RelatedDatasets))
 	}
-	if m.CanonicalTopic != nil {
-		b.WriteString(fmt.Sprintf("Canonical Topic: %s\n", *m.CanonicalTopic))
+	if m.CanonicalTopic != (Topic{}) {
+		b.WriteString(fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic))
 	}
-	if m.SubTopics != nil {
-		subTopics := *m.SubTopics
-		if len(subTopics) > 0 {
-			b.WriteString(fmt.Sprintf("SubTopics: %s\n", subTopics))
-		}
+	if len(m.SubTopics) > 0 {
+		b.WriteString(fmt.Sprintf("SubTopics: %s\n", m.SubTopics))
 	}
 	b.WriteString(fmt.Sprintf("Survey: %s\n", m.Survey))
 	return b.String()

--- a/dataset/data.go
+++ b/dataset/data.go
@@ -32,9 +32,9 @@ type DatasetDetails struct {
 	UnitOfMeasure     string            `json:"unit_of_measure,omitempty"`
 	URI               string            `json:"uri,omitempty"`
 	IsBasedOn         *IsBasedOn        `json:"is_based_on,omitempty"`
-	CanonicalTopic    *Topic            `json:"canonical_topic,omitempty"`
-	SubTopics         *[]Topic          `json:"sub_topics,omitempty"`
 	VersionsList      VersionsList      `json:"versions_list,omitempty"`
+	CanonicalTopic    string            `json:"canonical_topic,omitempty"`
+	Subtopics         []string          `json:"subtopics,omitempty"`
 	Survey            string            `json:"survey,omitempty"`
 }
 
@@ -505,11 +505,9 @@ func (m Metadata) ToString() string {
 	if m.RelatedDatasets != nil {
 		b.WriteString(fmt.Sprintf("Related Links: %s\n", *m.RelatedDatasets))
 	}
-	if m.CanonicalTopic != (Topic{}) {
-		b.WriteString(fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic))
-	}
-	if len(m.SubTopics) > 0 {
-		b.WriteString(fmt.Sprintf("SubTopics: %s\n", m.SubTopics))
+	b.WriteString(fmt.Sprintf("Canonical Topic: %s\n", m.CanonicalTopic))
+	if len(m.Subtopics) > 0 {
+		b.WriteString(fmt.Sprintf("Subtopics: %s\n", m.Subtopics))
 	}
 	b.WriteString(fmt.Sprintf("Survey: %s\n", m.Survey))
 	return b.String()

--- a/dataset/data.go
+++ b/dataset/data.go
@@ -35,6 +35,7 @@ type DatasetDetails struct {
 	CanonicalTopic    *Topic            `json:"canonical_topic,omitempty"`
 	SubTopics         *[]Topic          `json:"sub_topics,omitempty"`
 	VersionsList      VersionsList      `json:"versions_list,omitempty"`
+	Survey            string            `json:"survey,omitempty"`
 }
 
 // Dataset represents a dataset resource
@@ -513,6 +514,7 @@ func (m Metadata) ToString() string {
 			b.WriteString(fmt.Sprintf("SubTopics: %s\n", subTopics))
 		}
 	}
+	b.WriteString(fmt.Sprintf("Survey: %s\n", m.Survey))
 	return b.String()
 }
 

--- a/dataset/data_test.go
+++ b/dataset/data_test.go
@@ -97,6 +97,7 @@ func setupMetadata() Metadata {
 				ID:    "secondaryTopic2ID",
 				Title: "Secondary topic 2 title",
 			}},
+			Survey: "census",
 		},
 	}
 
@@ -116,7 +117,8 @@ func expectedData(isEmpty bool) string {
 			"Distribution:\n" +
 			"Unit of measure: \n" +
 			"License: \n" +
-			"National Statistic: false\n"
+			"National Statistic: false\n" +
+			"Survey: \n"
 	}
 
 	return "Title: title\n" +
@@ -141,7 +143,8 @@ func expectedData(isEmpty bool) string {
 		"Publications: [{publication description publication url publication title}]\n" +
 		"Related Links: [{related dataset url related dataset title}]\n" +
 		"Canonical Topic: {canonicalTopicID Canonical Topic title}\n" +
-		"SubTopics: [{secondaryTopic1ID Secondary topic 1 title} {secondaryTopic2ID Secondary topic 2 title}]\n"
+		"SubTopics: [{secondaryTopic1ID Secondary topic 1 title} {secondaryTopic2ID Secondary topic 2 title}]\n" +
+		"Survey: census\n"
 }
 
 // writeToFile, helpful function to write expected and actual outputs for syntax comparison

--- a/dataset/data_test.go
+++ b/dataset/data_test.go
@@ -86,17 +86,11 @@ func setupMetadata() Metadata {
 					Title: "related dataset title",
 				},
 			},
-			CanonicalTopic: Topic{
-				ID:    "canonicalTopicID",
-				Title: "Canonical Topic title",
+			CanonicalTopic: "canonicalTopicID",
+			Subtopics: []string{
+				"secondaryTopic1ID",
+				"secondaryTopic2ID",
 			},
-			SubTopics: []Topic{{
-				ID:    "secondaryTopic1ID",
-				Title: "Secondary topic 1 title",
-			}, {
-				ID:    "secondaryTopic2ID",
-				Title: "Secondary topic 2 title",
-			}},
 			Survey: "census",
 		},
 	}
@@ -118,6 +112,7 @@ func expectedData(isEmpty bool) string {
 			"Unit of measure: \n" +
 			"License: \n" +
 			"National Statistic: false\n" +
+			"Canonical Topic: \n" +
 			"Survey: \n"
 	}
 
@@ -142,8 +137,8 @@ func expectedData(isEmpty bool) string {
 		"National Statistic: true\n" +
 		"Publications: [{publication description publication url publication title}]\n" +
 		"Related Links: [{related dataset url related dataset title}]\n" +
-		"Canonical Topic: {canonicalTopicID Canonical Topic title}\n" +
-		"SubTopics: [{secondaryTopic1ID Secondary topic 1 title} {secondaryTopic2ID Secondary topic 2 title}]\n" +
+		"Canonical Topic: canonicalTopicID\n" +
+		"Subtopics: [secondaryTopic1ID secondaryTopic2ID]\n" +
 		"Survey: census\n"
 }
 

--- a/dataset/data_test.go
+++ b/dataset/data_test.go
@@ -86,11 +86,11 @@ func setupMetadata() Metadata {
 					Title: "related dataset title",
 				},
 			},
-			CanonicalTopic: &Topic{
+			CanonicalTopic: Topic{
 				ID:    "canonicalTopicID",
 				Title: "Canonical Topic title",
 			},
-			SubTopics: &[]Topic{{
+			SubTopics: []Topic{{
 				ID:    "secondaryTopic1ID",
 				Title: "Secondary topic 1 title",
 			}, {


### PR DESCRIPTION
### What

Adds survey field to DatasetDetails model to support census branding for Cantabular datasets. Also reverts Topic fields from pointers to values in line with [changes to the dataset-api.
](https://github.com/ONSdigital/dp-dataset-api/pull/383)

### How to review

Read the code, run the tests, run the journey.

### Who can review

Anyone.
