### PR TITLE
adds related content field to DatasetDetails response dataset model

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -36,6 +36,7 @@ type DatasetDetails struct {
 	CanonicalTopic    string            `json:"canonical_topic,omitempty"`
 	Subtopics         []string          `json:"subtopics,omitempty"`
 	Survey            string            `json:"survey,omitempty"`
+	RelatedContent    *[]GeneralDetails `json:"related_content,omitempty"`
 }
 
 // Dataset represents a dataset resource
@@ -201,9 +202,10 @@ type Metadata struct {
 	DatasetLinks Links `json:"dataset_links,omitempty"`
 }
 
-type Topic struct {
-	ID    string `json:"id,omitempty"`
-	Title string `json:"title,omitempty"`
+type GeneralDetails struct {
+	Description string `json:"description,omitempty"`
+	HRef        string `json:"href,omitempty"`
+	Title       string `json:"title,omitempty"`
 }
 
 // UnmarshalJSON is used to disambiguate the 'links' attribute of the incoming Metadata struct. As currently structured
@@ -510,6 +512,9 @@ func (m Metadata) ToString() string {
 		b.WriteString(fmt.Sprintf("Subtopics: %s\n", m.Subtopics))
 	}
 	b.WriteString(fmt.Sprintf("Survey: %s\n", m.Survey))
+	if m.RelatedContent != nil {
+		b.WriteString(fmt.Sprintf("Related Content: %s\n", *m.RelatedContent))
+	}
 	return b.String()
 }
 

--- a/dataset/data_test.go
+++ b/dataset/data_test.go
@@ -92,6 +92,13 @@ func setupMetadata() Metadata {
 				"secondaryTopic2ID",
 			},
 			Survey: "census",
+			RelatedContent: &[]GeneralDetails{
+				{
+					Description: "related content description",
+					HRef:        "related content url",
+					Title:       "related content title",
+				},
+			},
 		},
 	}
 
@@ -139,7 +146,8 @@ func expectedData(isEmpty bool) string {
 		"Related Links: [{related dataset url related dataset title}]\n" +
 		"Canonical Topic: canonicalTopicID\n" +
 		"Subtopics: [secondaryTopic1ID secondaryTopic2ID]\n" +
-		"Survey: census\n"
+		"Survey: census\n" +
+		"Related Content: [{related content description related content url related content title}]\n"
 }
 
 // writeToFile, helpful function to write expected and actual outputs for syntax comparison


### PR DESCRIPTION
### What

Adds support for related content field in dataset model, for use in Cantabular metadata journey.

### How to review

Read the code and run the tests.

### Who can review

Anyone
