### PR TITLE
questions is now a JS array

### DIFF
--- a/cantabular/metadata.go
+++ b/cantabular/metadata.go
@@ -135,7 +135,7 @@ type MetadataDatasetQuery struct {
 
 					Version graphql.String `graphql:"Version"  json:"version"`
 
-					Questions struct {
+					Questions []struct {
 						QuestionCode             graphql.String `graphql:"Question_Code" json:"question_code"`
 						QuestionFirstAskedInYear graphql.String `graphql:"Question_First_Asked_In_Year" json:"question_first_asked_in_year"`
 						QuestionLabel            graphql.String `graphql:"Question_Label" json:"question_label"`


### PR DESCRIPTION
### What

"failed to make GraphQL query: slice doesn't exist in any of 1 places to unmarshal" error seen with extractor-api running against v1.3 metadata as deployed. Questions is now an array according to SCC so we need a []struct.

### How to review

Quick test: run a local "dp-cantabular-metadata-extractor-api" server via make debug but point at a metadata server port forwarded from sandbox.  Also modify the extractor-api to use this version of "dp-api-clients-go"

curl -v  http://localhost:28300/cantabular-metadata/dataset/TS009/lang/en

should return a JSON response rather than an error



### Who can review

Rafa