### PR TITLE
Fix for total count

### DIFF
--- a/cantabular/contract.go
+++ b/cantabular/contract.go
@@ -8,8 +8,8 @@ type ErrorResponse struct {
 }
 
 type PaginationParams struct {
-	Limit  *int `json:"limit,omitempty"`
-	Offset int  `json:"offset"`
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
 }
 
 type PaginationResponse struct {

--- a/cantabular/contract.go
+++ b/cantabular/contract.go
@@ -8,8 +8,8 @@ type ErrorResponse struct {
 }
 
 type PaginationParams struct {
-	Limit  int `json:"limit"`
-	Offset int `json:"offset"`
+	Limit  *int `json:"limit,omitempty"`
+	Offset int  `json:"offset"`
 }
 
 type PaginationResponse struct {

--- a/cantabular/dimensions.go
+++ b/cantabular/dimensions.go
@@ -478,7 +478,7 @@ func (c *Client) GetGeographyBatchProcess(ctx context.Context, datasetID string,
 		req := GetGeographyDimensionsRequest{
 			PaginationParams: PaginationParams{
 				Offset: offset,
-				Limit:  batchSize,
+				Limit:  &batchSize,
 			},
 			Dataset: datasetID,
 		}

--- a/cantabular/dimensions.go
+++ b/cantabular/dimensions.go
@@ -478,7 +478,7 @@ func (c *Client) GetGeographyBatchProcess(ctx context.Context, datasetID string,
 		req := GetGeographyDimensionsRequest{
 			PaginationParams: PaginationParams{
 				Offset: offset,
-				Limit:  &batchSize,
+				Limit:  batchSize,
 			},
 			Dataset: datasetID,
 		}

--- a/cantabular/dimensions.go
+++ b/cantabular/dimensions.go
@@ -293,6 +293,29 @@ func (c *Client) GetAreas(ctx context.Context, req GetAreasRequest) (*GetAreasRe
 
 	return &resp.Data, nil
 }
+func (c *Client) GetAreasTotalCount(ctx context.Context, req GetAreasRequest) (int, error) {
+	resp := &struct {
+		Data   GetAreasResponse `json:"data"`
+		Errors []gql.Error      `json:"errors,omitempty"`
+	}{}
+
+	data := QueryData{
+		Dataset:  req.Dataset,
+		Text:     req.Variable,
+		Category: req.Category,
+	}
+
+	if err := c.queryUnmarshal(ctx, QueryAreasWithoutPagination, data, resp); err != nil {
+		return -1, errors.Wrap(err, "failed to unmarshal query")
+	}
+
+	var totalCount int
+	for _, v := range resp.Data.Dataset.Variables.Edges {
+		totalCount = totalCount + len(v.Node.Categories.Search.Edges)
+	}
+
+	return totalCount, nil
+}
 
 // GetArea performs a graphQL query to retrieve the exact area (category) for a given area type
 func (c *Client) GetArea(ctx context.Context, req GetAreaRequest) (*GetAreaResponse, error) {

--- a/cantabular/dimensions.go
+++ b/cantabular/dimensions.go
@@ -293,6 +293,7 @@ func (c *Client) GetAreas(ctx context.Context, req GetAreasRequest) (*GetAreasRe
 
 	return &resp.Data, nil
 }
+
 func (c *Client) GetAreasTotalCount(ctx context.Context, req GetAreasRequest) (int, error) {
 	resp := &struct {
 		Data   GetAreasResponse `json:"data"`

--- a/cantabular/dimensions_test.go
+++ b/cantabular/dimensions_test.go
@@ -1175,6 +1175,10 @@ func TestGetCategorisationsHappy(t *testing.T) {
 					mockHttpClient.PostCalls()[0].Body,
 					cantabular.QueryCategorisations,
 					cantabular.QueryData{
+						PaginationParams: cantabular.PaginationParams{
+							Limit:  20,
+							Offset: 0,
+						},
 						Dataset: dataset,
 						Text:    variable,
 					},

--- a/cantabular/dimensions_test.go
+++ b/cantabular/dimensions_test.go
@@ -14,6 +14,10 @@ import (
 	dphttp "github.com/ONSdigital/dp-net/http"
 )
 
+var limit20 *int = nil //non initialised limit is treated as default i.e. 20
+var limit10 = 10
+var limit1 = 1
+
 func TestGetBaseVariable(t *testing.T) {
 	Convey("Given a correct getBaseVariables response from the /graphql endpoint", t, func() {
 		testCtx := context.Background()
@@ -129,7 +133,7 @@ func TestGetGeographyDimensionsHappy(t *testing.T) {
 			resp, err := cantabularClient.GetGeographyDimensions(testCtx, cantabular.GetGeographyDimensionsRequest{
 				Dataset: "Teaching-Dataset",
 				PaginationParams: cantabular.PaginationParams{
-					Limit:  10,
+					Limit:  &limit10,
 					Offset: 0,
 				},
 			})
@@ -147,7 +151,7 @@ func TestGetGeographyDimensionsHappy(t *testing.T) {
 					cantabular.QueryData{
 						Dataset: "Teaching-Dataset",
 						PaginationParams: cantabular.PaginationParams{
-							Limit:  10,
+							Limit:  &limit10,
 							Offset: 0,
 						},
 					},
@@ -170,7 +174,7 @@ func TestGetGeographyDimensionsUnhappy(t *testing.T) {
 			resp, err := cantabularClient.GetGeographyDimensions(testCtx, cantabular.GetGeographyDimensionsRequest{
 				Dataset: "InexistentDataset",
 				PaginationParams: cantabular.PaginationParams{
-					Limit:  10,
+					Limit:  &limit10,
 					Offset: 0,
 				},
 			})
@@ -193,7 +197,7 @@ func TestGetGeographyDimensionsUnhappy(t *testing.T) {
 			resp, err := cantabularClient.GetGeographyDimensions(testCtx, cantabular.GetGeographyDimensionsRequest{
 				Dataset: "Teaching-Dataset",
 				PaginationParams: cantabular.PaginationParams{
-					Limit:  10,
+					Limit:  &limit10,
 					Offset: 0,
 				},
 			})
@@ -645,6 +649,7 @@ func TestGetAggregatedDimensionOptionsUnhappy(t *testing.T) {
 }
 
 func TestGetAreas(t *testing.T) {
+	limit := 1
 	Convey("Given a valid response from the /graphql endpoint", t, func() {
 		const dataset = "Example"
 		const variable = "city"
@@ -656,7 +661,7 @@ func TestGetAreas(t *testing.T) {
 		Convey("When GetAreas is called", func() {
 			req := cantabular.GetAreasRequest{
 				PaginationParams: cantabular.PaginationParams{
-					Limit:  1,
+					Limit:  &limit,
 					Offset: 0,
 				},
 				Dataset:  dataset,
@@ -678,7 +683,7 @@ func TestGetAreas(t *testing.T) {
 					cantabular.QueryAreas,
 					cantabular.QueryData{
 						PaginationParams: cantabular.PaginationParams{
-							Limit:  1,
+							Limit:  &limit,
 							Offset: 0,
 						},
 						Dataset:  dataset,
@@ -834,7 +839,7 @@ func TestGetParentsHappy(t *testing.T) {
 
 		Convey("When GetParents is called", func() {
 			req := cantabular.GetParentsRequest{
-				PaginationParams: cantabular.PaginationParams{Limit: 20},
+				PaginationParams: cantabular.PaginationParams{Limit: limit20},
 				Dataset:          dataset,
 				Variable:         variable,
 			}
@@ -853,7 +858,7 @@ func TestGetParentsHappy(t *testing.T) {
 					cantabular.QueryData{
 						Dataset:          dataset,
 						Variables:        []string{variable},
-						PaginationParams: cantabular.PaginationParams{Limit: 20},
+						PaginationParams: cantabular.PaginationParams{Limit: limit20},
 					},
 				)
 			})
@@ -997,6 +1002,7 @@ func TestGetParentAreaCountUnhappy(t *testing.T) {
 }
 
 func TestGetGeographyDimensionsInBatchesHappy(t *testing.T) {
+	limit := 1
 	Convey("Given a valid empty response from the /graphql endpoint", t, func() {
 		multiResponse := struct {
 			responses []string
@@ -1042,7 +1048,7 @@ func TestGetGeographyDimensionsInBatchesHappy(t *testing.T) {
 						cantabular.QueryData{
 							Dataset: "Teaching-Dataset",
 							PaginationParams: cantabular.PaginationParams{
-								Limit:  1,
+								Limit:  &limit,
 								Offset: 0,
 							},
 						},
@@ -1054,7 +1060,7 @@ func TestGetGeographyDimensionsInBatchesHappy(t *testing.T) {
 						cantabular.QueryData{
 							Dataset: "Teaching-Dataset",
 							PaginationParams: cantabular.PaginationParams{
-								Limit:  1,
+								Limit:  &limit,
 								Offset: 1,
 							},
 						},
@@ -1111,7 +1117,7 @@ func TestGetGeographyDimensionsInBatchesZeroHappy(t *testing.T) {
 						cantabular.QueryData{
 							Dataset: "Teaching-Dataset",
 							PaginationParams: cantabular.PaginationParams{
-								Limit:  10,
+								Limit:  &limit10,
 								Offset: 0,
 							},
 						},
@@ -1156,7 +1162,7 @@ func TestGetCategorisationsHappy(t *testing.T) {
 		Convey("When GetCategorisations is called", func() {
 			req := cantabular.GetCategorisationsRequest{
 				PaginationParams: cantabular.PaginationParams{
-					Limit:  20,
+					Limit:  limit20,
 					Offset: 0,
 				},
 				Dataset:  dataset,
@@ -1176,7 +1182,7 @@ func TestGetCategorisationsHappy(t *testing.T) {
 					cantabular.QueryCategorisations,
 					cantabular.QueryData{
 						PaginationParams: cantabular.PaginationParams{
-							Limit:  20,
+							Limit:  limit20,
 							Offset: 0,
 						},
 						Dataset: dataset,
@@ -1594,7 +1600,7 @@ var expectedGeographyDimensions = cantabular.GetGeographyDimensionsResponse{
 		Count:      2,
 		TotalCount: 2,
 		PaginationParams: cantabular.PaginationParams{
-			Limit:  10,
+			Limit:  &limit10,
 			Offset: 0,
 		},
 	},
@@ -2103,7 +2109,7 @@ var mockRespBodyGetArea = `
 var expectedAreas = cantabular.GetAreasResponse{
 	PaginationResponse: cantabular.PaginationResponse{
 		PaginationParams: cantabular.PaginationParams{
-			Limit: 1,
+			Limit: &limit1,
 		},
 		Count: 1, TotalCount: 100,
 	},
@@ -2203,7 +2209,7 @@ const mockRespBodyGetParents = `
 
 var expectedParents = cantabular.GetParentsResponse{
 	PaginationResponse: cantabular.PaginationResponse{
-		PaginationParams: cantabular.PaginationParams{Limit: 20, Offset: 0},
+		PaginationParams: cantabular.PaginationParams{Limit: limit20, Offset: 0},
 		TotalCount:       1,
 		Count:            1,
 	},
@@ -2269,7 +2275,7 @@ const mockRespBodyGetCategorisations = `
 
 var expectedCategorisations = &cantabular.GetCategorisationsResponse{
 	PaginationResponse: cantabular.PaginationResponse{
-		PaginationParams: cantabular.PaginationParams{Limit: 20, Offset: 0},
+		PaginationParams: cantabular.PaginationParams{Limit: limit20, Offset: 0},
 		Count:            1,
 		TotalCount:       1,
 	},

--- a/cantabular/dimensions_test.go
+++ b/cantabular/dimensions_test.go
@@ -14,10 +14,6 @@ import (
 	dphttp "github.com/ONSdigital/dp-net/http"
 )
 
-var limit20 *int = nil //non initialised limit is treated as default i.e. 20
-var limit10 = 10
-var limit1 = 1
-
 func TestGetBaseVariable(t *testing.T) {
 	Convey("Given a correct getBaseVariables response from the /graphql endpoint", t, func() {
 		testCtx := context.Background()
@@ -133,7 +129,7 @@ func TestGetGeographyDimensionsHappy(t *testing.T) {
 			resp, err := cantabularClient.GetGeographyDimensions(testCtx, cantabular.GetGeographyDimensionsRequest{
 				Dataset: "Teaching-Dataset",
 				PaginationParams: cantabular.PaginationParams{
-					Limit:  &limit10,
+					Limit:  10,
 					Offset: 0,
 				},
 			})
@@ -151,7 +147,7 @@ func TestGetGeographyDimensionsHappy(t *testing.T) {
 					cantabular.QueryData{
 						Dataset: "Teaching-Dataset",
 						PaginationParams: cantabular.PaginationParams{
-							Limit:  &limit10,
+							Limit:  10,
 							Offset: 0,
 						},
 					},
@@ -174,7 +170,7 @@ func TestGetGeographyDimensionsUnhappy(t *testing.T) {
 			resp, err := cantabularClient.GetGeographyDimensions(testCtx, cantabular.GetGeographyDimensionsRequest{
 				Dataset: "InexistentDataset",
 				PaginationParams: cantabular.PaginationParams{
-					Limit:  &limit10,
+					Limit:  10,
 					Offset: 0,
 				},
 			})
@@ -197,7 +193,7 @@ func TestGetGeographyDimensionsUnhappy(t *testing.T) {
 			resp, err := cantabularClient.GetGeographyDimensions(testCtx, cantabular.GetGeographyDimensionsRequest{
 				Dataset: "Teaching-Dataset",
 				PaginationParams: cantabular.PaginationParams{
-					Limit:  &limit10,
+					Limit:  10,
 					Offset: 0,
 				},
 			})
@@ -649,7 +645,6 @@ func TestGetAggregatedDimensionOptionsUnhappy(t *testing.T) {
 }
 
 func TestGetAreas(t *testing.T) {
-	limit := 1
 	Convey("Given a valid response from the /graphql endpoint", t, func() {
 		const dataset = "Example"
 		const variable = "city"
@@ -661,7 +656,7 @@ func TestGetAreas(t *testing.T) {
 		Convey("When GetAreas is called", func() {
 			req := cantabular.GetAreasRequest{
 				PaginationParams: cantabular.PaginationParams{
-					Limit:  &limit,
+					Limit:  1,
 					Offset: 0,
 				},
 				Dataset:  dataset,
@@ -683,7 +678,7 @@ func TestGetAreas(t *testing.T) {
 					cantabular.QueryAreas,
 					cantabular.QueryData{
 						PaginationParams: cantabular.PaginationParams{
-							Limit:  &limit,
+							Limit:  1,
 							Offset: 0,
 						},
 						Dataset:  dataset,
@@ -839,7 +834,7 @@ func TestGetParentsHappy(t *testing.T) {
 
 		Convey("When GetParents is called", func() {
 			req := cantabular.GetParentsRequest{
-				PaginationParams: cantabular.PaginationParams{Limit: limit20},
+				PaginationParams: cantabular.PaginationParams{Limit: 20},
 				Dataset:          dataset,
 				Variable:         variable,
 			}
@@ -858,7 +853,7 @@ func TestGetParentsHappy(t *testing.T) {
 					cantabular.QueryData{
 						Dataset:          dataset,
 						Variables:        []string{variable},
-						PaginationParams: cantabular.PaginationParams{Limit: limit20},
+						PaginationParams: cantabular.PaginationParams{Limit: 20},
 					},
 				)
 			})
@@ -1002,7 +997,6 @@ func TestGetParentAreaCountUnhappy(t *testing.T) {
 }
 
 func TestGetGeographyDimensionsInBatchesHappy(t *testing.T) {
-	limit := 1
 	Convey("Given a valid empty response from the /graphql endpoint", t, func() {
 		multiResponse := struct {
 			responses []string
@@ -1048,7 +1042,7 @@ func TestGetGeographyDimensionsInBatchesHappy(t *testing.T) {
 						cantabular.QueryData{
 							Dataset: "Teaching-Dataset",
 							PaginationParams: cantabular.PaginationParams{
-								Limit:  &limit,
+								Limit:  1,
 								Offset: 0,
 							},
 						},
@@ -1060,7 +1054,7 @@ func TestGetGeographyDimensionsInBatchesHappy(t *testing.T) {
 						cantabular.QueryData{
 							Dataset: "Teaching-Dataset",
 							PaginationParams: cantabular.PaginationParams{
-								Limit:  &limit,
+								Limit:  1,
 								Offset: 1,
 							},
 						},
@@ -1117,7 +1111,7 @@ func TestGetGeographyDimensionsInBatchesZeroHappy(t *testing.T) {
 						cantabular.QueryData{
 							Dataset: "Teaching-Dataset",
 							PaginationParams: cantabular.PaginationParams{
-								Limit:  &limit10,
+								Limit:  10,
 								Offset: 0,
 							},
 						},
@@ -1162,7 +1156,7 @@ func TestGetCategorisationsHappy(t *testing.T) {
 		Convey("When GetCategorisations is called", func() {
 			req := cantabular.GetCategorisationsRequest{
 				PaginationParams: cantabular.PaginationParams{
-					Limit:  limit20,
+					Limit:  20,
 					Offset: 0,
 				},
 				Dataset:  dataset,
@@ -1182,7 +1176,7 @@ func TestGetCategorisationsHappy(t *testing.T) {
 					cantabular.QueryCategorisations,
 					cantabular.QueryData{
 						PaginationParams: cantabular.PaginationParams{
-							Limit:  limit20,
+							Limit:  20,
 							Offset: 0,
 						},
 						Dataset: dataset,
@@ -1600,7 +1594,7 @@ var expectedGeographyDimensions = cantabular.GetGeographyDimensionsResponse{
 		Count:      2,
 		TotalCount: 2,
 		PaginationParams: cantabular.PaginationParams{
-			Limit:  &limit10,
+			Limit:  10,
 			Offset: 0,
 		},
 	},
@@ -2109,7 +2103,7 @@ var mockRespBodyGetArea = `
 var expectedAreas = cantabular.GetAreasResponse{
 	PaginationResponse: cantabular.PaginationResponse{
 		PaginationParams: cantabular.PaginationParams{
-			Limit: &limit1,
+			Limit: 1,
 		},
 		Count: 1, TotalCount: 100,
 	},
@@ -2209,7 +2203,7 @@ const mockRespBodyGetParents = `
 
 var expectedParents = cantabular.GetParentsResponse{
 	PaginationResponse: cantabular.PaginationResponse{
-		PaginationParams: cantabular.PaginationParams{Limit: limit20, Offset: 0},
+		PaginationParams: cantabular.PaginationParams{Limit: 20, Offset: 0},
 		TotalCount:       1,
 		Count:            1,
 	},
@@ -2275,7 +2269,7 @@ const mockRespBodyGetCategorisations = `
 
 var expectedCategorisations = &cantabular.GetCategorisationsResponse{
 	PaginationResponse: cantabular.PaginationResponse{
-		PaginationParams: cantabular.PaginationParams{Limit: limit20, Offset: 0},
+		PaginationParams: cantabular.PaginationParams{Limit: 20, Offset: 0},
 		Count:            1,
 		TotalCount:       1,
 	},

--- a/cantabular/queries.go
+++ b/cantabular/queries.go
@@ -247,6 +247,33 @@ query ($dataset: String!, $text: String!, $category: String!, $limit: Int!, $off
   }
 `
 
+// QueryAreasWithoutPagination is the graphQL query to search for areas and area types which match a specific string.
+const QueryAreasWithoutPagination = `
+query ($dataset: String!, $text: String!, $category: String!) {
+	dataset(name: $dataset) {
+	  variables(rule:true, names: [ $text ]) {
+		edges {
+		  node {
+			name
+			label
+			categories {
+			  totalCount
+			  search(text: $category ) {
+				edges {
+				  node {
+					code
+					label
+				  }
+				}
+			  }
+			}
+		  }
+		}
+	  }
+	}
+  }
+`
+
 // QueryArea is the graphQL query to search for an area which exactly match a specific string.
 const QueryArea = `
 query ($dataset: String!, $text: String!, $category: String!) {
@@ -271,32 +298,6 @@ query ($dataset: String!, $text: String!, $category: String!) {
 }
 `
 
-// QueryAreasWithoutPagination is the graphQL query to search for areas and area types which match a specific string.
-const QueryAreasWithoutPagination = `
-query ($dataset: String!, $text: String!, $category: String!, $limit: Int!, $offset: Int) {
-	dataset(name: $dataset) {
-	  variables(rule:true, names: [ $text ]) {
-		edges {
-		  node {
-			name
-			label
-			categories {
-			  totalCount
-			  search(text: $category ) {
-				edges {
-				  node {
-					code
-					label
-				  }
-				}
-			  }
-			}
-		  }
-		}
-	  }
-	}
-  }
-`
 const QueryParents = `
 query ($dataset: String!, $variables: [String!]!, $limit: Int!, $offset: Int) {
   dataset(name: $dataset) {
@@ -387,9 +388,6 @@ func (data *QueryData) Encode(query string) (bytes.Buffer, error) {
 	var b bytes.Buffer
 	enc := json.NewEncoder(&b)
 
-	if data.Limit == 0 {
-		data.Limit = defaultLimit
-	}
 	vars := map[string]interface{}{
 		"dataset":   data.Dataset,
 		"variables": data.Variables,

--- a/cantabular/queries.go
+++ b/cantabular/queries.go
@@ -271,6 +271,32 @@ query ($dataset: String!, $text: String!, $category: String!) {
 }
 `
 
+// QueryAreasWithoutPagination is the graphQL query to search for areas and area types which match a specific string.
+const QueryAreasWithoutPagination = `
+query ($dataset: String!, $text: String!, $category: String!, $limit: Int!, $offset: Int) {
+	dataset(name: $dataset) {
+	  variables(rule:true, names: [ $text ]) {
+		edges {
+		  node {
+			name
+			label
+			categories {
+			  totalCount
+			  search(text: $category ) {
+				edges {
+				  node {
+					code
+					label
+				  }
+				}
+			  }
+			}
+		  }
+		}
+	  }
+	}
+  }
+`
 const QueryParents = `
 query ($dataset: String!, $variables: [String!]!, $limit: Int!, $offset: Int) {
   dataset(name: $dataset) {

--- a/cantabular/queries.go
+++ b/cantabular/queries.go
@@ -12,7 +12,9 @@ import (
 	"github.com/ONSdigital/log.go/v2/log"
 )
 
-var defaultLimit = 20
+const (
+	defaultLimit = 20
+)
 
 const QueryBaseVariable = `
 query ($dataset: String!, $variables: [String!]!) {
@@ -386,10 +388,9 @@ func (data *QueryData) Encode(query string) (bytes.Buffer, error) {
 	var b bytes.Buffer
 	enc := json.NewEncoder(&b)
 
-	if data.Limit == nil {
-		data.Limit = &defaultLimit
+	if data.Limit == 0 {
+		data.Limit = defaultLimit
 	}
-
 	vars := map[string]interface{}{
 		"dataset":   data.Dataset,
 		"variables": data.Variables,

--- a/cantabular/queries.go
+++ b/cantabular/queries.go
@@ -12,9 +12,7 @@ import (
 	"github.com/ONSdigital/log.go/v2/log"
 )
 
-const (
-	defaultLimit = 20
-)
+var defaultLimit = 20
 
 const QueryBaseVariable = `
 query ($dataset: String!, $variables: [String!]!) {
@@ -387,6 +385,10 @@ type Filter struct {
 func (data *QueryData) Encode(query string) (bytes.Buffer, error) {
 	var b bytes.Buffer
 	enc := json.NewEncoder(&b)
+
+	if data.Limit == nil {
+		data.Limit = &defaultLimit
+	}
 
 	vars := map[string]interface{}{
 		"dataset":   data.Dataset,


### PR DESCRIPTION
### What

If a total count is included in the response for a Cantabular query, it always return the count of super-set and not the subset based on search criteria.This change is to return the total count based on the result of search criteria 

### How to review

All test are :green_circle: 

### Who can review

Anyone
