### PR TITLE
Fix/remove slash prefix

### DIFF
--- a/population/dimensions.go
+++ b/population/dimensions.go
@@ -66,7 +66,7 @@ func (c *Client) GetDimensions(ctx context.Context, input GetDimensionsInput) (G
 		"search_string":   input.SearchString,
 	}
 
-	urlPath := fmt.Sprintf("/population-types/%s/dimensions", input.PopulationType)
+	urlPath := fmt.Sprintf("population-types/%s/dimensions", input.PopulationType)
 	urlValues := url.Values{
 		"limit":  []string{strconv.Itoa(input.Limit)},
 		"offset": []string{strconv.Itoa(input.Offset)},
@@ -126,7 +126,7 @@ func (c *Client) GetCategorisations(ctx context.Context, input GetCategorisation
 		"dimension":       input.Dimension,
 	}
 
-	urlPath := fmt.Sprintf("/population-types/%s/dimensions/%s/categorisations", input.PopulationType, input.Dimension)
+	urlPath := fmt.Sprintf("population-types/%s/dimensions/%s/categorisations", input.PopulationType, input.Dimension)
 	urlValues := url.Values{
 		"limit":  []string{strconv.Itoa(input.Limit)},
 		"offset": []string{strconv.Itoa(input.Offset)},
@@ -181,7 +181,7 @@ func (c *Client) GetBaseVariable(ctx context.Context, input GetBaseVariableInput
 		"variable":        input.Variable,
 	}
 
-	urlPath := fmt.Sprintf("/population-types/%s/dimensions/%s/base", input.PopulationType, input.Variable)
+	urlPath := fmt.Sprintf("population-types/%s/dimensions/%s/base", input.PopulationType, input.Variable)
 
 	req, err := c.createGetRequest(ctx, input.UserAuthToken, input.ServiceAuthToken, urlPath, nil)
 	if err != nil {

--- a/population/dimensions_test.go
+++ b/population/dimensions_test.go
@@ -40,7 +40,7 @@ func TestGetDimensions(t *testing.T) {
 			calls := stubClient.DoCalls()
 			So(calls, ShouldNotBeEmpty)
 			fmt.Println(calls[0].Req.URL.String())
-			So(calls[0].Req.URL.String(), ShouldEqual, "http://test.test:2000/population-types/populationId/dimensions?limit=0&offset=0&q=searchString")
+			So(calls[0].Req.URL.String(), ShouldEqual, "http://test.test:2000/v1/population-types/populationId/dimensions?limit=0&offset=0&q=searchString")
 		})
 	})
 
@@ -259,7 +259,7 @@ func TestGetCategorisations(t *testing.T) {
 				calls := stubClient.DoCalls()
 				So(calls, ShouldNotBeEmpty)
 				fmt.Println(calls[0].Req.URL.String())
-				So(calls[0].Req.URL.String(), ShouldEqual, "http://test.test:2000/population-types/population-id/dimensions/dimension-id/categorisations?limit=10&offset=0")
+				So(calls[0].Req.URL.String(), ShouldEqual, "http://test.test:2000/v1/population-types/population-id/dimensions/dimension-id/categorisations?limit=10&offset=0")
 			})
 
 			Convey("And A list of categorisations should be returned", func() {


### PR DESCRIPTION
### What

Removed slash prefix from the `urlPath` as this was causing the `v1` from being dropped from the URL

### How to review

Sense check
Tests pass

### Who can review

!me
