### PR TITLE
Feature/allow supplemenntary variable for parent area count

### DIFF
--- a/cantabular/contract.go
+++ b/cantabular/contract.go
@@ -184,12 +184,13 @@ type GetCategorisationsResponse struct {
 	Dataset gql.Dataset `json:"dataset"`
 }
 
-// GetParentAreaCountRequest holds the input parameters for the GetParents query
+// GetParentAreaCountRequest holds the input parameters for the GetParentAreaCount query
 type GetParentAreaCountRequest struct {
-	Dataset  string
-	Variable string
-	Parent   string
-	Codes    []string
+	Dataset   string
+	Variable  string
+	Parent    string
+	SVariable string
+	Codes     []string
 }
 
 // GetParentAreaCountResponse is the response body for the GetParentAreaCount query

--- a/cantabular/dimensions.go
+++ b/cantabular/dimensions.go
@@ -2,6 +2,7 @@ package cantabular
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/batch"
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular/gql"
@@ -435,8 +436,15 @@ func (c *Client) GetParentAreaCount(ctx context.Context, req GetParentAreaCountR
 	}
 
 	// should be impossible but to avoid panic
-	if len(resp.Data.Dataset.Table.Dimensions) != 1 {
-		return nil, errors.New("invalid response from graphQL")
+	if l := len(resp.Data.Dataset.Table.Dimensions); l != 1 && l != 2 {
+		return nil, dperrors.New(
+			errors.New("invalid response from graphQL"),
+			http.StatusInternalServerError,
+			log.Data{
+				"expected_response_length": "1-2",
+				"response_length":          l,
+			},
+		)
 	}
 
 	return &GetParentAreaCountResult{

--- a/cantabular/dimensions.go
+++ b/cantabular/dimensions.go
@@ -415,6 +415,9 @@ func (c *Client) GetParentAreaCount(ctx context.Context, req GetParentAreaCountR
 			},
 		},
 	}
+	if sVar := req.SVariable; len(sVar) > 0 {
+		data.Variables = append(data.Variables, sVar)
+	}
 
 	if err := c.queryUnmarshal(ctx, QueryParentAreaCount, data, resp); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal query")

--- a/cantabular/dimensions_test.go
+++ b/cantabular/dimensions_test.go
@@ -1043,6 +1043,49 @@ func TestGetParentAreaCountHappy(t *testing.T) {
 				So(*resp, ShouldResemble, expectedParentAreaCount)
 			})
 		})
+
+		Convey("Given a supplemtary variable is also provided", func() {
+			sVar := "hh_tenura_7a"
+
+			req := cantabular.GetParentAreaCountRequest{
+				Dataset:   dataset,
+				Variable:  variable,
+				Parent:    parent,
+				Codes:     codes,
+				SVariable: sVar,
+			}
+
+			Convey("When GetParents is called", func() {
+
+				resp, err := cantabularClient.GetParentAreaCount(ctx, req)
+				Convey("Then no error should be returned", func() {
+					So(err, ShouldBeNil)
+				})
+
+				Convey("And the expected query is posted to cantabular api-ext", func() {
+					So(mockHttpClient.PostCalls(), ShouldHaveLength, 1)
+					So(mockHttpClient.PostCalls()[0].URL, ShouldEqual, "cantabular.ext.host/graphql")
+					validateQuery(
+						mockHttpClient.PostCalls()[0].Body,
+						cantabular.QueryParentAreaCount,
+						cantabular.QueryData{
+							Dataset:   dataset,
+							Variables: []string{variable, sVar},
+							Filters: []cantabular.Filter{
+								{
+									Variable: parent,
+									Codes:    codes,
+								},
+							},
+						},
+					)
+				})
+
+				Convey("And the expected response is returned", func() {
+					So(*resp, ShouldResemble, expectedParentAreaCount)
+				})
+			})
+		})
 	})
 }
 


### PR DESCRIPTION
### What

Update GetParentAreaCount query to allow supplementary variable to be added to query when needed (for prebuilt tables)

### How to review

Check changes make sense 

### Who can review

Anyone