### PR TITLE
Add UsageNotes to datasetDetails

### DIFF
--- a/dataset/data.go
+++ b/dataset/data.go
@@ -30,6 +30,7 @@ type DatasetDetails struct {
 	Title             string            `json:"title,omitempty"`
 	Type              string            `json:"type,omitempty"`
 	UnitOfMeasure     string            `json:"unit_of_measure,omitempty"`
+	UsageNotes        *[]UsageNote      `json:"usage_notes,omitempty"`
 	URI               string            `json:"uri,omitempty"`
 	IsBasedOn         *IsBasedOn        `json:"is_based_on,omitempty"`
 	VersionsList      VersionsList      `json:"versions_list,omitempty"`


### PR DESCRIPTION
### What

Add UsageNotes back to DatasetDetails, to prevent observation-api from breaking when it's updated.

### How to review

- Make sure change is ok and compatible with observation api.

### Who can review

@redhug1 