### PR TITLE
feat: default categorisation change

### DIFF
--- a/cantabularmetadata/classification.go
+++ b/cantabularmetadata/classification.go
@@ -3,7 +3,6 @@ package cantabularmetadata
 import (
 	"context"
 	"errors"
-	"net/http"
 
 	dperrors "github.com/ONSdigital/dp-api-clients-go/v2/errors"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -37,26 +36,11 @@ func (c *Client) GetDefaultClassification(ctx context.Context, req GetDefaultCla
 
 	for _, v := range res.Data.Dataset.Vars {
 		if v.Meta.DefaultClassificationFlag == "Y" {
-			resp.Variable = v.Name
 			defaultVars = append(defaultVars, v.Name)
 		}
 	}
 
-	if len(defaultVars) == 0 {
-		return nil, dperrors.New(
-			errors.New("no provided variable set as default classification"),
-			http.StatusBadRequest,
-			nil,
-		)
-	}
-
-	if len(defaultVars) > 1 {
-		return nil, dperrors.New(
-			errors.New("multiple provided variables set as default classification"),
-			http.StatusBadRequest,
-			log.Data{"default_variables": defaultVars},
-		)
-	}
+	resp.Variables = defaultVars
 
 	return &resp, nil
 }

--- a/cantabularmetadata/classification_test.go
+++ b/cantabularmetadata/classification_test.go
@@ -42,7 +42,7 @@ func TestGetDefaultClassificationHappy(t *testing.T) {
 			})
 
 			expected := &cantabularmetadata.GetDefaultClassificationResponse{
-				Variable: "test_variable_2",
+				Variables: []string{"test_variable_2"},
 			}
 
 			Convey("And the expected response is returned", func() {
@@ -66,8 +66,7 @@ func TestGetDefaultClassificationNoDefaultVariables(t *testing.T) {
 			resp, err := client.GetDefaultClassification(ctx, req)
 
 			Convey("Then the experected error should be returned", func() {
-				So(err, ShouldNotBeNil)
-				So(client.StatusCode(err), ShouldEqual, http.StatusBadRequest)
+				So(err, ShouldBeNil)
 			})
 
 			Convey("And the expected query is posted to cantabular metadata service", func() {
@@ -83,8 +82,10 @@ func TestGetDefaultClassificationNoDefaultVariables(t *testing.T) {
 				)
 			})
 
-			Convey("And the response should be nil", func() {
-				So(resp, ShouldBeNil)
+			expected := &cantabularmetadata.GetDefaultClassificationResponse{}
+
+			Convey("And the expected response should be returned", func() {
+				So(resp, ShouldResemble, expected)
 			})
 		})
 	})
@@ -103,9 +104,8 @@ func TestGetDefaultClassificationMultipleDefaultVariables(t *testing.T) {
 
 			resp, err := client.GetDefaultClassification(ctx, req)
 
-			Convey("Then the experected error should be returned", func() {
-				So(err, ShouldNotBeNil)
-				So(client.StatusCode(err), ShouldEqual, http.StatusBadRequest)
+			Convey("Then the experected error should be nil", func() {
+				So(err, ShouldBeNil)
 			})
 
 			Convey("And the expected query is posted to cantabular metadata service", func() {
@@ -121,8 +121,11 @@ func TestGetDefaultClassificationMultipleDefaultVariables(t *testing.T) {
 				)
 			})
 
+			expected := &cantabularmetadata.GetDefaultClassificationResponse{
+				Variables: []string{"test_variable_1", "test_variable_2"},
+			}
 			Convey("And the response should be nil", func() {
-				So(resp, ShouldBeNil)
+				So(resp, ShouldResemble, expected)
 			})
 		})
 	})

--- a/cantabularmetadata/contract.go
+++ b/cantabularmetadata/contract.go
@@ -11,7 +11,7 @@ type GetDefaultClassificationRequest struct {
 }
 
 type GetDefaultClassificationResponse struct {
-	Variable string
+	Variables []string
 }
 
 type Data struct {


### PR DESCRIPTION
### What
Amend default categorisation method to handle less failure cases (and send responsibility of that to the server)
change response to return list instead of string as main struct variable
Amend tests to reflect lesser error handling
