### PR TITLE
Release v2.32.1 - retract bad versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,3 +31,7 @@ require (
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 )
+
+retract (
+	[v2.226.0,v2.227.0] // contains breaking code
+)

--- a/population/population_types.go
+++ b/population/population_types.go
@@ -13,7 +13,9 @@ import (
 )
 
 type PopulationType struct {
-	Name string `json:"name"`
+	Name        string `json:"name"`
+	Label       string `json:"label"`
+	Description string `json:"description"`
 }
 
 type GetPopulationTypesInput struct {


### PR DESCRIPTION
### What

Restore git history of deleted v2.226.0 and v2.227.0 releases. Also add retraction notice to the go.mod so they aren't used.

### How to review

Ensure tests pass, history looks good and `retract` block looks correct.

### Who can review

Anyone but me