### PR TITLE
Removes catLabels field from extractor response

### DIFF
--- a/cantabular/metadata.go
+++ b/cantabular/metadata.go
@@ -166,7 +166,6 @@ type MetadataDatasetQuery struct {
 					TopicTitle       graphql.String `graphql:"Topic_Title" json:"topic_title"`
 				} `graphql:"Topics" json:"topics"`
 			} `json:"meta"`
-			CatLabels *graphql.String `graphql:"catLabels" json:"catLabels,omitempty"`
 		} `graphql:"vars(names: $vars)" json:"vars"`
 	} `graphql:"dataset(name: $ds, lang: $lang)" json:"dataset"`
 }


### PR DESCRIPTION
### What

`failed to make GraphQL query: struct field for "E06000001" doesn't exist in any of 1 places to unmarshal` error seen with `extractor-api` running against the latest version of metadata in sandbox at the time of writing. `CatLabels` was originally declared of type string and it was returned as `null` by the previous metadata versions, but it seems that in the most recent version it is an object, hence the error. As a fix, instead of updating the field type, it was agreed to remove the `catLabels` field from the extractor response since it isn't referenced anywhere in the cantabular journey. (ticket#1436)

### How to review

Quick test: run a local "dp-cantabular-metadata-extractor-api" server via make debug but point at a metadata server port forwarded from sandbox. Also modify the `extractor-api` to use this version of `dp-api-clients-go`.

curl -v http://localhost:28300/cantabular-metadata/dataset/TS002/lang/en

should return a JSON response rather than an error

### Who can review

Anyone
