### PR TITLE
Added support for new query to get type of dataset

### DIFF
--- a/cantabular/queries.go
+++ b/cantabular/queries.go
@@ -36,6 +36,14 @@ query ($dataset: String!, $variables: [String!]!) {
 	}
 }`
 
+// Query static dataset type
+const QueryStaticDatasetType = `
+query($dataset: String!){
+	dataset(name: $dataset) {
+	  type
+	}
+}`
+
 // QueryStaticDataset is the graphQL query to obtain static dataset counts (variables with categories and counts)
 const QueryStaticDataset = `
 query($dataset: String!, $variables: [String!]!, $filters: [Filter!]) {

--- a/cantabular/static_dataset.go
+++ b/cantabular/static_dataset.go
@@ -36,6 +36,45 @@ type DimensionsTable struct {
 	Error      string      `json:"error,omitempty" `
 }
 
+type StaticDatasetQueryTypeResponse struct {
+	Dataset gql.Dataset `json:"dataset"`
+}
+
+// StaticDatasetType will return the type of dataset
+func (c *Client) StaticDatasetType(ctx context.Context, datasetName string) (*gql.Dataset, error) {
+	logData := log.Data{
+		"url":     fmt.Sprintf("%s/graphql", c.extApiHost),
+		"request": datasetName,
+	}
+
+	var q struct {
+		Data   StaticDatasetQueryTypeResponse `json:"data"`
+		Errors []gql.Error                    `json:"errors"`
+	}
+
+	qd := QueryData{
+		Dataset: datasetName,
+	}
+
+	if err := c.queryUnmarshal(ctx, QueryStaticDatasetType, qd, &q); err != nil {
+		return nil, dperrors.New(
+			fmt.Errorf("failed to make GraphQL query: %w", err),
+			http.StatusInternalServerError,
+			logData,
+		)
+	}
+
+	if len(q.Errors) != 0 {
+		return nil, dperrors.New(
+			errors.New("error(s) returned by graphQL query"),
+			q.Errors[0].StatusCode(),
+			log.Data{"errors": q.Errors},
+		)
+	}
+
+	return &q.Data.Dataset, nil
+}
+
 // StaticDatasetQuery performs a query for a static dataset against the
 // Cantabular Extended API using the /graphql endpoint and returns a StaticDatasetQuery,
 // loading the whole response to memory.

--- a/cantabular/static_dataset_test.go
+++ b/cantabular/static_dataset_test.go
@@ -277,6 +277,29 @@ func TestStaticDatasetQueryUnHappy(t *testing.T) {
 	})
 }
 
+func TestStaticDatasetType(t *testing.T) {
+	Convey("Given a GraphQL error from the /graphql endpoint", t, func() {
+		testCtx := context.Background()
+		mockHttpClient := &dphttp.ClienterMock{PostFunc: func(ctx context.Context, url string, contentType string, body io.Reader) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(mockRespBodyDatasetType)),
+			}, nil
+		}}
+		cantabularClient := cantabular.NewClient(
+			cantabular.Config{
+				Host:       "cantabular.host",
+				ExtApiHost: "cantabular.ext.host",
+			},
+			mockHttpClient,
+			nil,
+		)
+		res, _ := cantabularClient.StaticDatasetType(testCtx, "testDataset")
+		So(res.Type, ShouldEqual, "microdata")
+	})
+
+}
+
 // mockRespBodyStaticDataset is a successful static dataset query respose that is returned from a mocked client for testing
 var mockRespBodyStaticDataset = `
 {
@@ -453,3 +476,13 @@ var mockRespBodyNoTable = `
 		}
 	]
 }`
+
+var mockRespBodyDatasetType = `
+{
+	"data": {
+	  "dataset": {
+		"type": "microdata"
+	  }
+	}
+  }		
+`


### PR DESCRIPTION
### What
ticket; https://trello.com/c/09GkfSkR/6071-ensure-census-observations-in-population-types-api-works-for-microdata-types-only
Added support for new query to get type of dataset. This could have been achieved by adding the type to existing 'QueryStaticDataset' but running that query is expensive. So added a query that will quickly determine the 'type' 

### How to review

All test are :green_circle: 

### Who can review

Anyone
