### PR TITLE
Fix function name to pass lint step

### DIFF
--- a/cantabular/static_dataset.go
+++ b/cantabular/static_dataset.go
@@ -212,7 +212,7 @@ func (c *Client) CheckQueryCount(ctx context.Context, req StaticDatasetQueryRequ
 // consume the transformed output with the provided Consumer concurrently.
 // Returns a json formatted response
 // Use this method if large query responses are expected.
-func (c *Client) StaticDatasetQueryStreamJson(ctx context.Context, req StaticDatasetQueryRequest, consume Consumer) (GetObservationsResponse, error) {
+func (c *Client) StaticDatasetQueryStreamJSON(ctx context.Context, req StaticDatasetQueryRequest, consume Consumer) (GetObservationsResponse, error) {
 	data := QueryData{
 		Dataset:   req.Dataset,
 		Variables: req.Variables,


### PR DESCRIPTION
### What

Amended function name to have an uppercase JSON as currently dp-cantabular-filter-flex-api fails the lint step due to this naming convention.

### How to review

Ensure the changes make sense.

### Who can review

Anyone.