### PR TITLE
Adding additonal links section

### DIFF
--- a/cantabular/table.go
+++ b/cantabular/table.go
@@ -59,11 +59,13 @@ type GetObservationsResponse struct {
 }
 
 type DatasetJSONLinks struct {
-	Self Link `json:"self"`
+	Self            Link  `json:"self"`
+	Version         *Link `json:"version,omitempty"`
+	DatasetMetadata *Link `json:"dataset_metadata,omitempty"`
 }
 
 type Link struct {
-	HREF  string `json:"href"`
+	HREF  string `json:"href,omitempty"`
 	Label string `json:"label,omitempty"`
 	ID    string `json:"id,omitempty"`
 }


### PR DESCRIPTION
### What

Adding version and metadata links to cantabular responses following updates to dp-cantabular-filter-flex to stop OOM kills.
This is a non-breaking change - have tested with the other service that uses this data model.

### How to review

Ensure the changes make sense.

### Who can review

Anyone.
