### PR TITLE
add 409 conflict error files api

### DIFF
--- a/files/client.go
+++ b/files/client.go
@@ -157,12 +157,21 @@ func (c *Client) RegisterFile(ctx context.Context, metadata FileMetaData) error 
 		e := jsonErrors.Errors[0]
 
 		switch e.Code {
-		case "DuplicateFileError":
-			return ErrFileAlreadyRegistered
 		case "ValidationError":
 			return fmt.Errorf("%w: %s", ErrValidationError, e.Description)
 		default:
 			return fmt.Errorf("%w: %s: %s", ErrUnknown, e.Code, e.Description)
+		}
+	case http.StatusConflict:
+		jsonErrors := dperrors.JsonErrors{}
+		if err := json.NewDecoder(resp.Body).Decode(&jsonErrors); err != nil {
+			return fmt.Errorf("%w: %s", ErrConflict, err)
+		}
+		e := jsonErrors.Errors[0]
+
+		switch e.Code {
+		case "DuplicateFileError":
+			return ErrFileAlreadyRegistered
 		}
 	}
 

--- a/files/client_test.go
+++ b/files/client_test.go
@@ -559,7 +559,7 @@ func TestRegisterFile(t *testing.T) {
 			Convey("duplicate file", func() {
 				expectedCode := "DuplicateFileError"
 				expectedDescription := ""
-				server := newMockFilesAPIServerWithError(http.StatusBadRequest, expectedCode, expectedDescription)
+				server := newMockFilesAPIServerWithError(http.StatusConflict, expectedCode, expectedDescription)
 
 				hCli := health.Client{URL: server.URL, Client: &dphttp.Client{}}
 				client := files.NewWithHealthClient(&hCli)
@@ -675,6 +675,7 @@ func TestRegisterFile(t *testing.T) {
 		Convey("resource conflict", func() {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				w.WriteHeader(http.StatusConflict)
+				fmt.Fprint(w, "<invalid JSON>")
 			}))
 
 			hCli := health.Client{URL: server.URL, Client: &dphttp.Client{}}
@@ -682,7 +683,7 @@ func TestRegisterFile(t *testing.T) {
 
 			err := client.RegisterFile(context.Background(), files.FileMetaData{})
 
-			So(err, ShouldEqual, files.ErrConflict)
+			So(errors.Is(err, files.ErrConflict), ShouldBeTrue)
 		})
 	})
 }


### PR DESCRIPTION
### What

Add `http.StatusConflict` error to `handleOtherCodes` function.
Fix related to these PR's - https://github.com/ONSdigital/dp-upload-service/pull/99 & https://github.com/ONSdigital/dp-files-api/pull/151
Tested locally with `dp-files-api` and `dp-upload-service` and working as expected

### How to review

Confirm changes make sense

### Who can review

Anyone
