### PR TITLE
allow zebedee sdk to return status code from errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dp-api-clients-go/v2
 
-go 1.24
+go 1.26
 
 require (
 	github.com/ONSdigital/dp-healthcheck v1.6.4

--- a/zebedee/client.go
+++ b/zebedee/client.go
@@ -48,6 +48,11 @@ func (e ErrInvalidZebedeeResponse) Error() string {
 	)
 }
 
+// Code returns the actual status code that was returned from zebedee.
+func (e ErrInvalidZebedeeResponse) Code() int {
+	return e.ActualCode
+}
+
 var _ error = ErrInvalidZebedeeResponse{}
 
 // New creates a new Zebedee Client, set

--- a/zebedee/client_test.go
+++ b/zebedee/client_test.go
@@ -1478,3 +1478,17 @@ func TestGetResourceStream(t *testing.T) {
 		})
 	})
 }
+
+func TestErrInvalidZebedeeResponse(t *testing.T) {
+	t.Parallel()
+
+	Convey("ErrInvalidZebedeeResponse exposes status code and formatted message", t, func() {
+		err := ErrInvalidZebedeeResponse{
+			ActualCode: http.StatusNotFound,
+			URI:        "/missing/resource",
+		}
+
+		So(err.Code(), ShouldEqual, http.StatusNotFound)
+		So(err.Error(), ShouldEqual, "invalid response from zebedee: 404, path: /missing/resource")
+	})
+}


### PR DESCRIPTION
### What

- Add `Code()` getter for zebedee SDK errors to allow error handling based on status code in other services
- This missing method is causing an error in the `dp-frontend-dataset-controller` [here](https://github.com/ONSdigital/dp-frontend-dataset-controller/blob/cf8579d987450e6240961102a2dbdd4263e18aa7/handlers/handlers.go#L147-L151) where the returned error cannot be handled properly due to not having a `Code()` method ([handling here](https://github.com/ONSdigital/dp-frontend-dataset-controller/blob/cf8579d987450e6240961102a2dbdd4263e18aa7/handlers/handlers.go#L49-L50)) which other clients do provide

### How to review

- Check changes are ok

### Who can review

- Anyone